### PR TITLE
Feature/add webhooks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,51 @@
+language: python
+python:
+  - 2.7
+  - 3.5
+
+cache: pip
+
+# Setup Miniconda
+before_install:
+  - sudo apt-get update
+  # Do this conditionally because it saves some downloading if the
+  # version is the same.
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a # For debugging any issues with conda
+  - conda create --yes --name condaenv python=$TRAVIS_PYTHON_VERSION 
+  - source activate condaenv
+
+# Currently mpi4py 2.0.0 fails with mpi_init error on some platforms - need dev version from source. 
+# Means installing dependencies sep. - including MPI lib.
+install:
+  - conda install --yes mpi4py
+  - conda install --yes -c conda-forge petsc4py
+  - conda install --yes -c conda-forge nlopt
+  - conda install --yes pytest pytest-cov
+  - conda install --yes -c conda-forge coveralls
+  - conda install --yes scipy 
+  - conda install --yes cython
+  - pip install git+https://bitbucket.org/mpi4py/mpi4py.git@master
+#  - python setup.py install
+
+# Run test
+script:
+  - code/tests/run-tests.sh
+
+# Coverage
+after_success:
+  - mv code/tests/.cov* .
+  - coveralls
+
+after_failure:
+  - cat code/tests/regression_tests/log.err
+  

--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# libEnsemble
-Library for managing ensemble-like collections of computations

--- a/README.rst
+++ b/README.rst
@@ -2,11 +2,11 @@
 libensemble
 ===========
 
-.. image::  https://travis-ci.org/libensemble/libensemble.svg?branch=master
-   :target: https://travis-ci.org/libensemble/libensemble
+.. image::  https://travis-ci.org/Libensemble/libensemble.svg?branch=master
+   :target: https://travis-ci.org/Libensemble/libensemble
 
-.. image:: https://coveralls.io/repos/github/libensemble/libensemble/badge.svg?branch=master
-   :target: https://coveralls.io/github/libensemble/libensemble?branch=master
+.. image:: https://coveralls.io/repos/github/Libensemble/libensemble/badge.svg?branch=master
+   :target: https://coveralls.io/github/Libensemble/libensemble?branch=master
    
 .. image::  https://readthedocs.org/projects/libensemble/badge/?version=latest
    :target: https://libensemble.readthedocs.org/en/latest/

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,16 @@
+===========
+libensemble
+===========
+
+.. image::  https://travis-ci.org/libensemble/libensemble.svg?branch=master
+   :target: https://travis-ci.org/libensemble/libensemble
+
+.. image:: https://coveralls.io/repos/github/libensemble/libensemble/badge.svg?branch=master
+   :target: https://coveralls.io/github/libensemble/libensemble?branch=master
+   
+.. image::  https://readthedocs.org/projects/libensemble/badge/?version=latest
+   :target: https://libensemble.readthedocs.org/en/latest/
+
+
+
+Library for managing ensemble-like collections of computations.


### PR DESCRIPTION
The badges currently show failing as they are tracking the master (which will fail as no travis script present), but if you click through to Travis you can see my branch is passing, also Coveralls is showing 98%. I have seen an option for the badges to show whatever branch you're on, which seems to make more sense to me, but linking to the master branch result seems to be the standard.