### PR TITLE
Update travis testing for OpenMPI and MPICH - and move mpi4py v3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,29 @@ language: python
 python:
   - 2.7
   - 3.5
+  
+os: linux
+dist: trusty
+sudo: false
 
-#cache: 
-#  pip: true
-#  apt: true
+env:
+  global:
+    - HYDRA_LAUNCHER=fork
+
+  matrix:
+    - MPI=mpich
+    - MPI=openmpi
+
+addons:
+  apt:
+    packages:
+      - gfortran
+      - libblas-dev
+      - liblapack-dev
+    
+cache: 
+  pip: true
+  apt: true
 
 # Setup Miniconda
 before_install:
@@ -18,27 +37,32 @@ before_install:
     fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
-  - export HYDRA_LAUNCHER=fork
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a # For debugging any issues with conda
+  - conda config --add channels conda-forge  
   - conda create --yes --name condaenv python=$TRAVIS_PYTHON_VERSION 
   - source activate condaenv
 
-# Currently mpi4py 2.0.0 fails with mpi_init error on some platforms - need dev version from source. 
-# Means installing dependencies sep. - including MPI lib.
+# Currently mpi4py 2.0.0 fails with mpi_init error on some platforms - need dev version from source.
+# Mpich can work with conda install - but currently for multiple MPI versions - need to get mpi4py and petsc from source
+# ...until conda has a better MPI solution. Could try caching built dependencies to cut time???
 install:
-  - pip install Cython #skip dodgy Cython version
-#  - conda install cython
-  - conda install --yes mpi4py #Get MPI library
-  - conda install --yes scipy
-  - conda install --yes -c conda-forge petsc4py
-  - conda install --yes -c conda-forge nlopt
-  - pip install git+https://bitbucket.org/mpi4py/mpi4py.git@master
-  - conda install --yes pytest pytest-cov
-  - conda install --yes -c conda-forge coveralls
-#  - python setup.py install
+  #- conda install $MPI cython #Install mpi4py and petsc from src to match these - until conda packages all match
+  - conda install $MPI
+  - conda install scipy
+  #- pip install git+https://bitbucket.org/mpi4py/mpi4py.git@master
+  - pip install mpi4py
+  - pip install petsc petsc4py
+  - conda install --no-update-deps nlopt
+  - conda install pytest pytest-cov
+  - conda install coveralls
+  # For confirmation of MPI library being used.
+  - python find_mpi.py #locate compilers
+  - mpiexec --version #Show MPI library details
+  
+  #  - python setup.py install
 
 # Run test
 script:
@@ -51,4 +75,3 @@ after_success:
 
 after_failure:
   - cat code/tests/regression_tests/log.err
-  

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ install:
   - conda install pytest pytest-cov
   - conda install coveralls
   # For confirmation of MPI library being used.
-  - python find_mpi.py #locate compilers
+  - python conda/find_mpi.py #locate compilers
   - mpiexec --version #Show MPI library details
   
   #  - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ sudo: false
 env:
   global:
     - HYDRA_LAUNCHER=fork
-
+    - OMPI_MCA_rmaps_base_oversubscribe=yes
   matrix:
     - MPI=mpich
     - MPI=openmpi

--- a/code/tests/run-tests.sh
+++ b/code/tests/run-tests.sh
@@ -131,8 +131,9 @@ unset RUN_PREFIX
 script_name=`basename "$0"`
 RUN_PREFIX=$script_name
 CLEAN_ONLY=false
+unset MPIEXEC_FLAGS
 
-while getopts ":p:n:c" opt; do
+while getopts ":p:n:a:c" opt; do
   case $opt in
     p)
       echo "Parameter supplied for Python version: $OPTARG" >&2
@@ -142,6 +143,10 @@ while getopts ":p:n:c" opt; do
       echo "Parameter supplied for Test Name: $OPTARG" >&2
       RUN_PREFIX=$OPTARG
       ;;
+    a)
+      echo "Parameter supplied for mpiexec args: $OPTARG" >&2
+      MPIEXEC_FLAGS=$OPTARG
+      ;;      
     c)
       #echo "Cleaning test output: $OPTARG" >&2
       echo "Cleaning test output"
@@ -243,7 +248,7 @@ if [ "$root_found" = true ]; then
     tput bold;tput setaf 6
     echo -e "\n$RUN_PREFIX --$PYTHON_RUN: Running regression tests"
     tput sgr 0
-    
+
     cd $ROOT_DIR/$REG_TEST_SUBDIR
     
     #Check output dir exists.
@@ -303,11 +308,11 @@ if [ "$root_found" = true ]; then
         if [ "$RUN_TEST" = "true" ]; then
 
            if [ "$REG_USE_PYTEST" = true ]; then
-             mpiexec -np $NPROCS $PYTHON_RUN -m pytest $TEST_SCRIPT >> $TEST_SCRIPT.$NPROCS'procs'.$REG_TEST_OUTPUT_EXT 2>test.err
+             mpiexec -np $NPROCS $MPIEXEC_FLAGS $PYTHON_RUN -m pytest $TEST_SCRIPT >> $TEST_SCRIPT.$NPROCS'procs'.$REG_TEST_OUTPUT_EXT 2>test.err
              #mpiexec -np $REG_TEST_PROCESS_COUNT $PYTHON_RUN -m pytest $COV_LINE_PARALLEL test_libE_on_GKLS_pytest.py >> $REG_TEST_OUTPUT
              test_code=$?
            else
-             mpiexec -np $NPROCS $PYTHON_RUN $COV_LINE_PARALLEL $TEST_SCRIPT >> $TEST_SCRIPT.$NPROCS'procs'.$REG_TEST_OUTPUT_EXT 2>test.err
+             mpiexec -np $NPROCS $MPIEXEC_FLAGS $PYTHON_RUN $COV_LINE_PARALLEL $TEST_SCRIPT >> $TEST_SCRIPT.$NPROCS'procs'.$REG_TEST_OUTPUT_EXT 2>test.err
              test_code=$?
            fi
            reg_count_runs=$((reg_count_runs+1))

--- a/conda/find_mpi.py
+++ b/conda/find_mpi.py
@@ -1,0 +1,22 @@
+from __future__ import print_function
+import os
+import mpi4py
+
+path=mpi4py.__path__[0]
+print("\nmpi4py path found is:", path)
+
+configfile=os.path.join(path,"mpi.cfg")
+print("\nShowing config file: ", configfile, "\n")
+
+with open(configfile, 'r') as confile_handle:
+    print(confile_handle.read())
+
+with open(configfile, 'r') as infile:
+    for line in infile:
+        if line.startswith("mpicc ="):
+           mpi4py_mpicc=line[8:-1]
+           cmd_line=str(mpi4py_mpicc) + ' -v'
+           break
+
+print(cmd_line, ":\n")
+os.system(cmd_line)


### PR DESCRIPTION
There is now a build matrix for different MPI libraries and pip install is used for mpi4py and PETSc, so these are separated from MPI libraries and should work correctly. Currently mpich and openmpi are tested. pip install mpi should now install v3.0.0, and so the develop version is no longer required.