### PR TITLE
Feature/test lib e exceptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ install:
   - pip install pytest
   - pip install pytest-cov
   - pip install pytest-timeout 
+  - pip install mock
   - pip install coveralls
   - conda install --no-deps nlopt  
   # For confirmation of MPI library being used.

--- a/libensemble/tests/unit_tests/test_libE_main.py
+++ b/libensemble/tests/unit_tests/test_libE_main.py
@@ -17,7 +17,7 @@ fname_abort = 'libE_history_at_abort_0.npy'
 def test_manager_exception():
     try:
         os.remove(fname_abort)
-    except FileNotFoundError as e:
+    except OSError as e:
         pass
     with mock.patch('libensemble.libE.manager_main') as managerMock:
         managerMock.side_effect = Exception


### PR DESCRIPTION
Added unit tests for manager/working exceptions by mocking calls to manager_main/worker_main and forcing exceptions. Have not been able to test mpi abort options as I was not able to mock that