### PR TITLE
Testing/speedup jobc unit tests #68

### DIFF
--- a/libensemble/controller.py
+++ b/libensemble/controller.py
@@ -1028,7 +1028,7 @@ class BalsamJobController(JobController):
         # Do not poll if job already finished
         if job.finished:
             logger.warning('Polled job has already finished. Not re-polling. Status is {}'.format(job.state))
-            return job
+            return
 
         #-------- Up to here should be common - can go in a baseclass and make all concrete classes inherit ------#
 

--- a/libensemble/controller.py
+++ b/libensemble/controller.py
@@ -665,7 +665,7 @@ class JobController:
             return
 
         if job.process is None:
-            time.sleep(1)
+            time.sleep(0.2)
             if job.process is None:
                 #logger.warning('Polled job has no process ID - returning stored state')
                 #Prob should be recoverable and return state - but currently fatal

--- a/libensemble/tests/standalone_tests/kill_test/readme.txt
+++ b/libensemble/tests/standalone_tests/kill_test/readme.txt
@@ -7,7 +7,7 @@ Test: sleep_and_print
 
 The default test (sleep_and_print), should automatically test if all processes of an MPI job are correctly killed and also that a second job can be launched and killed.
 
-Launching MPI jobs which write form each MPI task, at regular intervals, to an output file (see sleep_and_print.c).
+Launching MPI jobs which write from each MPI task, at regular intervals, to an output file (see sleep_and_print.c).
 
 This test launches a job, then kills after a few seconds, and then monitors output file to see if output continues. If the first job is succesfully killed, a second is launched and the test repeated.
 

--- a/libensemble/tests/unit_tests/simdir/my_simjob.c
+++ b/libensemble/tests/unit_tests/simdir/my_simjob.c
@@ -6,14 +6,15 @@
 
 int main(int argc, char **argv) 
 {
-    int ierr, num_procs, rank, delay, error;
+    int ierr, num_procs, rank, usec_delay, error;
+    double fdelay;
         
-    delay=3;
+    fdelay=3.0;
     error=0;
     
     if (argc >=3) {
         if (strcmp( argv[1],"sleep") == 0 ) {
-            delay = atoi(argv[2]);
+            fdelay = atof(argv[2]);
         }
     }
     if (argc >=4) {
@@ -30,15 +31,16 @@ int main(int argc, char **argv)
     ierr = MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     ierr = MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
     
-    printf("Hello world sleeping for %d seconds on rank %d of %d\n",delay, rank,num_procs);
-
-    sleep(delay);
+    printf("Hello world sleeping for %f seconds on rank %d of %d\n",fdelay, rank,num_procs);
+    
+    usec_delay = (int)(fdelay*1e6);
+    usleep(usec_delay);
     //printf("Woken up on rank %d of %d\n",rank,num_procs);  
     
     if (rank==0) {
         if (error==1) {
             printf("Oh Dear! An non-fatal Error seems to have occured on rank %d\n",rank);
-            sleep(delay);
+            usleep(usec_delay);
         }
     }
     

--- a/libensemble/tests/unit_tests/test_jobcontroller.py
+++ b/libensemble/tests/unit_tests/test_jobcontroller.py
@@ -107,7 +107,7 @@ def setup_job_controller_noapp():
         
 # -----------------------------------------------------------------------------
 # The following would typically be in the user sim_func
-def polling_loop(jobctl, job, timeout_sec=4.0, delay=0.5):
+def polling_loop(jobctl, job, timeout_sec=0.5, delay=0.05):
     #import time
     start = time.time()
     
@@ -134,7 +134,7 @@ def polling_loop(jobctl, job, timeout_sec=4.0, delay=0.5):
     return job
     
     
-def polling_loop_multijob(jobctl, job_list, timeout_sec=6.0, delay=0.25):
+def polling_loop_multijob(jobctl, job_list, timeout_sec=4.0, delay=0.05):
     #import time
     start = time.time()
 
@@ -172,7 +172,7 @@ def test_launch_and_poll():
     setup_job_controller()
     jobctl = JobController.controller
     cores = NCORES
-    args_for_sim = 'sleep 2'
+    args_for_sim = 'sleep 0.2'
     job = jobctl.launch(calc_type='sim', num_procs=cores, app_args=args_for_sim)
     job = polling_loop(jobctl, job)
     assert job.finished, "job.finished should be True. Returned " + str(job.finished)
@@ -185,7 +185,7 @@ def test_kill_on_file():
     setup_job_controller()
     jobctl = JobController.controller    
     cores = NCORES
-    args_for_sim = 'sleep 1 Error'
+    args_for_sim = 'sleep 0.1 Error'
     job = jobctl.launch(calc_type='sim', num_procs=cores, app_args=args_for_sim)
     job = polling_loop(jobctl, job)
     assert job.finished, "job.finished should be True. Returned " + str(job.finished)
@@ -197,7 +197,7 @@ def test_kill_on_timeout():
     setup_job_controller()
     jobctl = JobController.controller    
     cores = NCORES
-    args_for_sim = 'sleep 12'
+    args_for_sim = 'sleep 10'
     job = jobctl.launch(calc_type='sim', num_procs=cores, app_args=args_for_sim)
     job = polling_loop(jobctl, job)
     assert job.finished, "job.finished should be True. Returned " + str(job.finished)
@@ -214,7 +214,7 @@ def test_launch_and_poll_multijobs():
     for j in range(3):
         #outfilename = 'out_' + str(j) + '.txt' #Could allow launch to generate outfile names based on job.id
         outfile = 'multijob_job_' + str(j) + '.out'
-        sleeptime = 1 + j #Change args
+        sleeptime = 0.3 + (j*0.2) #Change args
         args_for_sim = 'sleep' + ' ' + str(sleeptime)
         rundir = 'run_' + str(sleeptime)
         job = jobctl.launch(calc_type='sim', num_procs=cores, app_args=args_for_sim, stdout=outfile)
@@ -270,13 +270,13 @@ def test_procs_and_machinefile_logic():
             f.write(socket.gethostname() + '\n')
 
     job = jobctl.launch(calc_type='sim', machinefile=machinefilename, app_args=args_for_sim)   
-    job = polling_loop(jobctl, job, delay=0.3)
+    job = polling_loop(jobctl, job, delay=0.02)
     assert job.finished, "job.finished should be True. Returned " + str(job.finished)
     assert job.state == 'FINISHED', "job.state should be FINISHED. Returned " + str(job.state)
 
     # Testing num_procs = num_nodes*ranks_per_node (shouldn't fail)
     job = jobctl.launch(calc_type='sim', num_procs=6, num_nodes=2, ranks_per_node=3, app_args=args_for_sim)
-    job = polling_loop(jobctl, job, delay=0.3)
+    job = polling_loop(jobctl, job, delay=0.02)
     assert job.finished, "job.finished should be True. Returned " + str(job.finished)
     assert job.state == 'FINISHED', "job.state should be FINISHED. Returned " + str(job.state)
 
@@ -291,7 +291,7 @@ def test_procs_and_machinefile_logic():
     # Testing no num_procs (shouldn't fail)
     job = jobctl.launch(calc_type='sim', num_nodes=2, ranks_per_node=3, app_args=args_for_sim)
     assert 1
-    job = polling_loop(jobctl, job, delay=0.3)
+    job = polling_loop(jobctl, job, delay=0.02)
     assert job.finished, "job.finished should be True. Returned " + str(job.finished)
     assert job.state == 'FINISHED', "job.state should be FINISHED. Returned " + str(job.state)
 
@@ -306,14 +306,14 @@ def test_procs_and_machinefile_logic():
     # Testing no num_nodes (shouldn't fail)
     job = jobctl.launch(calc_type='sim',num_procs=2,ranks_per_node=2, app_args=args_for_sim)
     assert 1
-    job = polling_loop(jobctl, job, delay=0.3)
+    job = polling_loop(jobctl, job, delay=0.02)
     assert job.finished, "job.finished should be True. Returned " + str(job.finished)
     assert job.state == 'FINISHED', "job.state should be FINISHED. Returned " + str(job.state)
 
     # Testing no ranks_per_node (shouldn't fail)
     job = jobctl.launch(calc_type='sim',num_nodes=1,num_procs=2, app_args=args_for_sim)
     assert 1
-    job = polling_loop(jobctl, job, delay=0.3)
+    job = polling_loop(jobctl, job, delay=0.02)
     assert job.finished, "job.finished should be True. Returned " + str(job.finished)
     assert job.state == 'FINISHED', "job.state should be FINISHED. Returned " + str(job.state)
 
@@ -328,7 +328,7 @@ def test_doublekill():
     setup_job_controller()
     jobctl = JobController.controller
     cores = NCORES
-    args_for_sim = 'sleep 3'
+    args_for_sim = 'sleep 2.0'
     job = jobctl.launch(calc_type='sim', num_procs=cores, app_args=args_for_sim) 
     jobctl.poll(job)
     #jobctl.set_kill_mode(wait_and_kill=True, wait_time=5)
@@ -351,10 +351,10 @@ def test_finish_and_kill():
     setup_job_controller()
     jobctl = JobController.controller
     cores = NCORES
-    args_for_sim = 'sleep 1'
+    args_for_sim = 'sleep 0.1'
     job = jobctl.launch(calc_type='sim', num_procs=cores, app_args=args_for_sim) 
     while not job.finished:
-        time.sleep(0.5)
+        time.sleep(0.1)
         jobctl.poll(job)
     assert job.finished, "job.finished should be True. Returned " + str(job.finished)
     assert job.state == 'FINISHED', "job.state should be FINISHED. Returned " + str(job.state)   
@@ -374,7 +374,7 @@ def test_launch_and_kill():
     setup_job_controller()
     jobctl = JobController.controller
     cores = NCORES
-    args_for_sim = 'sleep 2'
+    args_for_sim = 'sleep 2.0'
     job_list = []
     for jobid in range(5):
         job = jobctl.launch(calc_type='sim', num_procs=cores, app_args=args_for_sim)
@@ -391,7 +391,7 @@ def test_launch_as_gen():
     setup_job_controller()
     jobctl = JobController.controller
     cores = NCORES
-    args_for_sim = 'sleep 1'
+    args_for_sim = 'sleep 0.1'
     
     #Try launching as gen when not registered as gen
     try:
@@ -404,7 +404,7 @@ def test_launch_as_gen():
     registry = Register.default_registry
     registry.register_calc(full_path=sim_app, calc_type='gen')
     job = jobctl.launch(calc_type='gen', num_procs=cores, app_args=args_for_sim)
-    job = polling_loop(jobctl, job, delay=0.3)
+    job = polling_loop(jobctl, job)
     assert job.finished, "job.finished should be True. Returned " + str(job.finished)
     assert job.state == 'FINISHED', "job.state should be FINISHED. Returned " + str(job.state)
     
@@ -422,9 +422,9 @@ def test_launch_default_reg():
     setup_job_controller_noreg()
     jobctl = JobController.controller
     cores = NCORES
-    args_for_sim = 'sleep 1'  
+    args_for_sim = 'sleep 0.1'  
     job = jobctl.launch(calc_type='sim', num_procs=cores, app_args=args_for_sim)
-    job = polling_loop(jobctl, job, delay=0.3)
+    job = polling_loop(jobctl, job)
     assert job.finished, "job.finished should be True. Returned " + str(job.finished)
     assert job.state == 'FINISHED', "job.state should be FINISHED. Returned " + str(job.state)
 
@@ -432,7 +432,7 @@ def test_launch_default_reg():
 def test_create_jobcontroller_no_registry():
     print("\nTest: {}\n".format(sys._getframe().f_code.co_name))
     cores = NCORES
-    args_for_sim = 'sleep 1' 
+    args_for_sim = 'sleep 0.1' 
     #import pdb;pdb.set_trace()
     try:    
         jobctrl = JobController(auto_resources = False)
@@ -447,7 +447,7 @@ def test_launch_no_app():
     setup_job_controller_noapp()
     jobctl = JobController.controller
     cores = NCORES
-    args_for_sim = 'sleep 1' 
+    args_for_sim = 'sleep 0.1' 
     try:
         job = jobctl.launch(calc_type='sim', num_procs=cores, app_args=args_for_sim)
     except: 
@@ -555,9 +555,9 @@ def test_job_failure():
     setup_job_controller()
     jobctl = JobController.controller
     cores = NCORES
-    args_for_sim = 'sleep 1 Fail'  
+    args_for_sim = 'sleep 1.0 Fail'  
     job = jobctl.launch(calc_type='sim', num_procs=cores, app_args=args_for_sim)
-    job = polling_loop(jobctl, job, delay=0.3)
+    job = polling_loop(jobctl, job)
     assert job.finished, "job.finished should be True. Returned " + str(job.finished)
     assert job.state == 'FAILED', "job.state should be FAILED. Returned " + str(job.state)     
     
@@ -575,6 +575,7 @@ if __name__ == "__main__":
     test_launch_and_kill()
     test_launch_as_gen()
     test_launch_default_reg()
+    setup_function(test_create_jobcontroller_no_registry)
     test_create_jobcontroller_no_registry()
     test_launch_no_app()
     test_kill_job_with_no_launch()


### PR DESCRIPTION
Now running in about 4 seconds.

Old:
test_jobcontroller.py ................. [100%]
============================= 17 passed in 20.52 seconds

New:
test_jobcontroller.py ................. [100%]
============================= 17 passed in 3.95 seconds

The limitation is too ensure launched jobs run for long enough to get polled/killed as expected. This is probably about as short as we can safely make it.

Note: This gives 5 slowest jobs.
pytest --duration=5 test_jobcontroller.py

test_jobcontroller.py ................. [100%]
...
================================ slowest 5 test durations
0.77s call test_jobcontroller.py::test_launch_and_poll_multijobs
0.67s call test_jobcontroller.py::test_kill_on_timeout
0.57s call test_jobcontroller.py::test_launch_and_kill
0.34s call test_jobcontroller.py::test_procs_and_machinefile_logic
0.32s call test_jobcontroller.py::test_kill_on_file