### PR TITLE
Testing/query reg tests

### DIFF
--- a/libensemble/tests/regression_tests/test_1d_uniform_sampling.py
+++ b/libensemble/tests/regression_tests/test_1d_uniform_sampling.py
@@ -4,6 +4,10 @@
 # The number of concurrent evaluations of the objective function will be 4-1=3.
 # """
 
+# Do not change these lines - they are parsed by run-tests.sh
+# TESTSUITE_COMMS: mpi local tcp
+# TESTSUITE_NPROCS: 2 4
+
 import numpy as np
 
 # Import libEnsemble items for this test

--- a/libensemble/tests/regression_tests/test_6-hump_camel_active_persistent_worker_abort.py
+++ b/libensemble/tests/regression_tests/test_6-hump_camel_active_persistent_worker_abort.py
@@ -9,8 +9,9 @@
 
 # Do not change these lines - they are parsed by run-tests.sh
 # TESTSUITE_COMMS: mpi local tcp
-# TESTSUITE_NPROCS: 2 4
+# TESTSUITE_NPROCS: 3 4
 
+import sys
 import numpy as np
 
 # Import libEnsemble requirements

--- a/libensemble/tests/regression_tests/test_6-hump_camel_active_persistent_worker_abort.py
+++ b/libensemble/tests/regression_tests/test_6-hump_camel_active_persistent_worker_abort.py
@@ -7,6 +7,10 @@
 # The number of concurrent evaluations of the objective function will be 4-1=3.
 # """
 
+# Do not change these lines - they are parsed by run-tests.sh
+# TESTSUITE_COMMS: mpi local tcp
+# TESTSUITE_NPROCS: 2 4
+
 import numpy as np
 
 # Import libEnsemble requirements
@@ -43,8 +47,7 @@ persis_info = per_worker_stream({}, nworkers + 1)
 exit_criteria = {'sim_max': 10, 'elapsed_wallclock_time': 300}
 
 if nworkers < 2:
-    # Can't do a "persistent worker run" if only one worker
-    quit()
+    sys.exit("Cannot run with a persistent worker if only one worker -- aborting...")
 
 # Perform the run
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,

--- a/libensemble/tests/regression_tests/test_6-hump_camel_aposmm_LD_MMA.py
+++ b/libensemble/tests/regression_tests/test_6-hump_camel_aposmm_LD_MMA.py
@@ -7,6 +7,10 @@
 # The number of concurrent evaluations of the objective function will be 4-1=3.
 # """
 
+# Do not change these lines - they are parsed by run-tests.sh
+# TESTSUITE_COMMS: mpi local
+# TESTSUITE_NPROCS: 2 4
+
 import sys
 import numpy as np
 from math import gamma, pi, sqrt
@@ -22,8 +26,8 @@ from libensemble.tests.regression_tests.support import persis_info_1 as persis_i
 
 nworkers, is_master, libE_specs, _ = parse_args()
 
-if libE_specs['comms'] != 'mpi':
-    quit()
+#if libE_specs['comms'] == 'tcp':
+    #sys.exit("Cannot run with tcp when repeated calls to libE -- aborting...")
 
 n = 2
 sim_specs = {'sim_f': sim_f,

--- a/libensemble/tests/regression_tests/test_6-hump_camel_aposmm_LD_MMA.py
+++ b/libensemble/tests/regression_tests/test_6-hump_camel_aposmm_LD_MMA.py
@@ -8,7 +8,7 @@
 # """
 
 # Do not change these lines - they are parsed by run-tests.sh
-# TESTSUITE_COMMS: mpi local
+# TESTSUITE_COMMS: mpi
 # TESTSUITE_NPROCS: 2 4
 
 import sys

--- a/libensemble/tests/regression_tests/test_6-hump_camel_elapsed_time_abort.py
+++ b/libensemble/tests/regression_tests/test_6-hump_camel_elapsed_time_abort.py
@@ -7,6 +7,10 @@
 # The number of concurrent evaluations of the objective function will be 4-1=3.
 # """
 
+# Do not change these lines - they are parsed by run-tests.sh
+# TESTSUITE_COMMS: mpi local tcp
+# TESTSUITE_NPROCS: 2 4
+
 import numpy as np
 
 # Import libEnsemble items for this test

--- a/libensemble/tests/regression_tests/test_6-hump_camel_persistent_uniform_sampling.py
+++ b/libensemble/tests/regression_tests/test_6-hump_camel_persistent_uniform_sampling.py
@@ -9,8 +9,9 @@
 
 # Do not change these lines - they are parsed by run-tests.sh
 # TESTSUITE_COMMS: mpi local tcp
-# TESTSUITE_NPROCS: 2 4
+# TESTSUITE_NPROCS: 3 4
 
+import sys
 import numpy as np
 
 # Import libEnsemble items for this test

--- a/libensemble/tests/regression_tests/test_6-hump_camel_persistent_uniform_sampling.py
+++ b/libensemble/tests/regression_tests/test_6-hump_camel_persistent_uniform_sampling.py
@@ -7,6 +7,10 @@
 # The number of concurrent evaluations of the objective function will be 4-1=3.
 # """
 
+# Do not change these lines - they are parsed by run-tests.sh
+# TESTSUITE_COMMS: mpi local tcp
+# TESTSUITE_NPROCS: 2 4
+
 import numpy as np
 
 # Import libEnsemble items for this test
@@ -19,7 +23,7 @@ from libensemble.tests.regression_tests.common import parse_args, save_libE_outp
 nworkers, is_master, libE_specs, _ = parse_args()
 
 if nworkers < 2:
-    quit()
+    sys.exit("Cannot run with a persistent worker if only one worker -- aborting...")
 
 n = 2
 sim_specs = {'sim_f': sim_f,

--- a/libensemble/tests/regression_tests/test_6-hump_camel_pregenerated_sample.py
+++ b/libensemble/tests/regression_tests/test_6-hump_camel_pregenerated_sample.py
@@ -7,6 +7,10 @@
 # The number of concurrent evaluations of the objective function will be 4-1=3.
 # """
 
+# Do not change these lines - they are parsed by run-tests.sh
+# TESTSUITE_COMMS: mpi local tcp
+# TESTSUITE_NPROCS: 2 4
+
 import numpy as np
 
 # Import libEnsemble items for this test

--- a/libensemble/tests/regression_tests/test_6-hump_camel_uniform_sampling.py
+++ b/libensemble/tests/regression_tests/test_6-hump_camel_uniform_sampling.py
@@ -7,6 +7,10 @@
 # The number of concurrent evaluations of the objective function will be 4-1=3.
 # """
 
+# Do not change these lines - they are parsed by run-tests.sh
+# TESTSUITE_COMMS: mpi local tcp
+# TESTSUITE_NPROCS: 2 4
+
 import numpy as np
 
 # Import libEnsemble items for this test

--- a/libensemble/tests/regression_tests/test_6-hump_camel_uniform_sampling_with_persistent_localopt_gens.py
+++ b/libensemble/tests/regression_tests/test_6-hump_camel_uniform_sampling_with_persistent_localopt_gens.py
@@ -6,6 +6,11 @@
 #    mpiexec -np 4 python3 {FILENAME}.py
 # The number of concurrent evaluations of the objective function will be 4-1=3.
 # """
+
+# Do not change these lines - they are parsed by run-tests.sh
+# TESTSUITE_COMMS: mpi local tcp
+# TESTSUITE_NPROCS: 3 4
+
 import numpy as np
 
 # Import libEnsemble main, sim_specs, gen_specs, alloc_specs, and persis_info
@@ -19,8 +24,8 @@ from libensemble.tests.regression_tests.support import six_hump_camel_minima as 
 
 nworkers, is_master, libE_specs, _ = parse_args()
 
-if nworkers < 2:  # Don't do a "persistent worker run" if only one worker
-    quit()
+if nworkers < 2:
+    sys.exit("Cannot run with a persistent worker if only one worker -- aborting...")
 
 n = 2
 sim_specs = {'sim_f': sim_f,

--- a/libensemble/tests/regression_tests/test_6-hump_camel_uniform_sampling_with_persistent_localopt_gens.py
+++ b/libensemble/tests/regression_tests/test_6-hump_camel_uniform_sampling_with_persistent_localopt_gens.py
@@ -11,6 +11,7 @@
 # TESTSUITE_COMMS: mpi local tcp
 # TESTSUITE_NPROCS: 3 4
 
+import sys
 import numpy as np
 
 # Import libEnsemble main, sim_specs, gen_specs, alloc_specs, and persis_info

--- a/libensemble/tests/regression_tests/test_6-hump_camel_with_different_nodes_uniform_sample.py
+++ b/libensemble/tests/regression_tests/test_6-hump_camel_with_different_nodes_uniform_sample.py
@@ -7,6 +7,10 @@
 # The number of concurrent evaluations of the objective function will be 4-1=3.
 # """
 
+# Do not change these lines - they are parsed by run-tests.sh
+# TESTSUITE_COMMS: mpi
+# TESTSUITE_NPROCS: 2 4
+
 from mpi4py import MPI
 import numpy as np
 import argparse
@@ -21,7 +25,7 @@ nworkers, is_master, libE_specs, _ = parse_args()
 
 if libE_specs['comms'] != 'mpi':
     # Can't do this one with processes either?  Wants a machine file.
-    quit()
+    sys.exit("This test only runs with MPI -- aborting...")
 
 # Parse arguments
 parser = argparse.ArgumentParser()

--- a/libensemble/tests/regression_tests/test_branin_aposmm_nlopt_and_then_scipy.py
+++ b/libensemble/tests/regression_tests/test_branin_aposmm_nlopt_and_then_scipy.py
@@ -2,7 +2,7 @@
 # """
 
 # Do not change these lines - they are parsed by run-tests.sh
-# TESTSUITE_COMMS: mpi local
+# TESTSUITE_COMMS: mpi
 # TESTSUITE_NPROCS: 2 4
 
 import numpy as np

--- a/libensemble/tests/regression_tests/test_branin_aposmm_nlopt_and_then_scipy.py
+++ b/libensemble/tests/regression_tests/test_branin_aposmm_nlopt_and_then_scipy.py
@@ -1,5 +1,10 @@
 # """
 # """
+
+# Do not change these lines - they are parsed by run-tests.sh
+# TESTSUITE_COMMS: mpi local
+# TESTSUITE_NPROCS: 2 4
+
 import numpy as np
 from copy import deepcopy
 import pkg_resources
@@ -13,8 +18,8 @@ from libensemble.tests.regression_tests.common import parse_args, save_libE_outp
 
 nworkers, is_master, libE_specs, _ = parse_args()
 
-if libE_specs['comms'] != 'mpi':
-    quit()
+if libE_specs['comms'] == 'tcp':
+    sys.exit("Cannot run with tcp when repeated calls to libE -- aborting...")
 
 sim_specs = {'sim_f': sim_f,
              'in': ['x'],

--- a/libensemble/tests/regression_tests/test_chwirut_aposmm_one_residual_at_a_time.py
+++ b/libensemble/tests/regression_tests/test_chwirut_aposmm_one_residual_at_a_time.py
@@ -7,7 +7,7 @@
 # """
 
 # Do not change these lines - they are parsed by run-tests.sh
-# TESTSUITE_COMMS: mpi local tcp
+# TESTSUITE_COMMS: mpi
 # TESTSUITE_NPROCS: 2 4
 
 import numpy as np

--- a/libensemble/tests/regression_tests/test_chwirut_aposmm_one_residual_at_a_time.py
+++ b/libensemble/tests/regression_tests/test_chwirut_aposmm_one_residual_at_a_time.py
@@ -6,6 +6,10 @@
 
 # """
 
+# Do not change these lines - they are parsed by run-tests.sh
+# TESTSUITE_COMMS: mpi local tcp
+# TESTSUITE_NPROCS: 2 4
+
 import numpy as np
 
 # Import libEnsemble items for this test
@@ -18,8 +22,8 @@ from libensemble.tests.regression_tests.support import persis_info_3 as persis_i
 
 nworkers, is_master, libE_specs, _ = parse_args()
 
-if libE_specs['comms'] != 'mpi':
-    quit()
+#if libE_specs['comms'] != 'mpi':
+    #quit()
 
 # Declare the run parameters/functions
 m = 214

--- a/libensemble/tests/regression_tests/test_chwirut_pounders.py
+++ b/libensemble/tests/regression_tests/test_chwirut_pounders.py
@@ -5,6 +5,10 @@
 # mpiexec -np 4 python3 test_chwirut_pounders.py
 # """
 
+# Do not change these lines - they are parsed by run-tests.sh
+# TESTSUITE_COMMS: mpi local tcp
+# TESTSUITE_NPROCS: 2 4
+
 import numpy as np
 
 # Import libEnsemble items for this test
@@ -15,8 +19,6 @@ from libensemble.tests.regression_tests.support import persis_info_2 as persis_i
 from libensemble.tests.regression_tests.common import parse_args, save_libE_output, per_worker_stream
 
 nworkers, is_master, libE_specs, _ = parse_args()
-if libE_specs['comms'] == 'local':
-    quit()
 
 # Declare the run parameters/functions
 m = 214

--- a/libensemble/tests/regression_tests/test_chwirut_uniform_sampling_one_residual_at_a_time.py
+++ b/libensemble/tests/regression_tests/test_chwirut_uniform_sampling_one_residual_at_a_time.py
@@ -6,7 +6,7 @@
 # """
 
 # Do not change these lines - they are parsed by run-tests.sh
-# TESTSUITE_COMMS: mpi local
+# TESTSUITE_COMMS: mpi
 # TESTSUITE_NPROCS: 2 4
 
 import numpy as np

--- a/libensemble/tests/regression_tests/test_chwirut_uniform_sampling_one_residual_at_a_time.py
+++ b/libensemble/tests/regression_tests/test_chwirut_uniform_sampling_one_residual_at_a_time.py
@@ -5,6 +5,10 @@
 # mpiexec -np 4 python3 test_chwirut_uniform_sampling_one_residual_at_a_time.py
 # """
 
+# Do not change these lines - they are parsed by run-tests.sh
+# TESTSUITE_COMMS: mpi local
+# TESTSUITE_NPROCS: 2 4
+
 import numpy as np
 from copy import deepcopy
 
@@ -17,8 +21,11 @@ from libensemble.tests.regression_tests.support import persis_info_3 as persis_i
 from libensemble.tests.regression_tests.common import parse_args, save_libE_output, per_worker_stream
 
 nworkers, is_master, libE_specs, _ = parse_args()
-if libE_specs['comms'] != 'mpi':
-    quit()
+if libE_specs['comms'] == 'tcp':
+    # Can't use the same interface for manager and worker if we want
+    # repeated calls to libE -- the manager sets up a different server
+    # each time, and the worker will not know what port to connect to.
+    sys.exit("Cannot run with tcp when repeated calls to libE -- aborting...")
 
 # Declare the run parameters/functions
 m = 214

--- a/libensemble/tests/regression_tests/test_comms.py
+++ b/libensemble/tests/regression_tests/test_comms.py
@@ -8,6 +8,10 @@
 # The number of concurrent evaluations of the objective function will be N-1.
 # """
 
+# Do not change these lines - they are parsed by run-tests.sh
+# TESTSUITE_COMMS: mpi local
+# TESTSUITE_NPROCS: 2 4
+
 import numpy as np
 
 # Import libEnsemble items for this test
@@ -20,7 +24,7 @@ jobctrl = MPIJobController(auto_resources=False)
 
 nworkers, is_master, libE_specs, _ = parse_args()
 if libE_specs['comms'] == 'tcp':
-    quit()
+    sys.exit("Cannot be run with tcp -- aborting...")
 
 # Prob wrap this in the future libe comms module - and that will have init_comms...
 # and can report what its using - for comms - and in mpi case for packing/unpacking

--- a/libensemble/tests/regression_tests/test_fast_alloc.py
+++ b/libensemble/tests/regression_tests/test_fast_alloc.py
@@ -7,6 +7,10 @@
 # The number of concurrent evaluations of the objective function will be 4-1=3.
 # """
 
+# Do not change these lines - they are parsed by run-tests.sh
+# TESTSUITE_COMMS: mpi local
+# TESTSUITE_NPROCS: 2 4
+
 import numpy as np
 
 # Import libEnsemble items for this test
@@ -40,7 +44,7 @@ if libE_specs['comms'] == 'tcp':
     # Can't use the same interface for manager and worker if we want
     # repeated calls to libE -- the manager sets up a different server
     # each time, and the worker will not know what port to connect to.
-    quit()
+    sys.exit("Cannot run with tcp when repeated calls to libE -- aborting...")
 
 for time in np.append([0], np.logspace(-5, -1, 5)):
     for rep in range(1):

--- a/libensemble/tests/regression_tests/test_inverse_bayes_example.py
+++ b/libensemble/tests/regression_tests/test_inverse_bayes_example.py
@@ -12,6 +12,7 @@
 # TESTSUITE_COMMS: mpi local tcp
 # TESTSUITE_NPROCS: 3 4
 
+import sys
 import numpy as np
 
 from libensemble.libE import libE

--- a/libensemble/tests/regression_tests/test_inverse_bayes_example.py
+++ b/libensemble/tests/regression_tests/test_inverse_bayes_example.py
@@ -8,6 +8,10 @@
 # The number of concurrent evaluations of the objective function will be 4-1=3.
 # """
 
+# Do not change these lines - they are parsed by run-tests.sh
+# TESTSUITE_COMMS: mpi local tcp
+# TESTSUITE_NPROCS: 3 4
+
 import numpy as np
 
 from libensemble.libE import libE
@@ -20,8 +24,7 @@ from libensemble.tests.regression_tests.common import parse_args, per_worker_str
 nworkers, is_master, libE_specs, _ = parse_args()
 
 if nworkers < 2:
-    # Can't do a "persistent worker run" if only one worker
-    quit()
+    sys.exit("Cannot run with a persistent worker if only one worker -- aborting...")
 
 sim_specs = {'sim_f': sim_f, 'in': ['x'], 'out': [('like', float)]}
 

--- a/libensemble/tests/regression_tests/test_jobcontroller_hworld.py
+++ b/libensemble/tests/regression_tests/test_jobcontroller_hworld.py
@@ -11,6 +11,10 @@ from libensemble.sim_funcs.job_control_hworld import job_control_hworld as sim_f
 from libensemble.gen_funcs.uniform_sampling import uniform_random_sample as gen_f
 from libensemble.tests.regression_tests.common import build_simfunc, parse_args, per_worker_stream
 
+# Do not change these lines - they are parsed by run-tests.sh
+# TESTSUITE_COMMS: mpi local tcp
+# TESTSUITE_NPROCS: 2 4
+
 nworkers, is_master, libE_specs, _ = parse_args()
 
 USE_BALSAM = False

--- a/libensemble/tests/regression_tests/test_mpi_comms.py
+++ b/libensemble/tests/regression_tests/test_mpi_comms.py
@@ -2,9 +2,13 @@ from mpi4py import MPI
 from libensemble.comms.mpi import MPIComm, Timeout
 from libensemble.tests.regression_tests.common import parse_args
 
+# Do not change these lines - they are parsed by run-tests.sh
+# TESTSUITE_COMMS: mpi
+# TESTSUITE_NPROCS: 2 4
+
 nworkers, is_master, libE_specs, _ = parse_args()
 if libE_specs['comms'] != 'mpi':
-    quit()
+    sys.exit("This test can only be run with mpi comms -- aborting...")
 
 
 def check_recv(comm, expected_msg):

--- a/libensemble/tests/regression_tests/test_nan_func_aposmm.py
+++ b/libensemble/tests/regression_tests/test_nan_func_aposmm.py
@@ -6,6 +6,10 @@
 # The number of concurrent evaluations of the objective function will be 4-1=3.
 # """
 
+# Do not change these lines - they are parsed by run-tests.sh
+# TESTSUITE_COMMS: mpi local tcp
+# TESTSUITE_NPROCS: 2 4
+
 import numpy as np
 
 # Import libEnsemble items for this test
@@ -15,9 +19,6 @@ from libensemble.gen_funcs.aposmm import aposmm_logic as gen_f
 from libensemble.tests.regression_tests.common import parse_args, save_libE_output, per_worker_stream
 
 nworkers, is_master, libE_specs, _ = parse_args()
-if libE_specs['comms'] == 'local':
-    quit()
-
 n = 2
 
 sim_specs = {'sim_f': sim_f,

--- a/libensemble/tests/regression_tests/test_worker_exceptions.py
+++ b/libensemble/tests/regression_tests/test_worker_exceptions.py
@@ -6,6 +6,10 @@
 # The number of concurrent evaluations of the objective function will be 4-1=3.
 # """
 
+# Do not change these lines - they are parsed by run-tests.sh
+# TESTSUITE_COMMS: mpi local tcp
+# TESTSUITE_NPROCS: 2 4
+
 import numpy as np
 
 from libensemble.libE import libE
@@ -15,7 +19,6 @@ from libensemble.libE_manager import ManagerException
 from libensemble.tests.regression_tests.common import parse_args, per_worker_stream
 
 nworkers, is_master, libE_specs, _ = parse_args()
-
 n = 2
 
 sim_specs = {'sim_f': sim_f, 'in': ['x'], 'out': [('f', float)]}

--- a/libensemble/tests/run-tests.sh
+++ b/libensemble/tests/run-tests.sh
@@ -404,14 +404,15 @@ if [ "$root_found" = true ]; then
     reg_pass=0
     reg_fail=0
     test_num=0
+    set -x
     for TEST_SCRIPT in $REG_TEST_LIST
     do
-      COMMS_LIST=$(grep -Po '# TESTSUITE_COMMS: \K.*' $file)
+      COMMS_LIST=$(grep -Po '# TESTSUITE_COMMS: \K.*' $TEST_SCRIPT)
       for LAUNCHER in $COMMS_LIST
       do
 
       #Need proc count here for now - still stop on failure etc.
-      NPROCS_LIST=$(grep -Po '# TESTSUITE_NPROCS: \K.*' $file)
+      NPROCS_LIST=$(grep -Po '# TESTSUITE_NPROCS: \K.*' $TEST_SCRIPT)
       for NPROCS in $NPROCS_LIST
       do
         test_num=$((test_num+1))

--- a/libensemble/tests/run-tests.sh
+++ b/libensemble/tests/run-tests.sh
@@ -13,7 +13,7 @@ export RUN_PEP_TESTS=false     #Code syle conventions
 # Regression test options
 #export REG_TEST_LIST='test_number1.py test_number2.py' #selected/ordered
 export REG_TEST_LIST=test_*.py #unordered
-export REG_TEST_PROCESS_COUNT_LIST='2 4'
+# export REG_TEST_PROCESS_COUNT_LIST='2 4'
 export REG_USE_PYTEST=false
 export REG_TEST_OUTPUT_EXT=std.out #/dev/null
 export REG_STOP_ON_FAILURE=false
@@ -406,11 +406,13 @@ if [ "$root_found" = true ]; then
     test_num=0
     for TEST_SCRIPT in $REG_TEST_LIST
     do
-      for LAUNCHER in "mpi" "local" "tcp"
+      COMMS_LIST=$(grep -Po '# TESTSUITE_COMMS: \K.*' $file)
+      for LAUNCHER in $COMMS_LIST
       do
 
       #Need proc count here for now - still stop on failure etc.
-      for NPROCS in $REG_TEST_PROCESS_COUNT_LIST
+      NPROCS_LIST=$(grep -Po '# TESTSUITE_NPROCS: \K.*' $file)
+      for NPROCS in $NPROCS_LIST
       do
         test_num=$((test_num+1))
         NWORKERS=$((NPROCS-1))  

--- a/libensemble/tests/run-tests.sh
+++ b/libensemble/tests/run-tests.sh
@@ -404,79 +404,79 @@ if [ "$root_found" = true ]; then
     reg_pass=0
     reg_fail=0
     test_num=0
+    
     for TEST_SCRIPT in $REG_TEST_LIST
     do
       COMMS_LIST=$(grep -Po '# TESTSUITE_COMMS: \K.*' $TEST_SCRIPT)
       for LAUNCHER in $COMMS_LIST
       do
-
-      #Need proc count here for now - still stop on failure etc.
-      NPROCS_LIST=$(grep -Po '# TESTSUITE_NPROCS: \K.*' $TEST_SCRIPT)
-      for NPROCS in $NPROCS_LIST
-      do
-        test_num=$((test_num+1))
-        NWORKERS=$((NPROCS-1))  
-
-        RUN_TEST=true
-        if [ $REG_STOP_ON_FAILURE = "true" ]; then
-          #Before Each Test check code is 0 (passed so far) - or skip to test summary
-          if [ "$code" -ne "0" ]; then
-            RUN_TEST=false
-            break
+        #Need proc count here for now - still stop on failure etc.
+        NPROCS_LIST=$(grep -Po '# TESTSUITE_NPROCS: \K.*' $TEST_SCRIPT)
+        for NPROCS in $NPROCS_LIST
+        do
+          test_num=$((test_num+1))
+          NWORKERS=$((NPROCS-1))  
+        
+          RUN_TEST=true
+          if [ $REG_STOP_ON_FAILURE = "true" ]; then
+            #Before Each Test check code is 0 (passed so far) - or skip to test summary
+            if [ "$code" -ne "0" ]; then
+              RUN_TEST=false
+              break
+            fi
           fi
-        fi
-
-        if [ "$RUN_TEST" = "true" ]; then
-
-           if [ "$REG_USE_PYTEST" = true ]; then
-             if [ "$LAUNCHER" = mpi ]; then
-               mpiexec -np $NPROCS $MPIEXEC_FLAGS $PYTHON_RUN -m pytest $TEST_SCRIPT >> $TEST_SCRIPT.$NPROCS'procs'.$REG_TEST_OUTPUT_EXT 2>test.err
-               test_code=$?
-             else
-               $TIMEOUT $PYTHON_RUN -m pytest $TEST_SCRIPT --comms $LAUNCHER --nworkers $NWORKERS >> $TEST_SCRIPT.$NPROCS'procs'-$LAUNCHER.$REG_TEST_OUTPUT_EXT 2>test.err
-             fi
-           else
-             if [ "$LAUNCHER" = mpi ]; then
-               if [ "$RTEST_SHOW_OUT_ERR" = "true" ]; then
-                 mpiexec -np $NPROCS $MPIEXEC_FLAGS $PYTHON_RUN $COV_LINE_PARALLEL $TEST_SCRIPT
+        
+          if [ "$RUN_TEST" = "true" ]; then
+        
+             if [ "$REG_USE_PYTEST" = true ]; then
+               if [ "$LAUNCHER" = mpi ]; then
+                 mpiexec -np $NPROCS $MPIEXEC_FLAGS $PYTHON_RUN -m pytest $TEST_SCRIPT >> $TEST_SCRIPT.$NPROCS'procs'.$REG_TEST_OUTPUT_EXT 2>test.err
                  test_code=$?
                else
-                 mpiexec -np $NPROCS $MPIEXEC_FLAGS $PYTHON_RUN $COV_LINE_PARALLEL $TEST_SCRIPT >> $TEST_SCRIPT.$NPROCS'procs'.$REG_TEST_OUTPUT_EXT 2>test.err
-                 test_code=$?
-               fi               
+                 $TIMEOUT $PYTHON_RUN -m pytest $TEST_SCRIPT --comms $LAUNCHER --nworkers $NWORKERS >> $TEST_SCRIPT.$NPROCS'procs'-$LAUNCHER.$REG_TEST_OUTPUT_EXT 2>test.err
+               fi
              else
-               if [ "$RTEST_SHOW_OUT_ERR" = "true" ]; then
-                 $TIMEOUT $PYTHON_RUN $COV_LINE_PARALLEL $TEST_SCRIPT --comms $LAUNCHER --nworkers $NWORKERS
-                 test_code=$?
-               else      
-                 $TIMEOUT $PYTHON_RUN $COV_LINE_PARALLEL $TEST_SCRIPT --comms $LAUNCHER --nworkers $NWORKERS >> $TEST_SCRIPT.$NPROCS'procs'-$LAUNCHER.$REG_TEST_OUTPUT_EXT 2>test.err
-                 test_code=$?
+               if [ "$LAUNCHER" = mpi ]; then
+                 if [ "$RTEST_SHOW_OUT_ERR" = "true" ]; then
+                   mpiexec -np $NPROCS $MPIEXEC_FLAGS $PYTHON_RUN $COV_LINE_PARALLEL $TEST_SCRIPT
+                   test_code=$?
+                 else
+                   mpiexec -np $NPROCS $MPIEXEC_FLAGS $PYTHON_RUN $COV_LINE_PARALLEL $TEST_SCRIPT >> $TEST_SCRIPT.$NPROCS'procs'.$REG_TEST_OUTPUT_EXT 2>test.err
+                   test_code=$?
+                 fi               
+               else
+                 if [ "$RTEST_SHOW_OUT_ERR" = "true" ]; then
+                   $TIMEOUT $PYTHON_RUN $COV_LINE_PARALLEL $TEST_SCRIPT --comms $LAUNCHER --nworkers $NWORKERS
+                   test_code=$?
+                 else      
+                   $TIMEOUT $PYTHON_RUN $COV_LINE_PARALLEL $TEST_SCRIPT --comms $LAUNCHER --nworkers $NWORKERS >> $TEST_SCRIPT.$NPROCS'procs'-$LAUNCHER.$REG_TEST_OUTPUT_EXT 2>test.err
+                   test_code=$?
+                 fi
                fi
              fi
-           fi
-           reg_count_runs=$((reg_count_runs+1))
-
-           if [ "$test_code" -eq "0" ]; then
-             echo -e " ---Test $test_num: $TEST_SCRIPT using $LAUNCHER on $NPROCS processes ${pass_color} ...passed ${textreset}"
-             reg_pass=$((reg_pass+1))
-             #continue testing
-           else
-             echo -e " ---Test $test_num: $TEST_SCRIPT using $LAUNCHER on $NPROCS processes ${fail_color}  ...failed ${textreset}"
-             code=$test_code #sh - currently stop on failure
-             if [ $REG_STOP_ON_FAILURE != "true" ]; then
-               #Dump error to log file
-               echo -e "\nTest $test_num: $TEST_SCRIPT using $LAUNCHER on $NPROCS processes:\n" >>log.err
-               [ -e test.err ] && cat test.err >>log.err
+             reg_count_runs=$((reg_count_runs+1))
+        
+             if [ "$test_code" -eq "0" ]; then
+               echo -e " ---Test $test_num: $TEST_SCRIPT using $LAUNCHER on $NPROCS processes ${pass_color} ...passed ${textreset}"
+               reg_pass=$((reg_pass+1))
+               #continue testing
+             else
+               echo -e " ---Test $test_num: $TEST_SCRIPT using $LAUNCHER on $NPROCS processes ${fail_color}  ...failed ${textreset}"
+               code=$test_code #sh - currently stop on failure
+               if [ $REG_STOP_ON_FAILURE != "true" ]; then
+                 #Dump error to log file
+                 echo -e "\nTest $test_num: $TEST_SCRIPT using $LAUNCHER on $NPROCS processes:\n" >>log.err
+                 [ -e test.err ] && cat test.err >>log.err
+               fi;
+               reg_fail=$((reg_fail+1))
              fi;
-             reg_fail=$((reg_fail+1))
-           fi;
-
-           #If use sub-dirs - move this test's coverage files to regression dir where they can be merged with other tests
-           #[ "$RUN_COV_TESTS" = "true" ] && mv .cov_reg_out.* ../
-
-        fi; #if [ "$RUN_TEST" = "true" ];
-
-      done #nprocs
+        
+             #If use sub-dirs - move this test's coverage files to regression dir where they can be merged with other tests
+             #[ "$RUN_COV_TESTS" = "true" ] && mv .cov_reg_out.* ../
+        
+          fi; #if [ "$RUN_TEST" = "true" ];
+        
+        done #nprocs
       done #launcher
 
       [ $REG_STOP_ON_FAILURE = "true" ] && [ "$code" -ne "0" ] && cat test.err && break

--- a/libensemble/tests/run-tests.sh
+++ b/libensemble/tests/run-tests.sh
@@ -404,7 +404,6 @@ if [ "$root_found" = true ]; then
     reg_pass=0
     reg_fail=0
     test_num=0
-    set -x
     for TEST_SCRIPT in $REG_TEST_LIST
     do
       COMMS_LIST=$(grep -Po '# TESTSUITE_COMMS: \K.*' $TEST_SCRIPT)


### PR DESCRIPTION
Closes #129

I have added comment lines to regression tests specifying which tests to be run. These are queried by run-tests.sh. Currently, if those lines are not present none will be run, but we maybe could have a default if the lines are not found?

When something cannot run I've changed quit() to sys.exit with comment (will exit with 1 - failure) - and these will not be run in testsuite.

eg.
if nworkers < 2:
    sys.exit("Cannot run with a persistent worker if only one worker -- aborting...")

otherwise the quit() is just removed.

The persistent tests were running with 2 procs (1 worker and quitting) -  now runs 3 instead.

Also added some variants that were not run before.

