### PR TITLE
Feature/profiling

### DIFF
--- a/libensemble/libE_manager.py
+++ b/libensemble/libE_manager.py
@@ -34,7 +34,7 @@ def manager_main(hist, libE_specs, alloc_specs,
                  sim_specs, gen_specs, exit_criteria, persis_info, wcomms=[]):
     """Manager routine to coordinate the generation and simulation evaluations
     """
-    if sim_specs['profile']:
+    if sim_specs.get('profile'):
         pr = cProfile.Profile()
         pr.enable()
 
@@ -52,7 +52,7 @@ def manager_main(hist, libE_specs, alloc_specs,
                   sim_specs, gen_specs, exit_criteria, wcomms)
     result = mgr.run(persis_info)
 
-    if sim_specs['profile']:
+    if sim_specs.get('profile'):
         pr.disable()
         profile_stats_fname = 'manager.prof'
 

--- a/libensemble/libE_manager.py
+++ b/libensemble/libE_manager.py
@@ -19,7 +19,8 @@ from libensemble.message_numbers import \
     MAN_SIGNAL_FINISH, MAN_SIGNAL_KILL
 from libensemble.comms.comms import CommFinishedException
 from libensemble.libE_worker import WorkerErrMsg
-import cProfile, pstats
+import cProfile
+import pstats
 
 logger = logging.getLogger(__name__)
 # For debug messages - uncomment

--- a/libensemble/libE_worker.py
+++ b/libensemble/libE_worker.py
@@ -48,7 +48,7 @@ def worker_main(comm, sim_specs, gen_specs, workerID=None, log_comm=True):
     workerID: manager assigned worker ID (if None, default is comm.rank)
     """
 
-    if sim_specs['profile']:
+    if sim_specs.get('profile'):
         pr = cProfile.Profile()
         pr.enable()
 
@@ -64,7 +64,7 @@ def worker_main(comm, sim_specs, gen_specs, workerID=None, log_comm=True):
     worker = Worker(comm, dtypes, workerID, sim_specs, gen_specs)
     worker.run()
 
-    if sim_specs['profile']:
+    if sim_specs.get('profile'):
         pr.disable()
         profile_state_fname = 'worker_%d.prof' % (workerID)
 

--- a/libensemble/libE_worker.py
+++ b/libensemble/libE_worker.py
@@ -22,7 +22,8 @@ from libensemble.util.timer import Timer
 from libensemble.controller import JobController
 from libensemble.comms.logs import worker_logging_config
 from libensemble.comms.logs import LogConfig
-import cProfile, pstats
+import cProfile
+import pstats
 
 logger = logging.getLogger(__name__)
 # To change logging level for just this module

--- a/libensemble/tests/scaling_tests/forces/run_libe_forces.py
+++ b/libensemble/tests/scaling_tests/forces/run_libe_forces.py
@@ -57,7 +57,7 @@ if USE_BALSAM:
     jobctrl = BalsamJobController()
 else:
     from libensemble.mpi_controller import MPIJobController
-    jobctrl = MPIJobController(auto_resources=False)
+    jobctrl = MPIJobController(auto_resources=True)
 jobctrl.register_calc(full_path=sim_app, calc_type='sim')
 
 

--- a/libensemble/tests/scaling_tests/forces/run_libe_forces.py
+++ b/libensemble/tests/scaling_tests/forces/run_libe_forces.py
@@ -57,7 +57,7 @@ if USE_BALSAM:
     jobctrl = BalsamJobController()
 else:
     from libensemble.mpi_controller import MPIJobController
-    jobctrl = MPIJobController(auto_resources=True)
+    jobctrl = MPIJobController(auto_resources=False)
 jobctrl.register_calc(full_path=sim_app, calc_type='sim')
 
 

--- a/libensemble/tests/scaling_tests/forces/run_libe_forces.py
+++ b/libensemble/tests/scaling_tests/forces/run_libe_forces.py
@@ -76,8 +76,8 @@ sim_specs = {'sim_f': run_forces,             # This is the function whose outpu
              'sim_timesteps': 5,              # User attribute for number of timesteps in simulations
              'sim_kill_minutes': 10.0,        # User attribute for max time for simulations
              'kill_rate': 0.5,                # Between 0 and 1 for proportion of jobs that go bad (for testing kills)
-             'particle_variance': 0.2,         # Range over which particle count varies (for testing load imbalance)
-             'profile': True
+             'particle_variance': 0.2,        # Range over which particle count varies (for testing load imbalance)
+             'profile': False
              }
 
 # State the generating function, its arguments, output, and necessary parameters.

--- a/libensemble/tests/scaling_tests/forces/run_libe_forces.py
+++ b/libensemble/tests/scaling_tests/forces/run_libe_forces.py
@@ -76,7 +76,8 @@ sim_specs = {'sim_f': run_forces,             # This is the function whose outpu
              'sim_timesteps': 5,              # User attribute for number of timesteps in simulations
              'sim_kill_minutes': 10.0,        # User attribute for max time for simulations
              'kill_rate': 0.5,                # Between 0 and 1 for proportion of jobs that go bad (for testing kills)
-             'particle_variance': 0.2         # Range over which particle count varies (for testing load imbalance)
+             'particle_variance': 0.2,         # Range over which particle count varies (for testing load imbalance)
+             'profile': True
              }
 
 # State the generating function, its arguments, output, and necessary parameters.


### PR DESCRIPTION
- Adds basic support for profiling using cProfile
- Currently emits plaintext of all calls encountered, would there be a need to emit the profiling data in binary form so that it could be read by tools like [cprofilev](https://github.com/ymichael/cprofilev).