### PR TITLE
Adding travis flake8 check

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -32,6 +32,8 @@ exclude =
 per-file-ignores =
         # init needs to import the logger.
         libensemble/__init__.py:F401
+        libensemble/libensemble/__init__.py:F401
         # Need to turn of matching probes (before other imports) on some
         # systems/versions of MPI:
         libensemble/tests/standalone_tests/mpi_launch_test/create_mpi_jobs.py:E402 
+        libensemble/libensemble/tests/standalone_tests/mpi_launch_test/create_mpi_jobs.py:E402 

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,7 @@ install:
 
 # Run test (-z show output)
 script:
+  - flake8 libensemble --per-file-ignores='libensemble/libensemble/__init__.py:F401 libensemble/libensemble/tests/standalone_tests/mpi_launch_test/create_mpi_jobs.py:E402' 
   - libensemble/tests/run-tests.sh -z
 
 # Coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,9 +69,9 @@ install:
   - mpiexec --version #Show MPI library details
   - pip install -e .
 
-
 before_script:
-  - flake8 libensemble --per-file-ignores='libensemble/libensemble/__init__.py:F401 libensemble/libensemble/tests/standalone_tests/mpi_launch_test/create_mpi_jobs.py:E402' 
+  - flake8 libensemble 
+
 # Run test (-z show output)
 script:
   - libensemble/tests/run-tests.sh -z

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ install:
   - conda install petsc4py petsc
   - conda install --no-update-deps nlopt
   # pip install these as the conda installs downgrade pytest on python3.4
+  - pip install flake8
   - pip install pytest
   - pip install pytest-cov
   - pip install pytest-timeout
@@ -68,9 +69,11 @@ install:
   - mpiexec --version #Show MPI library details
   - pip install -e .
 
+
+before_script:
+  - flake8 libensemble --per-file-ignores='libensemble/libensemble/__init__.py:F401 libensemble/libensemble/tests/standalone_tests/mpi_launch_test/create_mpi_jobs.py:E402' 
 # Run test (-z show output)
 script:
-  - flake8 libensemble --per-file-ignores='libensemble/libensemble/__init__.py:F401 libensemble/libensemble/tests/standalone_tests/mpi_launch_test/create_mpi_jobs.py:E402' 
   - libensemble/tests/run-tests.sh -z
 
 # Coverage


### PR DESCRIPTION
Travis uses the `.flake8` file in the base `libensemble/` directory. 