### PR TITLE
Testing/fix travis py3.4 nlopt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ install:
         conda install mumps-mpi=5.1.2=h5bebb2f_1007;
     fi
   - conda install petsc4py petsc
-  - conda install --no-update-deps nlopt
+  - conda install nlopt
   # pip install these as the conda installs downgrade pytest on python3.4
   - pip install flake8
   - pip install pytest

--- a/conda/run_travis_locally/build_mpich_libE.sh
+++ b/conda/run_travis_locally/build_mpich_libE.sh
@@ -74,7 +74,7 @@ conda install --no-update-deps scipy || return
 conda install --no-update-deps  mpi4py || return
 conda install mumps-mpi=5.1.2=h5bebb2f_1007 || return # Force this version
 conda install petsc4py petsc || return
-conda install --no-update-deps nlopt || return
+conda install nlopt || return
 
 # pip install these as the conda installs downgrade pytest on python3.4
 pip install pytest || return


### PR DESCRIPTION
For some reason the travis build with Python 3.4 starting failing on the nlopt line with:

Solving environment: failed with current_repodata.json, will retry with next repodata source.
UnsatisfiableError: 
The command "conda install --no-update-deps nlopt" failed and exited with 1 during .

Strangely, nlopt is not attempting to update any dependencies, and yet removing --no-update-deps enables it to work.
