### PR TITLE
Checking that sim_ids are given in order

### DIFF
--- a/libensemble/history.py
+++ b/libensemble/history.py
@@ -152,7 +152,11 @@ class History:
             update_inds = np.arange(self.index, self.index+num_new)
             self.H['sim_id'][self.index:self.index+num_new] = range(self.index, self.index+num_new)
         else:
-            # gen method is building sim_id.
+            # gen method is building sim_id or adjusting values in existing sim_id rows.
+
+            # Ensure there aren't any gaps in the generated sim_id values:
+            assert np.all(np.isin(np.arange(self.index,np.max(O['sim_id'])+1),O['sim_id'])), "The generator function has produced sim_id that are not in order."
+
             num_new = len(np.setdiff1d(O['sim_id'], self.H['sim_id']))
 
             if num_new > rows_remaining:

--- a/libensemble/history.py
+++ b/libensemble/history.py
@@ -155,7 +155,7 @@ class History:
             # gen method is building sim_id or adjusting values in existing sim_id rows.
 
             # Ensure there aren't any gaps in the generated sim_id values:
-            assert np.all(np.isin(np.arange(self.index, np.max(O['sim_id'])+1), O['sim_id'])), "The generator function has produced sim_id that are not in order."
+            assert np.all(np.in1d(np.arange(self.index, np.max(O['sim_id'])+1), O['sim_id'])), "The generator function has produced sim_id that are not in order."
 
             num_new = len(np.setdiff1d(O['sim_id'], self.H['sim_id']))
 

--- a/libensemble/history.py
+++ b/libensemble/history.py
@@ -155,7 +155,7 @@ class History:
             # gen method is building sim_id or adjusting values in existing sim_id rows.
 
             # Ensure there aren't any gaps in the generated sim_id values:
-            assert np.all(np.isin(np.arange(self.index,np.max(O['sim_id'])+1),O['sim_id'])), "The generator function has produced sim_id that are not in order."
+            assert np.all(np.isin(np.arange(self.index, np.max(O['sim_id'])+1), O['sim_id'])), "The generator function has produced sim_id that are not in order."
 
             num_new = len(np.setdiff1d(O['sim_id'], self.H['sim_id']))
 


### PR DESCRIPTION
While we do give a warning that the user should be careful to generate `sim_id`s in a sequential manner, we should test whether this is occurring. 