### PR TITLE
Install/optional dependencies

### DIFF
--- a/docs/FAQ.rst
+++ b/docs/FAQ.rst
@@ -38,7 +38,7 @@ The generator will occupy the one worker, leaving none to run simulation functio
 libEnsemble hangs when using mpi4py
 -----------------------------------
 
-One cause of this could be that the communications fabric does not support matching 
+One cause of this could be that the communications fabric does not support matching
 probes (part of the MPI 3.0 standard), which mpi4py uses by default. This has been
 observed with Intels Truescale (TMI) fabric at time of writing. This can be solved
 either by switch fabric or turning off matching probes before the MPI module is first
@@ -127,10 +127,10 @@ The error message may be similar to below:
 **"can't open hfi unit: -1 (err=23)"**
 **"[13] MPI startup(): tmi fabric is not available and fallback fabric is not enabled"**
 
-This may occur on TMI when libEnsemble Python processes have been launched to a node and these, 
+This may occur on TMI when libEnsemble Python processes have been launched to a node and these,
 in turn, launch jobs on the node; creating too many processes for the available contexts. Note that
 while processes can share contexts, the system is confused by the fact that there are two
-phases, first libEnsemble processes and then sub-processes to run user jobs. The solution is to 
+phases, first libEnsemble processes and then sub-processes to run user jobs. The solution is to
 either reduce the number processes running or to specify a fallback fabric through environment
 variables::
 
@@ -140,3 +140,15 @@ variables::
 
 Another alternative is to run libEnsemble in central mode, in which libEnsemble runs on dedicated
 nodes, while launching all sub-jobs to other nodes.
+
+
+macOS - PETSc Installation issues
+---------------------------------
+
+**Frozen PETSc installation following a failed wheel build with** ``pip install petsc petsc4py``
+
+Following a failed wheel build for PETSc, the installation process may freeze when
+attempting to configure PETSc with the local Fortran compiler if it doesn't exist.
+Run the above command again after disabling Fortran configuring with ``export PETSC_CONFIGURE_OPTIONS='--with-fc=0'``
+The wheel build will still fail, but PETSc and petsc4py should still install
+successfully via setup.py after some time.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,10 +29,10 @@ Welcome to libEnsemble's documentation!
 libEnsemble is a library for managing ensemble-like collections of computations.
 
 
-* Completely new to libEnsemble? Start :doc:`here<quickstart>`.
+* New to libEnsemble? Start :doc:`here<quickstart>`.
 * Try out libEnsemble with a :doc:`tutorial<tutorials/local_sine_tutorial>`.
-* Ready to go more in-depth? Read the :doc:`User Guide<user_guide>`.
-* Check the :doc:`FAQ<FAQ>` for common questions, answers, errors, and resolutions.
+* Go in-depth by reading the :doc:`User Guide<user_guide>`.
+* Check the :doc:`FAQ<FAQ>` for common questions and answers, errors and resolutions.
 
 
 .. toctree::

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -112,7 +112,10 @@ libEnsemble is also available in the Spack_ distribution. It can be installed fr
 
 .. _Spack: https://spack.readthedocs.io/en/latest
 
-The tests and examples can be accessed in the `github <https://github.com/Libensemble/libensemble>`_ repository.
+The tests and examples can be accessed in the `GitHub <https://github.com/Libensemble/libensemble>`_ repository. If necessary, you may install all optional dependencies (listed above) at once with::
+
+    pip install libensemble[extras]
+
 A `tarball <https://github.com/Libensemble/libensemble/releases/latest>`_ of the most recent release is also available.
 
 
@@ -137,6 +140,13 @@ To clean the test repositories run::
 Further options are available. To see a complete list of options run::
 
     ./run-tests.sh -h
+
+If you have the source distribution, you can download (but not install) the testing
+prerequisites and run the tests with::
+
+    python setup.py test
+
+in the top-level directory containing the setup script.
 
 Coverage reports are produced separately for unit tests and regression tests
 under the relevant directories. For parallel tests, the union of all processors

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ class Run_TestSuite(TestCommand):
         import sys
         py_version = sys.version_info[0]
         print('Python version from setup.py is', py_version)
-        run_string = "code/tests/run-tests.sh -p " + str(py_version)
+        run_string = "libensemble/tests/run-tests.sh -p " + str(py_version)
         os.system(run_string)
 
 
@@ -60,8 +60,7 @@ setup(
                    ],
 
     extras_require = {
-           'extras': ['scipy', 'nlopt', 'mpi4py'],
-           'tests': tests_require},
+           'extras': ['scipy', 'nlopt', 'mpi4py', 'petsc', 'petsc4py']},
 
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,10 @@ setup(
                    'pytest-timeout',
                    ],
 
+    extras_require = {
+           'extras': ['scipy', 'nlopt', 'mpi4py'],
+           'tests': tests_require},
+
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
                    'pytest-cov>=2.5',
                    'pytest-pep8>=1.0',
                    'pytest-timeout',
+                   'mock'
                    ],
 
     extras_require = {


### PR DESCRIPTION
Adds more-integrated handling of optional dependencies for the examples and the testing suite, updates the docs a little.

Users that download the source can install all optional dependencies (scipy, NLopt, mpi4py, PETSc w/ petsc4py) at once with `pip install libensemble[extras]`. Users on certain systems that need to configure PETSc before installation can pass the necessary options before this command with `export PETSC_CONFIGURE_OPTIONS=...`

The `python setup.py test` capability has been updated.