### PR TITLE
Xsdk/remove mpi comm world

### DIFF
--- a/libensemble/comms/mpi.py
+++ b/libensemble/comms/mpi.py
@@ -24,7 +24,7 @@ class MPIComm(Comm):
     are still pending, we cancel those requests.
     """
 
-    def __init__(self, mpi_comm=MPI.COMM_WORLD, remote_rank=0):
+    def __init__(self, mpi_comm, remote_rank=0):
         "Initialize with a given MPI communicator and rank for the other end"
         self.mpi_comm = mpi_comm
         self.remote_rank = remote_rank

--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -194,25 +194,21 @@ def libE_mpi_defaults(libE_specs):
         libE_specs['comm'] = MPI.COMM_WORLD.Dup()
     if 'color' not in libE_specs:
         libE_specs['color'] = 0
-    return libE_specs
+    return libE_specs, MPI.COMM_NULL
 
 
 def libE_mpi(sim_specs, gen_specs, exit_criteria,
              persis_info, alloc_specs, libE_specs, H0):
     "MPI version of the libE main routine"
 
-    libE_specs = libE_mpi_defaults(libE_specs)
+    libE_specs, mpi_comm_null = libE_mpi_defaults(libE_specs)
     comm = libE_specs['comm']
-    try:
-        rank = comm.Get_rank()
-    except Exception:
-        # logger.warning("Rank {} not in libEnsemble communicator. Exiting".format(MPI.COMM_WORLD.Get_rank()))
-        logger.warning("Process not in libEnsemble communicator. Exiting")
-        # raise
-        return [], persis_info, []
 
+    if libE_specs['comm'] == mpi_comm_null:
+        return [], persis_info, 3  # Process not in comm
+
+    rank = comm.Get_rank()
     is_master = (rank == 0)
-
     check_inputs(libE_specs, alloc_specs, sim_specs, gen_specs, exit_criteria, H0)
 
     jobctl = JobController.controller

--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -205,8 +205,9 @@ def libE_mpi(sim_specs, gen_specs, exit_criteria,
     comm = libE_specs['comm']
     try:
         rank = comm.Get_rank()
-    except Exception as e:
-        logger.warning("Rank {} not in libEnsemble communicator. Exiting".format(MPI.COMM_WORLD.Get_rank()))
+    except Exception:
+        # logger.warning("Rank {} not in libEnsemble communicator. Exiting".format(MPI.COMM_WORLD.Get_rank()))
+        logger.warning("Process not in libEnsemble communicator. Exiting")
         # raise
         return [], persis_info, []
 

--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -191,7 +191,7 @@ def libE_mpi_defaults(libE_specs):
     from mpi4py import MPI
 
     if 'comm' not in libE_specs:
-        libE_specs['comm'] = MPI.COMM_WORLD
+        libE_specs['comm'] = MPI.COMM_WORLD.Dup()
     if 'color' not in libE_specs:
         libE_specs['color'] = 0
     return libE_specs

--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -203,7 +203,13 @@ def libE_mpi(sim_specs, gen_specs, exit_criteria,
 
     libE_specs = libE_mpi_defaults(libE_specs)
     comm = libE_specs['comm']
-    rank = comm.Get_rank()
+    try:
+        rank = comm.Get_rank()
+    except Exception as e:
+        logger.warning("Rank {} not in libEnsemble communicator. Exiting".format(MPI.COMM_WORLD.Get_rank()))
+        # raise
+        return [], persis_info, []
+
     is_master = (rank == 0)
 
     check_inputs(libE_specs, alloc_specs, sim_specs, gen_specs, exit_criteria, H0)

--- a/libensemble/tests/regression_tests/common.py
+++ b/libensemble/tests/regression_tests/common.py
@@ -40,13 +40,25 @@ def mpi_parse_args(args):
     return nworkers, is_master, libE_specs, args.tester_args
 
 
-def mpi_comm_excl(exc=[0]):
+def mpi_comm_excl(exc=[0], comm=None):
     "Exlude ranks from a communicator for MPI comms."
     from mpi4py import MPI
-    world_group = MPI.COMM_WORLD.Get_group()
-    new_group = world_group.Excl(exc)
-    mpi_comm = MPI.COMM_WORLD.Create(new_group)
+    parent_comm = comm or MPI.COMM_WORLD
+    parent_group = parent_comm.Get_group()
+    new_group = parent_group.Excl(exc)
+    mpi_comm = parent_comm.Create(new_group)
     return mpi_comm, MPI.COMM_NULL
+
+
+def mpi_comm_split(num_colors, comm=None):
+    "Split COMM_WORLD into sub-communicators for MPI comms."
+    from mpi4py import MPI
+    parent_comm = comm or MPI.COMM_WORLD
+    key = parent_comm.Get_rank()
+    color = key // num_colors
+    print('Rank {}: color {}'.format(key, color))
+    sub_comm = parent_comm.Split(color, key)
+    return sub_comm, color
 
 
 def local_parse_args(args):

--- a/libensemble/tests/regression_tests/common.py
+++ b/libensemble/tests/regression_tests/common.py
@@ -54,9 +54,10 @@ def mpi_comm_split(num_colors, comm=None):
     "Split COMM_WORLD into sub-communicators for MPI comms."
     from mpi4py import MPI
     parent_comm = comm or MPI.COMM_WORLD
+    parent_size = parent_comm.Get_size()
     key = parent_comm.Get_rank()
-    color = key // num_colors
-    print('Rank {}: color {}'.format(key, color))
+    row_size = parent_size // num_colors
+    color = key // row_size
     sub_comm = parent_comm.Split(color, key)
     return sub_comm, color
 

--- a/libensemble/tests/regression_tests/common.py
+++ b/libensemble/tests/regression_tests/common.py
@@ -40,6 +40,15 @@ def mpi_parse_args(args):
     return nworkers, is_master, libE_specs, args.tester_args
 
 
+def mpi_comm_excl(exc=[0]):
+    "Exlude ranks from a communicator for MPI comms."
+    from mpi4py import MPI
+    world_group = MPI.COMM_WORLD.Get_group()
+    new_group = world_group.Excl(exc)
+    mpi_comm = MPI.COMM_WORLD.Create(new_group)
+    return mpi_comm, MPI.COMM_NULL
+
+
 def local_parse_args(args):
     "Parse arguments for forked processes using multiprocessing."
     nworkers = args.nworkers or 4

--- a/libensemble/tests/regression_tests/test_chwirut_pounders_splitcomm.py
+++ b/libensemble/tests/regression_tests/test_chwirut_pounders_splitcomm.py
@@ -1,7 +1,7 @@
 # """
 # Runs libEnsemble with APOSMM+POUNDERS on the chwirut least squares problem.
 # All 214 residual calculations for a given point are performed as a single
-# simulation evaluation. This version uses sub-communicator
+# simulation evaluation. This version uses a split communicator.
 #
 # Execute via one of the following commands (e.g. 3 workers):
 #    mpiexec -np 4 python3 test_chwirut_pounders.py
@@ -23,7 +23,7 @@ from libensemble.gen_funcs.aposmm import aposmm_logic as gen_f
 from libensemble.tests.regression_tests.support import persis_info_2 as persis_info, aposmm_gen_out as gen_out
 from libensemble.tests.regression_tests.common import parse_args, save_libE_output, per_worker_stream, mpi_comm_split
 
-num_comms = 2
+num_comms = 2  # Must have atleast num_comms*2 processors
 nworkers, is_master, libE_specs, _ = parse_args()
 libE_specs['comm'], color = mpi_comm_split(num_comms)
 is_master = (libE_specs['comm'].Get_rank() == 0)

--- a/libensemble/tests/regression_tests/test_chwirut_pounders_splitcomm.py
+++ b/libensemble/tests/regression_tests/test_chwirut_pounders_splitcomm.py
@@ -1,0 +1,76 @@
+# """
+# Runs libEnsemble with APOSMM+POUNDERS on the chwirut least squares problem.
+# All 214 residual calculations for a given point are performed as a single
+# simulation evaluation. This version uses sub-communicator
+#
+# Execute via one of the following commands (e.g. 3 workers):
+#    mpiexec -np 4 python3 test_chwirut_pounders.py
+#
+# The number of concurrent evaluations of the objective function will be 4-1=3.
+# """
+
+# Do not change these lines - they are parsed by run-tests.sh
+# TESTSUITE_COMMS: mpi
+# TESTSUITE_NPROCS: 4
+
+import os
+import numpy as np
+
+# Import libEnsemble items for this test
+from libensemble.libE import libE
+from libensemble.sim_funcs.chwirut1 import chwirut_eval as sim_f
+from libensemble.gen_funcs.aposmm import aposmm_logic as gen_f
+from libensemble.tests.regression_tests.support import persis_info_2 as persis_info, aposmm_gen_out as gen_out
+from libensemble.tests.regression_tests.common import parse_args, save_libE_output, per_worker_stream, mpi_comm_split
+
+num_comms = 2
+nworkers, is_master, libE_specs, _ = parse_args()
+libE_specs['comm'], color = mpi_comm_split(num_comms)
+is_master = (libE_specs['comm'].Get_rank() == 0)
+
+# Declare the run parameters/functions
+m = 214
+n = 3
+budget = 10
+
+sim_specs = {'sim_f': sim_f,
+             'in': ['x'],
+             'out': [('f', float), ('fvec', float, m)],
+             'combine_component_func': lambda x: np.sum(np.power(x, 2))}
+
+gen_out += [('x', float, n), ('x_on_cube', float, n)]
+
+# lb tries to avoid x[1]=-x[2], which results in division by zero in chwirut.
+gen_specs = {'gen_f': gen_f,
+             'in': [o[0] for o in gen_out]+['f', 'fvec', 'returned'],
+             'out': gen_out,
+             'initial_sample_size': 5,
+             'num_active_gens': 1,
+             'batch_mode': True,
+             'lb': (-2-np.pi/10)*np.ones(n),
+             'ub': 2*np.ones(n),
+             'localopt_method': 'pounders',
+             'dist_to_bound_multiple': 0.5,
+             'components': m}
+
+gen_specs.update({'grtol': 1e-4, 'gatol': 1e-4, 'frtol': 1e-15, 'fatol': 1e-15})
+
+persis_info = per_worker_stream(persis_info, nworkers + 1)
+
+exit_criteria = {'sim_max': budget, 'elapsed_wallclock_time': 300}
+
+# Perform the run
+H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
+                            libE_specs=libE_specs)
+
+if is_master:
+    assert flag == 0
+    assert len(H) >= budget
+
+    # Calculating the Jacobian at the best point (though this information was not used by pounders)
+    from libensemble.sim_funcs.chwirut1 import EvaluateJacobian
+    J = EvaluateJacobian(H['x'][np.argmin(H['f'])])
+    assert np.linalg.norm(J) < 2000
+
+    outname = os.path.splitext(__file__)[0] + '_color' + str(color)
+    save_libE_output(H, persis_info, outname, nworkers)

--- a/libensemble/tests/regression_tests/test_chwirut_pounders_subcomm.py
+++ b/libensemble/tests/regression_tests/test_chwirut_pounders_subcomm.py
@@ -1,0 +1,81 @@
+# """
+# Runs libEnsemble with APOSMM+POUNDERS on the chwirut least squares problem.
+# All 214 residual calculations for a given point are performed as a single
+# simulation evaluation. This version uses sub-communicator
+#
+# Execute via one of the following commands (e.g. 3 workers):
+#    mpiexec -np 4 python3 test_chwirut_pounders.py
+#
+# The number of concurrent evaluations of the objective function will be 4-1=3.
+# """
+
+# Do not change these lines - they are parsed by run-tests.sh
+# TESTSUITE_COMMS: mpi
+# TESTSUITE_NPROCS: 3 4
+
+import numpy as np
+
+# Import libEnsemble items for this test
+from libensemble.libE import libE
+from libensemble.sim_funcs.chwirut1 import chwirut_eval as sim_f
+from libensemble.gen_funcs.aposmm import aposmm_logic as gen_f
+from libensemble.tests.regression_tests.support import persis_info_2 as persis_info, aposmm_gen_out as gen_out
+from libensemble.tests.regression_tests.common import parse_args, save_libE_output, per_worker_stream, mpi_comm_excl
+
+nworkers, is_master, libE_specs, _ = parse_args()
+libE_specs['comm'], mpi_comm_null = mpi_comm_excl()
+
+if libE_specs['comm'] == mpi_comm_null:
+    is_excluded = True
+    is_master = False
+else:
+    is_master = (libE_specs['comm'].Get_rank() == 0)
+    is_excluded = False
+
+# Declare the run parameters/functions
+m = 214
+n = 3
+budget = 10
+
+sim_specs = {'sim_f': sim_f,
+             'in': ['x'],
+             'out': [('f', float), ('fvec', float, m)],
+             'combine_component_func': lambda x: np.sum(np.power(x, 2))}
+
+gen_out += [('x', float, n), ('x_on_cube', float, n)]
+
+# lb tries to avoid x[1]=-x[2], which results in division by zero in chwirut.
+gen_specs = {'gen_f': gen_f,
+             'in': [o[0] for o in gen_out]+['f', 'fvec', 'returned'],
+             'out': gen_out,
+             'initial_sample_size': 5,
+             'num_active_gens': 1,
+             'batch_mode': True,
+             'lb': (-2-np.pi/10)*np.ones(n),
+             'ub': 2*np.ones(n),
+             'localopt_method': 'pounders',
+             'dist_to_bound_multiple': 0.5,
+             'components': m}
+
+gen_specs.update({'grtol': 1e-4, 'gatol': 1e-4, 'frtol': 1e-15, 'fatol': 1e-15})
+
+persis_info = per_worker_stream(persis_info, nworkers + 1)
+
+exit_criteria = {'sim_max': budget, 'elapsed_wallclock_time': 300}
+
+# Perform the run
+H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
+                            libE_specs=libE_specs)
+
+if is_master:
+    assert flag == 0
+    assert len(H) >= budget
+
+    # Calculating the Jacobian at the best point (though this information was not used by pounders)
+    from libensemble.sim_funcs.chwirut1 import EvaluateJacobian
+    J = EvaluateJacobian(H['x'][np.argmin(H['f'])])
+    assert np.linalg.norm(J) < 2000
+
+    save_libE_output(H, persis_info, __file__, nworkers)
+elif is_excluded:
+    assert flag == 3

--- a/libensemble/tests/regression_tests/test_mpi_comms.py
+++ b/libensemble/tests/regression_tests/test_mpi_comms.py
@@ -39,8 +39,7 @@ def worker_main(mpi_comm):
 def manager_main(mpi_comm):
     "Manager main routine"
     worker_comms = [
-        MPIComm(mpi_comm, r)
-        for r in range(1, mpi_comm.Get_size())]
+        MPIComm(mpi_comm, r) for r in range(1, mpi_comm.Get_size())]
     for comm in worker_comms:
         try:
             okay_flag = True
@@ -62,22 +61,20 @@ def mpi_comm_excl(exc=[0]):
     world_group = MPI.COMM_WORLD.Get_group()
     new_group = world_group.Excl(exc)
     mpi_comm = MPI.COMM_WORLD.Create(new_group)
-    #if MPI.COMM_WORLD.Get_rank() in exc:
-        #print('Removing world ranks {} from communicator'.format(exc))
-        #sys.exit()
     return mpi_comm
 
 
 def check_ranks(mpi_comm, test_exp, test_num):
     try:
         rank = mpi_comm.Get_rank()
-    except Exception as e:
+    except Exception:
         rank = -1
     comm_ranks_in_world = MPI.COMM_WORLD.allgather(rank)
-    print('got {},  exp {} '.format(comm_ranks_in_world, test_exp[test_num])); sys.stdout.flush()
+    print('got {},  exp {} '.format(comm_ranks_in_world, test_exp[test_num]))
+    sys.stdout.flush()
     # This is really testing the test is testing what is it supposed to test
     assert comm_ranks_in_world == test_exp[test_num], "comm_ranks_in_world are: " \
-                + str(comm_ranks_in_world) + " Expected: " + str(test_exp[test_num])
+        + str(comm_ranks_in_world) + " Expected: " + str(test_exp[test_num])
     if rank == -1:
         return False
     return True

--- a/libensemble/tests/regression_tests/test_mpi_comms.py
+++ b/libensemble/tests/regression_tests/test_mpi_comms.py
@@ -39,7 +39,7 @@ def worker_main(mpi_comm):
 def manager_main(mpi_comm):
     "Manager main routine"
     worker_comms = [
-        MPIComm(MPI.COMM_WORLD, r)
+        MPIComm(mpi_comm, r)
         for r in range(1, mpi_comm.Get_size())]
     for comm in worker_comms:
         try:

--- a/libensemble/tests/regression_tests/test_mpi_comms.py
+++ b/libensemble/tests/regression_tests/test_mpi_comms.py
@@ -57,6 +57,7 @@ def manager_main(mpi_comm):
         check_recv(comm, comm.remote_rank)
         comm.send("Goodbye")
 
+
 mpi_comm = MPI.COMM_WORLD
 if is_master:
     manager_main(mpi_comm)

--- a/libensemble/tests/regression_tests/test_mpi_comms.py
+++ b/libensemble/tests/regression_tests/test_mpi_comms.py
@@ -26,9 +26,9 @@ def check_recv(comm, expected_msg):
     assert msg == expected_msg, "Expected {}, received {}".format(expected_msg, msg)
 
 
-def worker_main():
+def worker_main(mpi_comm):
     "Worker main routine"
-    comm = MPIComm()
+    comm = MPIComm(mpi_comm)
     check_recv(comm, "Hello")
     check_recv(comm, "World")
     check_recv(comm, comm.rank)
@@ -36,11 +36,11 @@ def worker_main():
     check_recv(comm, "Goodbye")
 
 
-def manager_main():
+def manager_main(mpi_comm):
     "Manager main routine"
     worker_comms = [
         MPIComm(MPI.COMM_WORLD, r)
-        for r in range(1, MPI.COMM_WORLD.Get_size())]
+        for r in range(1, mpi_comm.Get_size())]
     for comm in worker_comms:
         try:
             okay_flag = True
@@ -57,8 +57,8 @@ def manager_main():
         check_recv(comm, comm.remote_rank)
         comm.send("Goodbye")
 
-
+mpi_comm = MPI.COMM_WORLD
 if is_master:
-    manager_main()
+    manager_main(mpi_comm)
 else:
-    worker_main()
+    worker_main(mpi_comm)


### PR DESCRIPTION
Resolves #108 

I have removed all uses of COMM_WORLD except to use for setting a default communicator if none is provided by the user. In this case COMM_WORLD is duplicated rather than used directly.

If a process enters libE() that is not in the communicator is returns with an exit flag of 3.

I have updated test_mpi_comms.py and added tests test_chwirut_pounders_subcomm.py and test_chwirut_pounders_splitcomm.py to test cases where a sub-communicator is provided. In the split test, multiple copies of libEnsemble are run, each with manager and workers.

Note: Some the commits to remove COMM_WORLD wen't through in pull request #216, as I took the travis_fix branch from this branch.