### PR TITLE
Logging / Manager Level

### DIFF
--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -1,10 +1,11 @@
 Logging
 =======
 
-The libEnsemble logger uses the standard Python logging levels (DEBUG, INFO, WARNING, ERROR, CRITICAL).
+The libEnsemble logger uses the standard Python logging levels (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+plus one additional custom level (MANAGER_WARNING) between WARNING and ERROR.
 
-The default level is INFO, which includes information such as how jobs are launched
-and when jobs are killed. To gain additional diagnostics, logging level can be set
+The default level is INFO, which includes information like how jobs are launched
+and when jobs are killed. To gain additional diagnostics, the logging level can be set
 to DEBUG. libEnsemble produces logging to the file ensemble.log by default. A log
 file name can also be supplied.
 
@@ -13,7 +14,8 @@ E.g. To change the logging level to DEBUG, provide the following in your the cal
     from libensemble import libE_logger
     libE_logger.set_level('DEBUG')
 
-Logger messages of WARNING level or higher are also displayed through stderr by default. This boundary can be adjusted as follows::
+Logger messages of WARNING level or higher are also displayed through stderr by default.
+This boundary can be adjusted as follows::
 
     from libensemble import libE_logger
 

--- a/libensemble/libE_logger.py
+++ b/libensemble/libE_logger.py
@@ -3,6 +3,20 @@ import logging
 from libensemble.comms.logs import LogConfig
 LogConfig(__package__)
 
+# From https://stackoverflow.com/questions/2183233/how-to-add-a-custom-loglevel-to-pythons-logging-facility/35804945
+
+MANAGER_WARNING = 35
+
+logging.addLevelName(MANAGER_WARNING, 'MANAGER_WARNING')
+
+
+def manager_warning(self, message, *args, **kwargs):
+    if self.isEnabledFor(MANAGER_WARNING):
+        self._log(MANAGER_WARNING, message, args, **kwargs)
+
+
+logging.Logger.manager_warning = manager_warning
+
 
 def set_level(level):
     """Set libEnsemble logging level"""

--- a/libensemble/libE_logger.py
+++ b/libensemble/libE_logger.py
@@ -6,8 +6,8 @@ LogConfig(__package__)
 # From https://stackoverflow.com/questions/2183233/how-to-add-a-custom-loglevel-to-pythons-logging-facility/35804945
 
 MANAGER_WARNING = 35
-
 logging.addLevelName(MANAGER_WARNING, 'MANAGER_WARNING')
+logging.MANAGER_WARNING = MANAGER_WARNING
 
 
 def manager_warning(self, message, *args, **kwargs):

--- a/libensemble/libE_manager.py
+++ b/libensemble/libE_manager.py
@@ -345,7 +345,7 @@ class Manager:
         while any(self.W['active']) and exit_flag == 0:
             persis_info = self._receive_from_workers(persis_info)
             if self.term_test(logged=False) == 2 and any(self.W['active']):
-                logger.warning(_WALLCLOCK_MSG)
+                logger.manager_warning(_WALLCLOCK_MSG)
                 sys.stdout.flush()
                 sys.stderr.flush()
                 exit_flag = 2

--- a/libensemble/tests/unit_tests/test_libE_main.py
+++ b/libensemble/tests/unit_tests/test_libE_main.py
@@ -139,7 +139,7 @@ def test_checking_inputs():
     # Test warning for unreturned points
     H0 = np.zeros(3, dtype=sim_specs['out'] + gen_specs['out'] +
                   alloc_specs['out'] + [('returned', bool)])
-    #check_inputs(libE_specs, alloc_specs, sim_specs, gen_specs, exit_criteria, H0)
+    # check_inputs(libE_specs, alloc_specs, sim_specs, gen_specs, exit_criteria, H0)
 
     # # Should fail because H0 has points with 'return'==False
     try:

--- a/libensemble/tests/unit_tests/test_libE_main.py
+++ b/libensemble/tests/unit_tests/test_libE_main.py
@@ -139,23 +139,23 @@ def test_checking_inputs():
     # Test warning for unreturned points
     H0 = np.zeros(3, dtype=sim_specs['out'] + gen_specs['out'] +
                   alloc_specs['out'] + [('returned', bool)])
-    check_inputs(libE_specs, alloc_specs, sim_specs, gen_specs, exit_criteria, H0)
+    #check_inputs(libE_specs, alloc_specs, sim_specs, gen_specs, exit_criteria, H0)
 
     # # Should fail because H0 has points with 'return'==False
-    # try:
-    #     check_inputs(libE_specs, alloc_specs, sim_specs, gen_specs, exit_criteria, H0)
-    # except AssertionError:
-    #     assert 1
-    # else:
-    #     assert 0
+    try:
+        check_inputs(libE_specs, alloc_specs, sim_specs, gen_specs, exit_criteria, H0)
+    except AssertionError:
+        assert 1
+    else:
+        assert 0
 
-    # # Should not fail
-    # H0['returned'] = True
-    # check_inputs(libE_specs, alloc_specs, sim_specs, gen_specs, exit_criteria, H0)
-    # #
-    # # Removing 'returned' and then testing again.
-    # H0 = rmfield(H0, 'returned')
-    # check_inputs(libE_specs, alloc_specs, sim_specs, gen_specs, exit_criteria, H0)
+    # Should not fail
+    H0['returned'] = True
+    check_inputs(libE_specs, alloc_specs, sim_specs, gen_specs, exit_criteria, H0)
+    #
+    # Removing 'returned' and then testing again.
+    H0 = rmfield(H0, 'returned')
+    check_inputs(libE_specs, alloc_specs, sim_specs, gen_specs, exit_criteria, H0)
 
     # Should fail because H0 has fields not in H
     H0 = np.zeros(3, dtype=sim_specs['out'] + gen_specs['out'] + alloc_specs['out'] + [('bad_name', bool), ('bad_name2', bool)])

--- a/libensemble/tests/unit_tests_logger/test_logger.py
+++ b/libensemble/tests/unit_tests_logger/test_logger.py
@@ -21,9 +21,15 @@ def test_set_log_level():
     level = libE_logger.get_level()
     assert level == 30, "Log level should be 30. Found: " + str(level)
 
+    libE_logger.set_level('MANAGER_WARNING')
+    level = libE_logger.get_level()
+    assert level == 35, "Log level should be 35. Found: " + str(level)
+
     libE_logger.set_level('ERROR')
     level = libE_logger.get_level()
     assert level == 40, "Log level should be 40. Found: " + str(level)
+
+    libE_logger.manager_warning('This test message should not log')
 
     libE_logger.set_level('INFO')
     level = libE_logger.get_level()
@@ -94,6 +100,10 @@ def test_set_stderr_level():
     libE_logger.set_stderr_level('WARNING')
     stderr_level = libE_logger.get_stderr_level()
     assert stderr_level == 30, "Log level should be 30. Found: " + str(stderr_level)
+
+    libE_logger.set_stderr_level('MANAGER_WARNING')
+    stderr_level = libE_logger.get_stderr_level()
+    assert stderr_level == 35, "Log level should be 35. Found: " + str(stderr_level)
 
     libE_logger.set_stderr_level('ERROR')
     stderr_level = libE_logger.get_stderr_level()

--- a/libensemble/tests/unit_tests_logger/test_logger.py
+++ b/libensemble/tests/unit_tests_logger/test_logger.py
@@ -4,6 +4,7 @@
 Unit test of libensemble log functions.
 """
 import os
+import logging
 from libensemble import libE_logger
 from libensemble.comms.logs import LogConfig
 
@@ -28,9 +29,6 @@ def test_set_log_level():
     libE_logger.set_level('ERROR')
     level = libE_logger.get_level()
     assert level == 40, "Log level should be 40. Found: " + str(level)
-
-    # Determine if self.isEnabledFor() works
-    libE_logger.manager_warning('This test message should not log')
 
     libE_logger.set_level('INFO')
     level = libE_logger.get_level()
@@ -109,6 +107,11 @@ def test_set_stderr_level():
     libE_logger.set_stderr_level('ERROR')
     stderr_level = libE_logger.get_stderr_level()
     assert stderr_level == 40, "Log level should be 40. Found: " + str(stderr_level)
+
+    libE_logger.set_level('ERROR')
+    logger = logging.getLogger('libensemble')
+    logger.manager_warning('This test message should not log')
+
 
 
 # Need setup/teardown here to kill loggers if running file without pytest

--- a/libensemble/tests/unit_tests_logger/test_logger.py
+++ b/libensemble/tests/unit_tests_logger/test_logger.py
@@ -29,6 +29,7 @@ def test_set_log_level():
     level = libE_logger.get_level()
     assert level == 40, "Log level should be 40. Found: " + str(level)
 
+    # Determine if self.isEnabledFor() works
     libE_logger.manager_warning('This test message should not log')
 
     libE_logger.set_level('INFO')

--- a/libensemble/tests/unit_tests_logger/test_logger.py
+++ b/libensemble/tests/unit_tests_logger/test_logger.py
@@ -113,7 +113,6 @@ def test_set_stderr_level():
     logger.manager_warning('This test message should not log')
 
 
-
 # Need setup/teardown here to kill loggers if running file without pytest
 # Issue: cannot destroy loggers and they are set up in other unit tests.
 # Partial solution: either rename the file so it is the first unit test, or


### PR DESCRIPTION
Different pull request due to some accidental git trickery. Oops.

Adds a "Manager Warning" level (35) to the logger between the standard Warning and Error.

In calling script:

`libE_logger.set_level('MANAGER_WARNING')`

Situations that justify a logging message of this level will need to be determined.