### PR TITLE
Testing/testing check inputs

### DIFF
--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -1,10 +1,11 @@
 Logging
 =======
 
-The libEnsemble logger uses the standard Python logging levels (DEBUG, INFO, WARNING, ERROR, CRITICAL).
+The libEnsemble logger uses the standard Python logging levels (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+plus one additional custom level (MANAGER_WARNING) between WARNING and ERROR.
 
-The default level is INFO, which includes information such as how jobs are launched
-and when jobs are killed. To gain additional diagnostics, logging level can be set
+The default level is INFO, which includes information like how jobs are launched
+and when jobs are killed. To gain additional diagnostics, the logging level can be set
 to DEBUG. libEnsemble produces logging to the file ensemble.log by default. A log
 file name can also be supplied.
 
@@ -13,7 +14,8 @@ E.g. To change the logging level to DEBUG, provide the following in your the cal
     from libensemble import libE_logger
     libE_logger.set_level('DEBUG')
 
-Logger messages of WARNING level or higher are also displayed through stderr by default. This boundary can be adjusted as follows::
+Logger messages of WARNING level or higher are also displayed through stderr by default.
+This boundary can be adjusted as follows::
 
     from libensemble import libE_logger
 

--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -534,8 +534,9 @@ def check_H(H0, sim_specs, alloc_specs, gen_specs):
         # assert 'returned' not in fields or np.all(H0['returned']), \
         #     "H0 contains unreturned points."
 
-        # Fail if prior history contains unreturned points.
-        assert('returned' not in fields or np.all(H0['returned'])), 'H0 contains unreturned points'
+        # Fail if prior history contains unreturned points (or returned but not given).
+        assert('returned' not in fields or np.all(H0['given'] == H0['returned'])), \
+            'H0 contains unreturned or invalid points'
 
         # Check dimensional compatibility of fields
         for field in fields:

--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -535,7 +535,7 @@ def check_H(H0, sim_specs, alloc_specs, gen_specs):
         #     "H0 contains unreturned points."
 
         # Fail if prior history contains unreturned points.
-        assert('returned' not in fields or np.all(H0['returned']))
+        assert('returned' not in fields or np.all(H0['returned'])), 'H0 contains unreturned points'
 
         # Check dimensional compatibility of fields
         for field in fields:
@@ -548,7 +548,6 @@ def check_inputs(libE_specs=None, alloc_specs=None, sim_specs=None, gen_specs=No
     sufficient information to perform a run.
     """
     # Detailed checking based on Required Keys in docs for each specs
-
     if libE_specs is not None:
         check_libE_specs(libE_specs, serial_check)
 

--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -464,7 +464,6 @@ def check_consistent_field(name, field0, field1):
 
 
 def check_libE_specs(libE_specs):
-    logger.debug('Checking libE_specs')
     assert isinstance(libE_specs, dict), "libE_specs must be a dictionary"
     comms_type = libE_specs.get('comms', 'undefined')
     if comms_type in ['mpi']:
@@ -477,13 +476,11 @@ def check_libE_specs(libE_specs):
 
 
 def check_alloc_specs(alloc_specs):
-    logger.debug('Checking alloc_specs')
     assert isinstance(alloc_specs, dict), "alloc_specs must be a dictionary"
     assert alloc_specs['alloc_f'], "Allocation function must be specified"
 
 
 def check_sim_specs(sim_specs):
-    logger.debug('Checking sim_specs')
     assert isinstance(sim_specs, dict), "sim_specs must be a dictionary"
     assert any([term_field in sim_specs for term_field in ['sim_f', 'in', 'out']]), \
         "sim_specs must contain 'sim_f', 'in', 'out'"
@@ -493,13 +490,11 @@ def check_sim_specs(sim_specs):
 
 
 def check_gen_specs(gen_specs):
-    logger.debug('Checking gen_specs')
     assert isinstance(gen_specs, dict), "gen_specs must be a dictionary"
     assert not bool(gen_specs) or len(gen_specs['out']), "gen_specs must have 'out' entries"
 
 
 def check_exit_criteria(exit_criteria, sim_specs, gen_specs):
-    logger.debug('Checking exit_criteria')
     assert isinstance(exit_criteria, dict), "exit_criteria must be a dictionary"
 
     assert len(exit_criteria) > 0, "Must have some exit criterion"
@@ -520,7 +515,6 @@ def check_exit_criteria(exit_criteria, sim_specs, gen_specs):
 
 
 def check_H(H0, sim_specs, alloc_specs, gen_specs):
-    logger.debug('Checking previous History array')
     if len(H0):
         # Handle if gen outputs sim IDs
         from libensemble.libE_fields import libE_fields
@@ -540,8 +534,10 @@ def check_H(H0, sim_specs, alloc_specs, gen_specs):
         #     "H0 contains unreturned points."
 
         # Warn user if prior history contains unreturned points.
-        if not ('returned' not in fields or np.all(H0['returned'])):
-            logger.warning('H0 contains unreturned points')
+        #if not ('returned' not in fields or np.all(H0['returned'])):
+            #logger.warning('H0 contains unreturned points')
+            
+        assert('returned' not in fields or np.all(H0['returned']))
 
         # Check dimensional compatibility of fields
         for field in fields:

--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -463,11 +463,12 @@ def check_consistent_field(name, field0, field1):
         "H too small to receive all components of H0 in field {}".format(name)
 
 
-def check_libE_specs(libE_specs):
+def check_libE_specs(libE_specs, serial_check=False):
     assert isinstance(libE_specs, dict), "libE_specs must be a dictionary"
-    comms_type = libE_specs.get('comms', 'undefined')
+    comms_type = libE_specs.get('comms', 'mpi')
     if comms_type in ['mpi']:
-        assert libE_specs['comm'].Get_size() > 1, "Manager only - must be at least one worker (2 MPI tasks)"
+        if not serial_check:
+            assert libE_specs['comm'].Get_size() > 1, "Manager only - must be at least one worker (2 MPI tasks)"
     elif comms_type in ['local']:
         assert libE_specs['nprocesses'] >= 1, "Must specify at least one worker"
     elif comms_type in ['tcp']:
@@ -534,7 +535,6 @@ def check_H(H0, sim_specs, alloc_specs, gen_specs):
         #     "H0 contains unreturned points."
 
         # Fail if prior history contains unreturned points.
-
         assert('returned' not in fields or np.all(H0['returned']))
 
         # Check dimensional compatibility of fields
@@ -542,7 +542,7 @@ def check_H(H0, sim_specs, alloc_specs, gen_specs):
             check_consistent_field(field, H0[field], Dummy_H[field])
 
 
-def check_inputs(libE_specs=None, alloc_specs=None, sim_specs=None, gen_specs=None, exit_criteria=None, H0=None):
+def check_inputs(libE_specs=None, alloc_specs=None, sim_specs=None, gen_specs=None, exit_criteria=None, H0=None, serial_check=False):
     """
     Check if the libEnsemble arguments are of the correct data type contain
     sufficient information to perform a run.
@@ -550,7 +550,7 @@ def check_inputs(libE_specs=None, alloc_specs=None, sim_specs=None, gen_specs=No
     # Detailed checking based on Required Keys in docs for each specs
 
     if libE_specs is not None:
-        check_libE_specs(libE_specs)
+        check_libE_specs(libE_specs, serial_check)
 
     if alloc_specs is not None:
         check_alloc_specs(alloc_specs)

--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -533,10 +533,8 @@ def check_H(H0, sim_specs, alloc_specs, gen_specs):
         # assert 'returned' not in fields or np.all(H0['returned']), \
         #     "H0 contains unreturned points."
 
-        # Warn user if prior history contains unreturned points.
-        #if not ('returned' not in fields or np.all(H0['returned'])):
-            #logger.warning('H0 contains unreturned points')
-            
+        # Fail if prior history contains unreturned points.
+
         assert('returned' not in fields or np.all(H0['returned']))
 
         # Check dimensional compatibility of fields

--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -147,7 +147,7 @@ def libE_manager(wcomms, sim_specs, gen_specs, exit_criteria, persis_info,
     "Generic manager routine run."
 
     if 'out' in gen_specs and ('sim_id', int) in gen_specs['out']:
-        logger.warning(_USER_SIM_ID_WARNING)
+        logger.manager_warning(_USER_SIM_ID_WARNING)
 
     try:
         persis_info, exit_flag, elapsed_time = \

--- a/libensemble/libE_logger.py
+++ b/libensemble/libE_logger.py
@@ -3,6 +3,20 @@ import logging
 from libensemble.comms.logs import LogConfig
 LogConfig(__package__)
 
+# From https://stackoverflow.com/questions/2183233/how-to-add-a-custom-loglevel-to-pythons-logging-facility/35804945
+
+MANAGER_WARNING = 35
+
+logging.addLevelName(MANAGER_WARNING, 'MANAGER_WARNING')
+
+
+def manager_warning(self, message, *args, **kwargs):
+    if self.isEnabledFor(MANAGER_WARNING):
+        self._log(MANAGER_WARNING, message, args, **kwargs)
+
+
+logging.Logger.manager_warning = manager_warning
+
 
 def set_level(level):
     """Set libEnsemble logging level"""

--- a/libensemble/libE_logger.py
+++ b/libensemble/libE_logger.py
@@ -6,8 +6,8 @@ LogConfig(__package__)
 # From https://stackoverflow.com/questions/2183233/how-to-add-a-custom-loglevel-to-pythons-logging-facility/35804945
 
 MANAGER_WARNING = 35
-
 logging.addLevelName(MANAGER_WARNING, 'MANAGER_WARNING')
+logging.MANAGER_WARNING = MANAGER_WARNING
 
 
 def manager_warning(self, message, *args, **kwargs):

--- a/libensemble/libE_manager.py
+++ b/libensemble/libE_manager.py
@@ -345,7 +345,7 @@ class Manager:
         while any(self.W['active']) and exit_flag == 0:
             persis_info = self._receive_from_workers(persis_info)
             if self.term_test(logged=False) == 2 and any(self.W['active']):
-                logger.warning(_WALLCLOCK_MSG)
+                logger.manager_warning(_WALLCLOCK_MSG)
                 sys.stdout.flush()
                 sys.stderr.flush()
                 exit_flag = 2

--- a/libensemble/tests/unit_tests/test_libE_main.py
+++ b/libensemble/tests/unit_tests/test_libE_main.py
@@ -187,11 +187,10 @@ def test_checking_inputs_single():
     sim_specs, gen_specs, exit_criteria = setup.make_criteria_and_specs_0()
     libE_specs = {'comm': fake_mpi, 'comms': 'mpi'}
 
-    # Other individual tests
-    check_inputs(libE_specs)
-    check_inputs(alloc_specs)
-    check_inputs(sim_specs)
-    check_inputs(gen_specs)
+    check_inputs(libE_specs=libE_specs)
+    check_inputs(alloc_specs=alloc_specs)
+    check_inputs(sim_specs=sim_specs)
+    check_inputs(gen_specs=gen_specs)
     check_inputs(exit_criteria=exit_criteria, sim_specs=sim_specs, gen_specs=gen_specs)
 
 

--- a/libensemble/tests/unit_tests/test_libE_main.py
+++ b/libensemble/tests/unit_tests/test_libE_main.py
@@ -166,26 +166,25 @@ def test_checking_inputs_H0():
     # Should fail because H0 has fields not in H
     H0 = np.zeros(3, dtype=sim_specs['out'] + gen_specs['out'] + alloc_specs['out'] + [('bad_name', bool), ('bad_name2', bool)])
     errstr = check_assertion(libE_specs, alloc_specs, sim_specs, gen_specs, exit_criteria, H0)
-    assert 'not in the History' in errstr, 'Incorrect assertion error: ' + errstr    
+    assert 'not in the History' in errstr, 'Incorrect assertion error: ' + errstr
 
 
 def test_checking_inputs_exit_crit():
     sim_specs, gen_specs, _ = setup.make_criteria_and_specs_0()
     libE_specs = {'comm': fake_mpi, 'comms': 'mpi'}
-    H0 = {}    
-    
+    H0 = {}
+
     exit_criteria = {}
     errstr = check_assertion(libE_specs, alloc_specs, sim_specs, gen_specs, exit_criteria, H0)
     assert 'Must have some exit criterion' in errstr, 'Incorrect assertion error: ' + errstr
-        
-    exit_criteria = {'swim_max':10}
+
+    exit_criteria = {'swim_max': 10}
     errstr = check_assertion(libE_specs, alloc_specs, sim_specs, gen_specs, exit_criteria, H0)
-    assert 'Valid termination options' in errstr, 'Incorrect assertion error: ' + errstr        
+    assert 'Valid termination options' in errstr, 'Incorrect assertion error: ' + errstr
 
 
 def test_checking_inputs_single():
     sim_specs, gen_specs, exit_criteria = setup.make_criteria_and_specs_0()
-    libE_specs = {}
     libE_specs = {'comm': fake_mpi, 'comms': 'mpi'}
 
     # Other individual tests

--- a/libensemble/tests/unit_tests_logger/test_logger.py
+++ b/libensemble/tests/unit_tests_logger/test_logger.py
@@ -21,9 +21,15 @@ def test_set_log_level():
     level = libE_logger.get_level()
     assert level == 30, "Log level should be 30. Found: " + str(level)
 
+    libE_logger.set_level('MANAGER_WARNING')
+    level = libE_logger.get_level()
+    assert level == 35, "Log level should be 35. Found: " + str(level)
+
     libE_logger.set_level('ERROR')
     level = libE_logger.get_level()
     assert level == 40, "Log level should be 40. Found: " + str(level)
+
+    libE_logger.manager_warning('This test message should not log')
 
     libE_logger.set_level('INFO')
     level = libE_logger.get_level()
@@ -94,6 +100,10 @@ def test_set_stderr_level():
     libE_logger.set_stderr_level('WARNING')
     stderr_level = libE_logger.get_stderr_level()
     assert stderr_level == 30, "Log level should be 30. Found: " + str(stderr_level)
+
+    libE_logger.set_stderr_level('MANAGER_WARNING')
+    stderr_level = libE_logger.get_stderr_level()
+    assert stderr_level == 35, "Log level should be 35. Found: " + str(stderr_level)
 
     libE_logger.set_stderr_level('ERROR')
     stderr_level = libE_logger.get_stderr_level()

--- a/libensemble/tests/unit_tests_logger/test_logger.py
+++ b/libensemble/tests/unit_tests_logger/test_logger.py
@@ -4,6 +4,7 @@
 Unit test of libensemble log functions.
 """
 import os
+import logging
 from libensemble import libE_logger
 from libensemble.comms.logs import LogConfig
 
@@ -28,9 +29,6 @@ def test_set_log_level():
     libE_logger.set_level('ERROR')
     level = libE_logger.get_level()
     assert level == 40, "Log level should be 40. Found: " + str(level)
-
-    # Determine if self.isEnabledFor() works
-    libE_logger.manager_warning('This test message should not log')
 
     libE_logger.set_level('INFO')
     level = libE_logger.get_level()
@@ -109,6 +107,11 @@ def test_set_stderr_level():
     libE_logger.set_stderr_level('ERROR')
     stderr_level = libE_logger.get_stderr_level()
     assert stderr_level == 40, "Log level should be 40. Found: " + str(stderr_level)
+
+    libE_logger.set_level('ERROR')
+    logger = logging.getLogger('libensemble')
+    logger.manager_warning('This test message should not log')
+
 
 
 # Need setup/teardown here to kill loggers if running file without pytest

--- a/libensemble/tests/unit_tests_logger/test_logger.py
+++ b/libensemble/tests/unit_tests_logger/test_logger.py
@@ -29,6 +29,7 @@ def test_set_log_level():
     level = libE_logger.get_level()
     assert level == 40, "Log level should be 40. Found: " + str(level)
 
+    # Determine if self.isEnabledFor() works
     libE_logger.manager_warning('This test message should not log')
 
     libE_logger.set_level('INFO')

--- a/libensemble/tests/unit_tests_logger/test_logger.py
+++ b/libensemble/tests/unit_tests_logger/test_logger.py
@@ -113,7 +113,6 @@ def test_set_stderr_level():
     logger.manager_warning('This test message should not log')
 
 
-
 # Need setup/teardown here to kill loggers if running file without pytest
 # Issue: cannot destroy loggers and they are set up in other unit tests.
 # Partial solution: either rename the file so it is the first unit test, or


### PR DESCRIPTION
Updated testing of new check_inputs.

Logging removed as logger not set up
Adds argument for serial check that does not check number MPI processors
Asserts that given and returned values match for each point in H0
Checks assertion messages returned for selected errors.