### PR TITLE
Debugging/balsam no file Resolution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ matrix:
 services:
     - postgresql
 
-addons:
-  hostname: libensemble-travis
 
 # matrix:
 #  allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ matrix:
       language: generic
       python: 3
 
-addons:
-  hostname: libensemble-travis
 
 services:
     - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ matrix:
       language: generic
       python: 3
 
+addons:
+  hostname: libensemble-travis
+
 services:
     - postgresql
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,8 @@ matrix:
       language: generic
       python: 3
 
-
 services:
     - postgresql
-
 
 # matrix:
 #  allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ matrix:
 services:
     - postgresql
 
+addons:
+  hostname: libensemble-travis
+
 # matrix:
 #  allow_failures:
 #    - env: MPI=openmpi

--- a/conda/test_balsam_hworld.py
+++ b/conda/test_balsam_hworld.py
@@ -2,7 +2,7 @@ import subprocess
 import os
 import time
 import libensemble
-from libensemble.tests.regression_tests.common import modify_Balsam_worker, modify_Balsam_hostprint
+from libensemble.tests.regression_tests.common import modify_Balsam_worker, modify_Balsam_JobEnv
 
 # TESTSUITE_COMMS: local
 # TESTSUITE_NPROCS: 3
@@ -98,7 +98,7 @@ if __name__ == '__main__':
     basedb = os.environ['HOME'] + '/test-balsam/data/libe_test-balsam'
 
     modify_Balsam_worker()
-    modify_Balsam_hostprint()
+    modify_Balsam_JobEnv()
     run_Balsam_job()
 
     jobdir = wait_for_job_dir(basedb)
@@ -107,20 +107,3 @@ if __name__ == '__main__':
     move_job_coverage(jobdir)
 
     print('Test complete.')
-
-
-# IN BALSAM LOG:
-
-# 11-Sep-2019 14:36:27|7301|   ERROR|balsam:47] Uncaught Exception <class 'ValueError'>: Cooley WorkerGroup needs workers_file to setup
-# Traceback (most recent call last):
-#   File "/home/travis/build/Libensemble/balsam/balsam/launcher/launcher.py", line 443, in <module>
-#     main(args)
-#   File "/home/travis/build/Libensemble/balsam/balsam/launcher/launcher.py", line 422, in main
-#     launcher = Launcher(wf_filter, timelimit_min, gpus_per_node)
-#   File "/home/travis/build/Libensemble/balsam/balsam/launcher/launcher.py", line 104, in __init__
-#     self.worker_group = worker.WorkerGroup()
-#   File "/home/travis/build/Libensemble/balsam/balsam/launcher/worker.py", line 50, in __init__
-#     self.setup()
-#   File "/home/travis/build/Libensemble/balsam/balsam/launcher/worker.py", line 112, in setup_COOLEY
-#     raise ValueError("Cooley WorkerGroup needs workers_file to setup")
-# ValueError: Cooley WorkerGroup needs workers_file to setup

--- a/libensemble/tests/regression_tests/common.py
+++ b/libensemble/tests/regression_tests/common.py
@@ -227,41 +227,27 @@ def modify_Balsam_pyCoverage():
             f.write(line)
 
 
-def modify_Balsam_hostprint():
-    # Also modify Balsam Worker & Worker Gropu to print Host type (for debugging
-    #    purposes). Balsam test bug may be caused by setup_COOLEY() being called
-    #   instead of setup_DEFAULT() within Balsam's worker.py
+def modify_Balsam_JobEnv():
+    # If Balsam detects that the system on which it is running contains the string
+    #   'cc' in it's hostname, then it thinks it's on Cooley! Travis hostnames are
+    #   randomly generated and occasionally may contain that offending string. This
+    #   modifies Balsam's JobEnvironment class to not check for 'cc'.
     import balsam
 
-    print_lines = {"host": "        print('HOST TYPE: ', self.host_type)\n",
-                   "COOLEY": "        print('IN setup_COOLEY')\n",
-                   "DEFAULT": "        print('IN setup_DEFAULT')\n"}
+    bad_line = "        'COOLEY' : 'cooley cc'.split()\n"
+    new_line = "        'COOLEY' : 'cooley'.split()\n"
 
-    host_prior_lines = ["        self.host_type = JobEnv.host_type\n",
-                        "        self.host_type = host_type\n"]
+    jobenv_file = 'JobEnvironment.py'
+    balsam_path = os.path.dirname(balsam.__file__) + '/service/schedulers'
+    balsam_jobenv_path = os.path.join(balsam_path, jobenv_file)
 
-    setup_prior_lines = ["    def setup_COOLEY(self):\n",
-                         "    def setup_DEFAULT(self):\n"]
-
-    workerfile = 'worker.py'
-    balsam_path = os.path.dirname(balsam.__file__) + '/launcher'
-    balsam_worker_path = os.path.join(balsam_path, workerfile)
-
-    with open(balsam_worker_path, 'r') as f:
+    with open(balsam_jobenv_path, 'r') as f:
         lines = f.readlines()
 
-    newlines = []
-    for line in lines:
-        if line in print_lines.values():
-            continue
-        newlines.append(line)               # Line of code from prior
-        if line in host_prior_lines:        #
-            newlines.append(print_lines['host'])
-        elif line == setup_prior_lines[0]:
-            newlines.append(print_lines['COOLEY'])
-        elif line == setup_prior_lines[1]:
-            newlines.append(print_lines['DEFAULT'])
+    for i in range(len(lines)):
+        if lines[i] == bad_line:
+            lines[i] = new_line
 
-    with open(balsam_worker_path, 'w') as f:
-        for line in newlines:
+    with open(balsam_jobenv_path, 'w') as f:
+        for line in lines:
             f.write(line)

--- a/libensemble/tests/regression_tests/script_test_balsam_hworld.py
+++ b/libensemble/tests/regression_tests/script_test_balsam_hworld.py
@@ -56,7 +56,7 @@ gen_specs = {'gen_f': gen_f,
 
 persis_info = per_worker_stream({}, nworkers + 1)
 
-exit_criteria = {'elapsed_wallclock_time': 30}
+exit_criteria = {'elapsed_wallclock_time': 35}
 
 # Perform the run
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria,


### PR DESCRIPTION
(hopefully) Resolves intermittent Balsam File Not Found error.

Each Travis job has a generated hostname similar to "travis-job-210bb586-bfc7-44fa-abd5-8d46e097ebfa". If this hostname contains 'cc', Balsam will think it's running on Cooley!

This implements another ugly hack to Balsam to not be so strict. Unfortunately, the method to change Travis job hostnames via .travis.yml appears to break PostgreSQL on installation.