### PR TITLE
Debugging/travis clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,13 +65,12 @@ install:
         mkdir ../sdk; tar xf MacOSX10.14.sdk.tar.xz -C ../sdk;
         COMPILERS=clang_osx-64;
         MUMPS=mumps-mpi=5.1.2=haf446c3_1007;
-        echo "export CONDA_BUILD_SYSROOT=/Users/travis/build/Libensemble/sdk/MacOSX10.14.sdk" > setenv.sh;
-        source setenv.sh;
+        conda install clang=8.0.1
     else
         COMPILERS=gcc_linux-64;
         MUMPS=mumps-mpi=5.1.2=h5bebb2f_1007;
     fi
-  - conda install $COMPILERS
+  - conda install --no-update-dependencies $COMPILERS
   #S- conda install nlopt petsc4py petsc mpi4py scipy $MPI
   - conda install nlopt petsc4py petsc $MUMPS mpi4py scipy $MPI
   # pip install these as the conda installs downgrade pytest on python3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,12 +65,12 @@ install:
         mkdir ../sdk; tar xf MacOSX10.14.sdk.tar.xz -C ../sdk;
         COMPILERS=clang_osx-64;
         MUMPS=mumps-mpi=5.1.2=haf446c3_1007;
-        conda install clang=8.0.1
+        conda install clang=8.0.1;
     else
         COMPILERS=gcc_linux-64;
         MUMPS=mumps-mpi=5.1.2=h5bebb2f_1007;
     fi
-  - conda install --no-update-dependencies $COMPILERS
+  - conda install --freeze-installed $COMPILERS
   #S- conda install nlopt petsc4py petsc mpi4py scipy $MPI
   - conda install nlopt petsc4py petsc $MUMPS mpi4py scipy $MPI
   # pip install these as the conda installs downgrade pytest on python3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,8 @@ cache:
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       wget https://repo.continuum.io/miniconda/Miniconda3-4.6.14-MacOSX-x86_64.sh -O miniconda.sh;
+      brew update && brew upgrade;
+      sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /
     else
       wget https://repo.continuum.io/miniconda/Miniconda3-4.6.14-Linux-x86_64.sh -O miniconda.sh;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,14 +62,14 @@ before_install:
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-        wget https://github.com/phracker/MacOSX-SDKs/releases/download/10.14-beta4/MacOSX10.14.sdk.tar.xz;
-        mkdir ../sdk; tar xf MacOSX10.14.sdk.tar.xz -C ../sdk;
         COMPILERS=clang_osx-64;
         MUMPS=mumps-mpi=5.1.2=haf446c3_1007;
     else
         COMPILERS=gcc_linux-64;
         MUMPS=mumps-mpi=5.1.2=h5bebb2f_1007;
     fi
+    # wget https://github.com/phracker/MacOSX-SDKs/releases/download/10.14-beta4/MacOSX10.14.sdk.tar.xz;
+    # mkdir ../sdk; tar xf MacOSX10.14.sdk.tar.xz -C ../sdk;
   - conda install $COMPILERS
   #S- conda install nlopt petsc4py petsc mpi4py scipy $MPI
   - conda install nlopt petsc4py petsc $MUMPS mpi4py scipy $MPI
@@ -93,10 +93,10 @@ before_script:
   # Allow 10000 files to be open at once (critical for persistent_aposmm)
   - ulimit -Sn 10000
   # Set conda compilers to use new SDK instead of Travis default.
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-        echo "export CONDA_BUILD_SYSROOT=/Users/travis/build/Libensemble/sdk/MacOSX10.14.sdk" > setenv.sh;
-        source setenv.sh;
-    fi
+  # - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+  #       echo "export CONDA_BUILD_SYSROOT=/Users/travis/build/Libensemble/sdk/MacOSX10.14.sdk" > setenv.sh;
+  #       source setenv.sh;
+  #   fi
 
 # Run test (-z show output)
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,35 +19,11 @@ env:
 matrix:
   include:
     - os: osx
-      osx_image: xcode11
-      env: MPI=mpich PY=3
-      language: generic
-      python: 3
-    - os: osx
-      osx_image: xcode10.3
-      env: MPI=mpich PY=3
-      language: generic
-      python: 3
-    - os: osx
-      osx_image: xcode10.2
-      env: MPI=mpich PY=3
-      language: generic
-      python: 3
-    - os: osx
       osx_image: xcode10.1
       env: MPI=mpich PY=3
       language: generic
       python: 3
-    - os: osx
-      osx_image: xcode10
-      env: MPI=mpich PY=3
-      language: generic
-      python: 3
-    - os: osx
-      osx_image: xcode9.4
-      env: MPI=mpich PY=3
-      language: generic
-      python: 3
+
 
 services:
     - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,8 +61,8 @@ before_install:
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-        wget https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX10.13.sdk.tar.xz;
-        mkdir ../sdk; tar xf MacOSX10.13.sdk.tar.xz -C ../sdk;
+        wget https://github.com/phracker/MacOSX-SDKs/releases/download/10.14-beta4/MacOSX10.14.sdk.tar.xz;
+        mkdir ../sdk; tar xf MacOSX10.14.sdk.tar.xz -C ../sdk;
         COMPILERS=clang_osx-64;
         MUMPS=mumps-mpi=5.1.2=haf446c3_1007;
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,16 +18,16 @@ env:
 
 matrix:
   include:
-    - os: osx
-      osx_image: xcode11
-      env: MPI=mpich PY=3
-      language: generic
-      python: 3
-    - os: osx
-      osx_image: xcode10.3
-      env: MPI=mpich PY=3
-      language: generic
-      python: 3
+    # - os: osx
+    #   osx_image: xcode11
+    #   env: MPI=mpich PY=3
+    #   language: generic
+    #   python: 3
+    # - os: osx
+    #   osx_image: xcode10.3
+    #   env: MPI=mpich PY=3
+    #   language: generic
+    #   python: 3
     - os: osx
       osx_image: xcode9.4
       env: MPI=mpich PY=3
@@ -57,7 +57,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       wget https://repo.continuum.io/miniconda/Miniconda3-4.7.10-MacOSX-x86_64.sh -O miniconda.sh;
     else
-      wget https://repo.continuum.io/miniconda/Miniconda3-4.6.14-Linux-x86_64.sh -O miniconda.sh;
+      wget https://repo.continuum.io/miniconda/Miniconda3-4.7.10-Linux-x86_64.sh -O miniconda.sh;
     fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
@@ -68,7 +68,7 @@ before_install:
   - conda config --add channels conda-forge
   - conda create --yes --name condaenv python=$TRAVIS_PYTHON_VERSION
   - source activate condaenv
-        # sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /;
+    # sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /;
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,16 +18,31 @@ env:
 
 matrix:
   include:
-    # - os: osx
-    #   osx_image: xcode11
-    #   env: MPI=mpich PY=3
-    #   language: generic
-    #   python: 3
-    # - os: osx
-    #   osx_image: xcode10.3
-    #   env: MPI=mpich PY=3
-    #   language: generic
-    #   python: 3
+    - os: osx
+      osx_image: xcode11
+      env: MPI=mpich PY=3
+      language: generic
+      python: 3
+    - os: osx
+      osx_image: xcode10.3
+      env: MPI=mpich PY=3
+      language: generic
+      python: 3
+    - os: osx
+      osx_image: xcode10.2
+      env: MPI=mpich PY=3
+      language: generic
+      python: 3
+    - os: osx
+      osx_image: xcode10.1
+      env: MPI=mpich PY=3
+      language: generic
+      python: 3
+    - os: osx
+      osx_image: xcode10
+      env: MPI=mpich PY=3
+      language: generic
+      python: 3
     - os: osx
       osx_image: xcode9.4
       env: MPI=mpich PY=3

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,16 @@ matrix:
       env: MPI=mpich PY=3
       language: generic
       python: 3
+    - os: osx
+      osx_image: xcode10.3
+      env: MPI=mpich PY=3
+      language: generic
+      python: 3
+    - os: osx
+      osx_image: xcode9.4
+      env: MPI=mpich PY=3
+      language: generic
+      python: 3
 
 services:
     - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       wget https://repo.continuum.io/miniconda/Miniconda3-4.6.14-MacOSX-x86_64.sh -O miniconda.sh;
       brew update && brew upgrade;
-      sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /
+      sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /;
     else
       wget https://repo.continuum.io/miniconda/Miniconda3-4.6.14-Linux-x86_64.sh -O miniconda.sh;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,7 @@ cache:
 # Setup Miniconda
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda3-4.6.14-MacOSX-x86_64.sh -O miniconda.sh;
-      brew update && brew upgrade;
+      wget https://repo.continuum.io/miniconda/Miniconda3-4.7.10-MacOSX-x86_64.sh -O miniconda.sh;
       sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /;
     else
       wget https://repo.continuum.io/miniconda/Miniconda3-4.6.14-Linux-x86_64.sh -O miniconda.sh;
@@ -67,12 +66,12 @@ install:
         mkdir ../sdk; tar xf MacOSX10.14.sdk.tar.xz -C ../sdk;
         COMPILERS=clang_osx-64;
         MUMPS=mumps-mpi=5.1.2=haf446c3_1007;
-        conda install clang=8.0.1;
+        #conda install clang=8.0.1;
     else
         COMPILERS=gcc_linux-64;
         MUMPS=mumps-mpi=5.1.2=h5bebb2f_1007;
     fi
-  - conda install --freeze-installed $COMPILERS
+  - conda install $COMPILERS
   #S- conda install nlopt petsc4py petsc mpi4py scipy $MPI
   - conda install nlopt petsc4py petsc $MUMPS mpi4py scipy $MPI
   # pip install these as the conda installs downgrade pytest on python3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,8 @@ install:
         mkdir ../sdk; tar xf MacOSX10.14.sdk.tar.xz -C ../sdk;
         COMPILERS=clang_osx-64;
         MUMPS=mumps-mpi=5.1.2=haf446c3_1007;
+        echo "export CONDA_BUILD_SYSROOT=/Users/travis/build/Libensemble/sdk/MacOSX10.14.sdk" > setenv.sh;
+        source setenv.sh;
     else
         COMPILERS=gcc_linux-64;
         MUMPS=mumps-mpi=5.1.2=h5bebb2f_1007;

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   #- conda update -q -y conda
-  - conda info -a # For debugging any issues with conda 
+  - conda info -a # For debugging any issues with conda
   - conda config --add channels conda-forge
   - conda create --yes --name condaenv python=$TRAVIS_PYTHON_VERSION
   - source activate condaenv
@@ -66,7 +66,6 @@ install:
         mkdir ../sdk; tar xf MacOSX10.14.sdk.tar.xz -C ../sdk;
         COMPILERS=clang_osx-64;
         MUMPS=mumps-mpi=5.1.2=haf446c3_1007;
-        #conda install clang=8.0.1;
     else
         COMPILERS=gcc_linux-64;
         MUMPS=mumps-mpi=5.1.2=h5bebb2f_1007;

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,6 @@ cache:
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       wget https://repo.continuum.io/miniconda/Miniconda3-4.7.10-MacOSX-x86_64.sh -O miniconda.sh;
-      sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /;
     else
       wget https://repo.continuum.io/miniconda/Miniconda3-4.6.14-Linux-x86_64.sh -O miniconda.sh;
     fi
@@ -69,6 +68,7 @@ before_install:
   - conda config --add channels conda-forge
   - conda create --yes --name condaenv python=$TRAVIS_PYTHON_VERSION
   - source activate condaenv
+        # sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /;
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ before_script:
   - ulimit -Sn 10000
   # Set conda compilers to use new SDK instead of Travis default.
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-        echo "export CONDA_BUILD_SYSROOT=/Users/travis/build/Libensemble/sdk/MacOSX10.13.sdk" > setenv.sh;
+        echo "export CONDA_BUILD_SYSROOT=/Users/travis/build/Libensemble/sdk/MacOSX10.14.sdk" > setenv.sh;
         source setenv.sh;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   #- conda update -q -y conda
-  - conda info -a # For debugging any issues with conda
+  - conda info -a # For debugging any issues with conda 
   - conda config --add channels conda-forge
   - conda create --yes --name condaenv python=$TRAVIS_PYTHON_VERSION
   - source activate condaenv


### PR DESCRIPTION
Currently, there appears to be an issue with the Xcode SDK on every macOS Mojave (10.14) build on Travis that causes Balsam's installation to fail. For now, this sets Travis to test on macOS 10.13.

This also updates the downloaded miniconda version and slims down the macOS configuration process.