### PR TITLE
Testing/py35 omit balsam

### DIFF
--- a/conda/install-balsam.py
+++ b/conda/install-balsam.py
@@ -26,8 +26,20 @@ def move_test_balsam(balsam_test):
     if not os.path.isfile(reg_dir_with_btest):
         os.rename('./conda/{}'.format(balsam_test), reg_dir_with_btest)
 
+def configure_coverage():
+    # Enables coverage of balsam_controller.py if running test
+    coveragerc = './libensemble/tests/.coveragerc'
+    with open(coveragerc, 'r') as f:
+        lines = f.readlines()
+
+    newlines = [i for i in lines if i != '    */balsam_controller.py\n']
+
+    with open(coveragerc, 'w') as f:
+        for line in newlines:
+            f.write(line)
 
 if int(sys.version[2]) >= 6:  # Balsam only supports Python 3.6+
     install_balsam()
     move_test_balsam('test_balsam_hworld.py')
+    configure_coverage()
     subprocess.run('./conda/configure-balsam-test.sh'.split())

--- a/libensemble/tests/.coveragerc
+++ b/libensemble/tests/.coveragerc
@@ -4,7 +4,7 @@
 [run]
 data_file = .cov_merge_out
 
-[html]    
+[html]
 directory = cov_merge
 
 #Report files can be controlled here
@@ -20,6 +20,7 @@ omit =
     */unit_tests_logger/*
     */regression_tests/*
     */sim_funcs/helloworld.py
+    */balsam_controller.py
 #    */sim_funcs/*
 #    */gen_funcs/*
 exclude_lines =

--- a/libensemble/tests/regression_tests/.coveragerc
+++ b/libensemble/tests/regression_tests/.coveragerc
@@ -9,7 +9,7 @@ omit =
     */branin_*/*
 
 branch = true
-	 
+
 data_file = .cov_reg_out
 
 parallel = true
@@ -22,9 +22,11 @@ omit =
     */unit_tests/*
     */unit_tests_nompi/*
     */regression_tests/*
+    */balsam_controller.py
+
 
 exclude_lines =
     if __name__ == .__main__.:
 
-[html]    
+[html]
 directory = cov_reg

--- a/libensemble/tests/regression_tests/.coveragerc
+++ b/libensemble/tests/regression_tests/.coveragerc
@@ -7,8 +7,6 @@ omit =
     */unit_tests_nompi/*
     */regression_tests/*
     */branin_*/*
-    balsam_controller.py
-
 
 branch = true
 
@@ -24,7 +22,6 @@ omit =
     */unit_tests/*
     */unit_tests_nompi/*
     */regression_tests/*
-
 
 exclude_lines =
     if __name__ == .__main__.:

--- a/libensemble/tests/regression_tests/.coveragerc
+++ b/libensemble/tests/regression_tests/.coveragerc
@@ -22,7 +22,7 @@ omit =
     */unit_tests/*
     */unit_tests_nompi/*
     */regression_tests/*
-    */balsam_controller.py
+    balsam_controller.py
 
 
 exclude_lines =

--- a/libensemble/tests/regression_tests/.coveragerc
+++ b/libensemble/tests/regression_tests/.coveragerc
@@ -7,6 +7,8 @@ omit =
     */unit_tests_nompi/*
     */regression_tests/*
     */branin_*/*
+    balsam_controller.py
+
 
 branch = true
 
@@ -22,7 +24,6 @@ omit =
     */unit_tests/*
     */unit_tests_nompi/*
     */regression_tests/*
-    balsam_controller.py
 
 
 exclude_lines =


### PR DESCRIPTION
`balsam_controller.py`'s coverage is omitted except when Balsam is installed through install_balsam.py or the omission line is removed (on a non-CI system).

On Coveralls, only three versions (with coverage) of `balsam_controller.py` are now listed, as opposed to four versions with one uncovered.

This means overall coverage shouldn't be depressed by the Python 3.5 build which doesn't run the Balsam tests anyway.