### PR TITLE
Feature/resources partition groups

### DIFF
--- a/conda/install-balsam.py
+++ b/conda/install-balsam.py
@@ -26,6 +26,7 @@ def move_test_balsam(balsam_test):
     if not os.path.isfile(reg_dir_with_btest):
         os.rename('./conda/{}'.format(balsam_test), reg_dir_with_btest)
 
+
 def configure_coverage():
     # Enables coverage of balsam_controller.py if running test
     coveragerc = './libensemble/tests/.coveragerc'
@@ -37,6 +38,7 @@ def configure_coverage():
     with open(coveragerc, 'w') as f:
         for line in newlines:
             f.write(line)
+
 
 if int(sys.version[2]) >= 6:  # Balsam only supports Python 3.6+
     install_balsam()

--- a/libensemble/env_resources.py
+++ b/libensemble/env_resources.py
@@ -33,7 +33,6 @@ class EnvResources:
     default_nodelist_env_lsf = 'LSB_HOSTS'
     default_nodelist_env_lsf_shortform = 'LSB_MCPU_HOSTS'
 
-
     def __init__(self,
                  nodelist_env_slurm=None,
                  nodelist_env_cobalt=None,
@@ -77,7 +76,6 @@ class EnvResources:
         self.ndlist_funcs['LSF'] = EnvResources.get_lsf_nodelist
         self.ndlist_funcs['LSF_shortform'] = EnvResources.get_lsf_nodelist_frm_shortform
 
-
     def get_nodelist(self):
         """Return nodelist from environment or an empty list"""
         for env, env_var in self.nodelists.items():
@@ -89,13 +87,11 @@ class EnvResources:
                 return global_nodelist
         return []
 
-
     def abbrev_nodenames(self, node_list):
         """Return nodelist with entries in abbreviated form"""
         if self.schedular == 'Cobalt':
             return EnvResources.cobalt_abbrev_nodenames(node_list)
         return node_list
-
 
     @staticmethod
     def _range_split(s):
@@ -109,7 +105,6 @@ class EnvResources:
         b = b + 1
         return a, b, nnum_len
 
-
     @staticmethod
     def _noderange_append(prefix, nidstr):
         """Format and append nodes to overall nodelist"""
@@ -119,7 +114,6 @@ class EnvResources:
             for nid in range(a, b):
                 nidlst.append(prefix + str(nid).zfill(nnum_len))
         return nidlst
-
 
     @staticmethod
     def get_slurm_nodelist(node_list_env):
@@ -147,7 +141,6 @@ class EnvResources:
 
         return sorted(nidlst)
 
-
     @staticmethod
     def get_cobalt_nodelist(node_list_env):
         """Get global libEnsemble nodelist from the Cobalt environment"""
@@ -161,14 +154,12 @@ class EnvResources:
                 nidlst.append(str(nid))
         return sorted(nidlst, key=int)
 
-
     @staticmethod
     def cobalt_abbrev_nodenames(node_list, prefix='nid'):
         """Return nodelist with prefix and leading zeros stripped"""
         newlist = [s.lstrip(prefix) for s in node_list]
         newlist = [s.lstrip('0') for s in newlist]
         return newlist
-
 
     @staticmethod
     def get_lsf_nodelist(node_list_env):
@@ -179,7 +170,6 @@ class EnvResources:
         unique_entries = list(OrderedDict.fromkeys(entries))
         nodes = [n for n in unique_entries if 'batch' not in n]
         return nodes
-
 
     @staticmethod
     def get_lsf_nodelist_frm_shortform(node_list_env):

--- a/libensemble/env_resources.py
+++ b/libensemble/env_resources.py
@@ -106,7 +106,8 @@ class EnvResources:
         return a, b, nnum_len
 
     @staticmethod
-    def _noderange_split(prefix, nidstr, nidlst):
+    def _noderange_split(prefix, nidstr):
+        nidlst = []
         for nidgroup in nidstr.split(','):
             a, b, nnum_len = EnvResources._range_split(nidgroup)
             for nid in range(a, b):
@@ -126,8 +127,7 @@ class EnvResources:
                 return splitstr
             prefix = splitstr[0]
             nidstr = splitstr[1].strip("]")
-            nidlst = EnvResources._noderange_split(prefix, nidstr, [])
-            return sorted(nidlst)
+            nidlst = EnvResources._noderange_split(prefix, nidstr)
         else:
             splitgroups = [str.split('[', 1) for str in splitstr]
             prefixgroups = [group[0] for group in splitgroups]
@@ -136,8 +136,9 @@ class EnvResources:
             for i in range(len(prefixgroups)):
                 prefix = prefixgroups[i]
                 nidstr = nodegroups[i]
-                nidlst.extend(EnvResources._noderange_split(prefix, nidstr, nidlst))
-            return sorted(set(nidlst))
+                nidlst.extend(EnvResources._noderange_split(prefix, nidstr))
+
+        return sorted(nidlst)
 
     @staticmethod
     def get_cobalt_nodelist(node_list_env):

--- a/libensemble/env_resources.py
+++ b/libensemble/env_resources.py
@@ -136,7 +136,7 @@ class EnvResources:
             nidstr = splitstr[1].strip("]")
             nidlst = EnvResources._noderange_append(prefix, nidstr)
         else:                           # Multiple Partitions
-            splitgroups = [str.split('[', 1) for str in splitstr]
+            splitgroups = [str.split('[', 1) for str in part_splitstr]
             prefixgroups = [group[0] for group in splitgroups]
             nodegroups = [group[1].strip(']') for group in splitgroups]
             nidlst = []

--- a/libensemble/tests/unit_tests/test_env_resources.py
+++ b/libensemble/tests/unit_tests/test_env_resources.py
@@ -66,6 +66,13 @@ def test_slurm_nodelist_groups():
     assert nodelist == exp_out, "Nodelist returned does not match expected"
 
 
+def test_slurm_nodelist_groups_partitions():
+    os.environ["LIBE_RESOURCES_TEST_NODE_LIST"] = "bdw-[0254,0384,0565-0568],bdwd-[0004,0009]"
+    exp_out = ['bdw-0254', 'bdw-0384', 'bdw-0565', 'bdw-0566', 'bdw-0567', 'bdw-0568', 'bdwd-0004', 'bdwd-0009']
+    nodelist = EnvResources.get_slurm_nodelist(node_list_env="LIBE_RESOURCES_TEST_NODE_LIST")
+    assert nodelist == exp_out, "Nodelist returned does not match expected"
+
+
 def test_slurm_nodelist_groups_nodash():
     os.environ["LIBE_RESOURCES_TEST_NODE_LIST"] = "nid0[0020-0022,0137-0139,1234]"
     exp_out = ['nid00020', 'nid00021', 'nid00022', 'nid00137', 'nid00138', 'nid00139', 'nid01234']
@@ -209,6 +216,7 @@ if __name__ == "__main__":
     test_slurm_nodelist_knl_seq()
     test_slurm_nodelist_bdw_seq()
     test_slurm_nodelist_groups()
+    test_slurm_nodelist_groups_partitions()
     test_slurm_nodelist_groups_nodash()
     test_slurm_nodelist_groups_longprefix()
     test_slurm_nodelist_reverse_grp()


### PR DESCRIPTION
Adds env_resources capability to produce node-list from multiple partitions.

For example, allocations similar to the format `bdw-[0254,0384,0565-0568],bdwd-[0004,0009]` should now be correctly parsed and split.

Includes test.