### PR TITLE
Document moved utilities

### DIFF
--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -15,6 +15,39 @@ For example::
   from libensemble.utils import check_inputs
   check_inputs(sim_specs=my-sim_specs, gen_specs=my-gen_specs, exit_criteria=ec)
 
+
+Save output to file
+-------------------
+
+The ``save_libE_output()`` function can to dump the contents of the History
+array and ``persis_info`` to NumPy and pickle objects respectively following
+a libEnsemble run. Import with::
+
+    from libensemble.utils import save_libE_output
+
+And write the output of a run to files::
+
+    H, persis_info, _ = libE(sim_specs, gen_specs, exit_criteria, persis_info,
+                             libE_specs)
+
+    if is_master:
+        save_libE_output(H, persis_info, __file__, nworkers)
+
+
+Per-worker random streams
+-------------------------
+
+Since many libEnsemble use-cases require that each worker accesses it's own random
+stream, we provide a simple utility to populate the ``persis_info`` dictionary
+with the necessary objects.
+
+Import and run with::
+
+    from libensemble.utils import add_unique_random_streams
+
+    persis_info = add_unique_random_streams(old_persis_info, nworkers+1)
+
+
 Parameters as command-line arguments
 ------------------------------------
 

--- a/libensemble/utils.py
+++ b/libensemble/utils.py
@@ -342,8 +342,8 @@ def save_libE_output(H, persis_info, calling_file, nworkers):
 
 
 def add_unique_random_streams(persis_info, size):
-    # Creates size random number streams for the libE manager and workers when
-    # size is num_workers + 1. Stream i is initialized with seed i.
+    # Creates ``size`` random number streams for the libE manager and workers
+    # where ``size`` is num_workers + 1. Stream i is initialized with seed i.
     for i in range(size):
         if i in persis_info:
             persis_info[i].update({

--- a/libensemble/utils.py
+++ b/libensemble/utils.py
@@ -331,13 +331,15 @@ def save_libE_output(H, persis_info, calling_file, nworkers):
     Parameters
     ----------
 
-    H: :obj:`numpy structured array`, optional
+    H: :obj:`numpy structured array`
 
         A previous libEnsemble history array
         :doc:`(example)<data_structures/history_array>`
 
-    persis_info: [dict] :
-        Dictionary containing persistent info
+    persis_info: :obj:`dict`
+
+        Persistent information to be passed between user functions
+        :doc:`(example)<data_structures/persis_info>`
 
     calling_file: [path] :
         Filepath to calling script (typically __file__), or base-name for output
@@ -369,12 +371,22 @@ def add_unique_random_streams(persis_info, size):
     Parameters
     ----------
 
-    persis_info: [dict] :
-        Dictionary containing persistent info
+    persis_info: :obj:`dict`
+
+        Persistent information to be passed between user functions
+        :doc:`(example)<data_structures/persis_info>`
 
     size: [int] :
         Number of entries to update with random streams in `persis_info`
 
+
+    Returns
+    -------
+
+    persis_info: :obj:`dict`
+
+        persistent information updated with random streams
+        :doc:`(example)<data_structures/persis_info>`
 
     """
     for i in range(size):

--- a/libensemble/utils.py
+++ b/libensemble/utils.py
@@ -341,10 +341,10 @@ def save_libE_output(H, persis_info, calling_file, nworkers):
         Persistent information to be passed between user functions
         :doc:`(example)<data_structures/persis_info>`
 
-    calling_file: [path] :
+    calling_file: :obj:`path`
         Filepath to calling script (typically __file__), or base-name for output
 
-    nworkers: [int] :
+    nworkers: :obj:`int`
         Number of workers
 
     """
@@ -376,7 +376,7 @@ def add_unique_random_streams(persis_info, size):
         Persistent information to be passed between user functions
         :doc:`(example)<data_structures/persis_info>`
 
-    size: [int] :
+    size: :obj:`int`
         Number of entries to update with random streams in `persis_info`
 
 

--- a/libensemble/utils.py
+++ b/libensemble/utils.py
@@ -326,6 +326,26 @@ def parse_args():
 
 
 def save_libE_output(H, persis_info, calling_file, nworkers):
+    """Save History array contents to NumPy arrays and persis_info to pickle
+
+    Parameters
+    ----------
+
+    H: :obj:`numpy structured array`, optional
+
+        A previous libEnsemble history array
+        :doc:`(example)<data_structures/history_array>`
+
+    persis_info: [dict] :
+        Dictionary containing persistent info
+
+    calling_file: [path] :
+        Filepath to calling script (typically __file__), or base-name for output
+
+    nworkers: [int] :
+        Number of workers
+
+    """
     script_name = os.path.splitext(os.path.basename(calling_file))[0]
     short_name = script_name.split("test_", 1).pop()
     filename = short_name + '_results_History_length=' + str(len(H)) \
@@ -342,8 +362,21 @@ def save_libE_output(H, persis_info, calling_file, nworkers):
 
 
 def add_unique_random_streams(persis_info, size):
-    # Creates ``size`` random number streams for the libE manager and workers
-    # where ``size`` is num_workers + 1. Stream i is initialized with seed i.
+    """
+    Creates ``size`` random number streams for the libE manager and workers
+    where ``size`` is num_workers + 1. Stream i is initialized with seed i.
+
+    Parameters
+    ----------
+
+    persis_info: [dict] :
+        Dictionary containing persistent info
+
+    size: [int] :
+        Number of entries to update with random streams in `persis_info`
+
+
+    """
     for i in range(size):
         if i in persis_info:
             persis_info[i].update({


### PR DESCRIPTION
Adds docs entries for newly moved utilities, also adds descriptive docstrings to each utility just in case.

I copied-and-pasted docstring parts from other functions; if the formatting is off, please let me know.