### PR TITLE
Silly Hotfix - Update coveralls coverage badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@
 .. image:: https://travis-ci.org/Libensemble/libensemble.svg?branch=master
    :target: https://travis-ci.org/Libensemble/libensemble
 
-.. image:: https://coveralls.io/repos/github/Libensemble/libensemble/badge/?maxAge=2592000/?branch=master
+.. image:: https://coveralls.io/repos/github/Libensemble/libensemble/badge.svg?branch=master
    :target: https://coveralls.io/github/Libensemble/libensemble?branch=master
 
 .. image:: https://readthedocs.org/projects/libensemble/badge/?maxAge=2592000

--- a/docs/dev_guide/release_management/release_process.rst
+++ b/docs/dev_guide/release_management/release_process.rst
@@ -61,4 +61,4 @@ After release
 - Ensure all relevant GitHub issues are closed and moved to the *Done* column
   on the kanban project board (inc. the release checklist).
 
-- Email libEnsemble mailing list
+- Email libEnsemble mailing list and notify main Slack channel


### PR DESCRIPTION
Prior version doesn't display new value (94%), possibly due to maxAge parameter.