### PR TITLE
Feature/subsecond time

### DIFF
--- a/libensemble/tests/unit_tests/test_timer.py
+++ b/libensemble/tests/unit_tests/test_timer.py
@@ -48,7 +48,7 @@ def test_timer():
 
     time_end = time.time() - time_start + time_mid
 
-    assert total1>= 1 and total1 <= time_end, \
+    assert total1 >= 1 and total1 <= time_end, \
         "Check cumulative timing (active)."
     assert timer.total >= 1 and timer.total <= time_end, \
         "Check cumulative timing (not active)."

--- a/libensemble/tests/unit_tests/test_timer.py
+++ b/libensemble/tests/unit_tests/test_timer.py
@@ -27,7 +27,8 @@ def test_timer():
     # Use external wall-clock time for upper limit to allow for system overhead
     # (e.g. virtualization, or sharing machine with other tasks)
     # assert (e1 >= 0.5) and (e1 <= 0.6), "Check timed sleep seems correct"
-    assert (e1 >= 0.5) and (e1 < time_mid), "Check timed sleep within boundaries"
+
+    assert (e1/1000 >= 0.5) and (e1/1000 < time_mid), "Check timed sleep within boundaries"
     assert e2 >= e1, "Check timer order."
     assert e2 == e3, "Check elapsed time stable when timer inactive."
 
@@ -48,9 +49,9 @@ def test_timer():
 
     time_end = time.time() - time_start + time_mid
 
-    assert total1 >= 1 and total1 <= time_end, \
+    assert total1/1000 >= 1 and total1/1000 <= time_end, \
         "Check cumulative timing (active)."
-    assert timer.total >= 1 and timer.total <= time_end, \
+    assert timer.total/1000 >= 1 and timer.total/1000 <= time_end, \
         "Check cumulative timing (not active)."
 
 

--- a/libensemble/tests/unit_tests/test_timer.py
+++ b/libensemble/tests/unit_tests/test_timer.py
@@ -27,8 +27,7 @@ def test_timer():
     # Use external wall-clock time for upper limit to allow for system overhead
     # (e.g. virtualization, or sharing machine with other tasks)
     # assert (e1 >= 0.5) and (e1 <= 0.6), "Check timed sleep seems correct"
-
-    assert (e1/1000 >= 0.5) and (e1/1000 < time_mid), "Check timed sleep within boundaries"
+    assert (e1 >= 0.5) and (e1 < time_mid), "Check timed sleep within boundaries"
     assert e2 >= e1, "Check timer order."
     assert e2 == e3, "Check elapsed time stable when timer inactive."
 
@@ -49,9 +48,9 @@ def test_timer():
 
     time_end = time.time() - time_start + time_mid
 
-    assert total1/1000 >= 1 and total1/1000 <= time_end, \
+    assert total1>= 1 and total1 <= time_end, \
         "Check cumulative timing (active)."
-    assert timer.total/1000 >= 1 and timer.total/1000 <= time_end, \
+    assert timer.total >= 1 and timer.total <= time_end, \
         "Check cumulative timing (not active)."
 
 

--- a/libensemble/util/timer.py
+++ b/libensemble/util/timer.py
@@ -44,13 +44,13 @@ class Timer:
     @property
     def date_start(self):
         """Return a string representing the start datetime."""
-        start_time = datetime.date.fromtimestamp(self.tstart / 1000)
+        start_time = datetime.datetime.fromtimestamp(self.tstart / 1000)
         return start_time.strftime("%Y-%m-%d %H:%M:%S") + '.' + str(self.tstart)[-3:]
 
     @property
     def date_end(self):
         """Return a string representing the end datetime."""
-        end_time = datetime.date.fromtimestamp(self.tend / 1000)
+        end_time = datetime.datetime.fromtimestamp(self.tend / 1000)
         return end_time.strftime("%Y-%m-%d %H:%M:%S") + '.' + str(self.tend)[-3:]
 
     @property

--- a/libensemble/util/timer.py
+++ b/libensemble/util/timer.py
@@ -55,24 +55,11 @@ class Timer:
     def elapsed(self):
         """Return time since last start (active) or in most recent interval."""
         etime = self.tend if not self.timing else TimestampMillisec64()
-        return (etime-self.tstart) / 1000
-
-    @property
-    def m_elapsed(self):
-        """Return time in milliseconds since last start (active) or in most recent interval."""
-        etime = self.tend if not self.timing else TimestampMillisec64()
         return etime-self.tstart
 
     @property
     def total(self):
         """Return the total time since last start."""
-        if self.timing:
-            return (self.tcum + self.elapsed) / 1000
-        return self.tcum / 1000
-
-    @property
-    def m_total(self):
-        """Return the total time in milliseconds since last start."""
         if self.timing:
             return self.tcum + self.elapsed
         return self.tcum

--- a/libensemble/util/timer.py
+++ b/libensemble/util/timer.py
@@ -2,7 +2,6 @@
 libensemble utility class -- manages timer
 """
 
-import time
 import datetime
 
 
@@ -45,12 +44,14 @@ class Timer:
     @property
     def date_start(self):
         """Return a string representing the start datetime."""
-        return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(self.tstart / 1000)) + '.' + str(self.tstart)[-3:]
+        start_time = datetime.date.fromtimestamp(self.tstart / 1000)
+        return start_time.strftime("%Y-%m-%d %H:%M:%S") + '.' + str(self.tstart)[-3:]
 
     @property
     def date_end(self):
         """Return a string representing the end datetime."""
-        return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(self.tend / 1000)) + '.' + str(self.tend)[-3:]
+        end_time = datetime.date.fromtimestamp(self.tend / 1000)
+        return end_time.strftime("%Y-%m-%d %H:%M:%S") + '.' + str(self.tend)[-3:]
 
     @property
     def elapsed(self):

--- a/libensemble/util/timer.py
+++ b/libensemble/util/timer.py
@@ -38,7 +38,7 @@ class Timer:
 
     def __str__(self):
         """Return a string representation of the timer."""
-        return ("Time: {0:.2f} Start: {1} End: {2}".
+        return ("Time: {0:.3f} Start: {1} End: {2}".
                 format(self.total, self.date_start, self.date_end))
 
     @property

--- a/libensemble/util/timer.py
+++ b/libensemble/util/timer.py
@@ -5,6 +5,7 @@ libensemble utility class -- manages timer
 import time
 import datetime
 
+
 # https://stackoverflow.com/questions/5998245/get-current-time-in-milliseconds-in-python
 def TimestampMillisec64():
     return int((datetime.datetime.utcnow() - datetime.datetime(1970, 1, 1)).total_seconds() * 1000)

--- a/libensemble/util/timer.py
+++ b/libensemble/util/timer.py
@@ -55,14 +55,14 @@ class Timer:
     def elapsed(self):
         """Return time since last start (active) or in most recent interval."""
         etime = self.tend if not self.timing else TimestampMillisec64()
-        return etime-self.tstart
+        return (etime - self.tstart) / 1000
 
     @property
     def total(self):
         """Return the total time since last start."""
         if self.timing:
-            return self.tcum + self.elapsed
-        return self.tcum
+            return self.tcum / 1000 + self.elapsed  # second term divided above
+        return self.tcum / 1000
 
     def start(self):
         """Start the timer."""

--- a/libensemble/util/timer.py
+++ b/libensemble/util/timer.py
@@ -3,6 +3,11 @@ libensemble utility class -- manages timer
 """
 
 import time
+import datetime
+
+# https://stackoverflow.com/questions/5998245/get-current-time-in-milliseconds-in-python
+def TimestampMillisec64():
+    return int((datetime.datetime.utcnow() - datetime.datetime(1970, 1, 1)).total_seconds() * 1000)
 
 
 class Timer:
@@ -39,34 +44,47 @@ class Timer:
     @property
     def date_start(self):
         """Return a string representing the start datetime."""
-        return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(self.tstart))
+        return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(self.tstart / 1000)) + '.' + str(self.tstart)[-3:]
 
     @property
     def date_end(self):
         """Return a string representing the end datetime."""
-        return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(self.tend))
+        return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(self.tend / 1000)) + '.' + str(self.tend)[-3:]
 
     @property
     def elapsed(self):
         """Return time since last start (active) or in most recent interval."""
-        etime = self.tend if not self.timing else time.time()
+        etime = self.tend if not self.timing else TimestampMillisec64()
+        return (etime-self.tstart) / 1000
+
+    @property
+    def m_elapsed(self):
+        """Return time in milliseconds since last start (active) or in most recent interval."""
+        etime = self.tend if not self.timing else TimestampMillisec64()
         return etime-self.tstart
 
     @property
     def total(self):
         """Return the total time since last start."""
         if self.timing:
+            return (self.tcum + self.elapsed) / 1000
+        return self.tcum / 1000
+
+    @property
+    def m_total(self):
+        """Return the total time in milliseconds since last start."""
+        if self.timing:
             return self.tcum + self.elapsed
         return self.tcum
 
     def start(self):
         """Start the timer."""
-        self.tstart = time.time()
+        self.tstart = TimestampMillisec64()
         self.timing = True
 
     def stop(self):
         """Stop the timer."""
-        self.tend = time.time()
+        self.tend = TimestampMillisec64()
         self.timing = False
         self.tcum += (self.tend-self.tstart)
 


### PR DESCRIPTION
The Timer module now measures in milliseconds behind-the-scenes. ``libE_stats`` displays additional millisecond values for Start and End times:

``Start: 2019-12-11 10:27:50.227 End: 2019-12-11 10:27:50.733``

However, for compatibility with current timing mechanisms ``timer.elapsed``  and ``timer.total`` times are returned as seconds. If necessary, I can implement additional settings or parameters for milliseconds if we want to be more precise throughout the project.
