### PR TITLE
Adding ability for allocation function to issue a stop flag

### DIFF
--- a/docs/sim_gen_alloc_funcs.rst
+++ b/docs/sim_gen_alloc_funcs.rst
@@ -71,7 +71,7 @@ Returns:
   **persis_info**: :obj:`dict`
   :doc:`(example)<data_structures/persis_info>`
 
-  **calc_status**: :obj:`int`, optional.
+  **calc_status**: :obj:`int`, optional
   Provides a job status to the manager and the libE_stats.txt file
   :doc:`(example)<data_structures/calc_status>`
 
@@ -108,7 +108,7 @@ Returns:
   **persis_info**: :obj:`dict`
   :doc:`(example)<data_structures/persis_info>`
 
-  **calc_status**: :obj:`int`, optional.
+  **calc_status**: :obj:`int`, optional
   Provides a job status to the manager and the libE_stats.txt file
   :doc:`(example)<data_structures/calc_status>`
 
@@ -150,3 +150,6 @@ Returns:
 
   **persis_info**: :obj:`dict`
   :doc:`(example)<data_structures/persis_info>`
+
+  **stop_flag**: :obj:`int`, optional
+  Set to 1 if job should stop

--- a/libensemble/alloc_funcs/start_only_persistent.py
+++ b/libensemble/alloc_funcs/start_only_persistent.py
@@ -17,11 +17,15 @@ def only_persistent_gens(W, H, sim_specs, gen_specs, alloc_specs, persis_info):
     Work = {}
     gen_count = count_persis_gens(W)
 
-    # If i is in persistent mode, and any of its calculated values have
+    if len(H) and gen_count == 0:
+        # The one persistent worker is done. Exiting
+        return Work, persis_info, 1
+
+    # If i is in persistent mode, and all of its calculated values have
     # returned, give them back to i. Otherwise, give nothing to i
     for i in avail_worker_ids(W, persistent=True):
         gen_inds = (H['gen_worker'] == i)
-        if np.any(np.logical_and(H['returned'][gen_inds], ~H['given_back'][gen_inds])):
+        if np.all(H['returned'][gen_inds]):
             last_time_gen_gave_batch = np.max(H['gen_time'][gen_inds])
             inds_of_last_batch_from_gen = H['sim_id'][gen_inds][H['gen_time'][gen_inds] == last_time_gen_gave_batch]
             gen_work(Work, i,
@@ -44,4 +48,4 @@ def only_persistent_gens(W, H, sim_specs, gen_specs, alloc_specs, persis_info):
             gen_work(Work, i, gen_specs['in'], [], persis_info[i],
                      persistent=True)
 
-    return Work, persis_info
+    return Work, persis_info, 0

--- a/libensemble/gen_funcs/persistent_fd_param_finder.py
+++ b/libensemble/gen_funcs/persistent_fd_param_finder.py
@@ -1,0 +1,48 @@
+import numpy as np
+
+from libensemble.message_numbers import STOP_TAG, PERSIS_STOP, FINISHED_PERSISTENT_GEN_TAG
+from libensemble.gen_funcs.support import sendrecv_mgr_worker_msg
+
+
+def fd_param_finder(H, persis_info, gen_specs, libE_info):
+    """
+    This generation function loops through a set of suitable finite difference
+    parameters for a mapping F from R^n to R^m.
+
+    .. seealso::
+        `test_persistent_fd_param_finder.py` <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_persistent_fd_param_finder.py>`_
+    """
+    x = gen_specs['user']['x']
+    kmax = gen_specs['user']['kmax']
+    n = len(x)
+
+    comm = libE_info['comm']
+
+    requested_points = np.zeros((kmax*n, n))
+
+    h = 1  # Starting finite difference parameter
+
+    # Send batches until a stop tag is received or we are happy with h
+    O = np.zeros(kmax*n, dtype=gen_specs['out'])
+    tag = None
+    while tag not in [STOP_TAG, PERSIS_STOP]:
+
+        ind = 0
+        for i in range(n):
+            for k in range(10):
+                requested_points[ind] = x + (k+1)*h*np.eye(n)[i]
+                ind += 1
+
+        O['x'] = requested_points
+        tag, Work, calc_in = sendrecv_mgr_worker_msg(comm, O)
+
+        # returned_values = calc_in['f']
+        # print(returned_values)
+
+        if h < 1e-1:
+            tag = FINISHED_PERSISTENT_GEN_TAG
+            break
+        else:
+            h = 0.5*h
+
+    return O, persis_info, tag

--- a/libensemble/sim_funcs/noisy_vector_mapping.py
+++ b/libensemble/sim_funcs/noisy_vector_mapping.py
@@ -1,0 +1,52 @@
+"""
+This module contains a test noisy function
+"""
+
+import numpy as np
+from numpy.linalg import norm
+from numpy import cos, sin
+
+
+def func_wrapper(H, persis_info, sim_specs, libE_info):
+    """
+    Wraps an objective function
+
+    .. seealso::
+        `test_persistent_fd_param_finder.py` <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_persistent_fd_param_finder.py>`_
+    """
+
+    batch = len(H['x'])
+    O = np.zeros(batch, dtype=sim_specs['out'])
+
+    for i, x in enumerate(H['x']):
+
+        O['f'][i] = noisy_function(x)
+
+    return O, persis_info
+
+
+def noisy_function(x):
+    """
+    """
+
+    x1 = x[0]
+    x2 = x[1]
+    term1 = (4-2.1*x1**2+(x1**4)/3) * x1**2
+    term2 = x1*x2
+    term3 = (-4+4*x2**2) * x2**2
+
+    phi1 = 0.9*sin(100*norm(x, 1))*cos(100*norm(x, np.inf)) + 0.1*cos(norm(x, 2))
+    phi1 = phi1*(4*phi1**2 - 3)
+
+    phi2 = 0.8*sin(100*norm(x, 1))*cos(100*norm(x, np.inf)) + 0.2*cos(norm(x, 2))
+    phi2 = phi2*(4*phi2**2 - 3)
+
+    phi3 = 0.7*sin(100*norm(x, 1))*cos(100*norm(x, np.inf)) + 0.3*cos(norm(x, 2))
+    phi3 = phi3*(4*phi3**2 - 3)
+
+    F = np.zeros(3)
+    F[0] = (1 + 1e-1*phi1)*term1
+    F[1] = (1 + 1e-2*phi2)*term2
+    F[2] = (1 + 1e-3*phi3)*term3
+
+    return F

--- a/libensemble/tests/regression_tests/test_persistent_fd_param_finder.py
+++ b/libensemble/tests/regression_tests/test_persistent_fd_param_finder.py
@@ -1,0 +1,55 @@
+# """
+# Runs libEnsemble with the persistent generator that finds an appropriate
+# finite-difference parameter for the sim_f mapping from R^n to R^m around the
+# point x.
+#
+# Execute via one of the following commands (e.g. 3 workers):
+#    mpiexec -np 4 python3 test_persistent_fd_param_finder.py
+# """
+
+# Do not change these lines - they are parsed by run-tests.sh
+# TESTSUITE_COMMS: mpi
+# TESTSUITE_NPROCS: 4
+
+import sys
+import numpy as np
+
+# Import libEnsemble items for this test
+from libensemble.libE import libE
+from libensemble.sim_funcs.noisy_vector_mapping import func_wrapper as sim_f
+from libensemble.gen_funcs.persistent_fd_param_finder import fd_param_finder as gen_f
+from libensemble.alloc_funcs.start_only_persistent import only_persistent_gens as alloc_f
+from libensemble.utils import parse_args, save_libE_output, add_unique_random_streams
+
+nworkers, is_master, libE_specs, _ = parse_args()
+
+if nworkers < 2:
+    sys.exit("Cannot run with a persistent worker if only one worker -- aborting...")
+
+n = 2
+m = 3
+sim_specs = {'sim_f': sim_f,
+             'in': ['x'],
+             'out': [('f', float, m)]}
+
+gen_specs = {'gen_f': gen_f,
+             'in': [],
+             'out': [('x', float, (n,))],
+             'user': {'x': np.array([1.23, -0.12]),
+                      'kmax': 10}
+             }
+
+alloc_specs = {'alloc_f': alloc_f, 'out': [('given_back', bool)]}
+
+persis_info = add_unique_random_streams({}, nworkers + 1)
+
+exit_criteria = {'gen_max': 400}
+
+# Perform the run
+H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
+                            alloc_specs, libE_specs)
+
+if is_master:
+    assert len(H) < exit_criteria['gen_max'], "Problem didn't stop early, which should have been the case."
+
+    save_libE_output(H, persis_info, __file__, nworkers)


### PR DESCRIPTION
I'm not sure if this is too "hacky" or appropriate. 

The manager now stops via a mechanism that is different than a `term_test`, and I didn't see a reasonable way to add this to the existing termination mechanism. 

(I could make it a term_test, but then the calling script must have `'alloc_f_stop_flag'` (or whatever) as an `exit_criteria` entry.)