### PR TITLE
Feature/improving saves

### DIFF
--- a/libensemble/libE_manager.py
+++ b/libensemble/libE_manager.py
@@ -118,7 +118,7 @@ class Manager:
         """Initializes the manager"""
         timer = Timer()
         timer.start()
-        self.date_start = timer.date_start.replace(' ','_')
+        self.date_start = timer.date_start.replace(' ', '_')
         self.hist = hist
         self.libE_specs = libE_specs
         self.alloc_specs = alloc_specs
@@ -178,9 +178,9 @@ class Manager:
     def _save_every_k(self, fname, count, k):
         "Saves history every kth step"
         count = k*(count//k)
-        filename = fname.format(self.date_start,count)
+        filename = fname.format(self.date_start, count)
         if not os.path.isfile(filename) and count > 0:
-            for old_file in glob.glob(fname.format(self.date_start,'*')):
+            for old_file in glob.glob(fname.format(self.date_start, '*')):
                 os.remove(old_file)
             np.save(filename, self.hist.H)
 

--- a/libensemble/libE_manager.py
+++ b/libensemble/libE_manager.py
@@ -5,6 +5,7 @@ libEnsemble manager routines
 
 import sys
 import os
+import glob
 import logging
 import socket
 import numpy as np
@@ -179,6 +180,8 @@ class Manager:
         count = k*(count//k)
         filename = fname.format(self.date_start,count)
         if not os.path.isfile(filename) and count > 0:
+            for old_file in glob.glob(fname.format(self.date_start,'*')):
+                os.remove(old_file)
             np.save(filename, self.hist.H)
 
     def _save_every_k_sims(self):

--- a/libensemble/libE_manager.py
+++ b/libensemble/libE_manager.py
@@ -117,6 +117,7 @@ class Manager:
         """Initializes the manager"""
         timer = Timer()
         timer.start()
+        self.date_start = timer.date_start.replace(' ','_')
         self.hist = hist
         self.libE_specs = libE_specs
         self.alloc_specs = alloc_specs
@@ -176,19 +177,19 @@ class Manager:
     def _save_every_k(self, fname, count, k):
         "Saves history every kth step"
         count = k*(count//k)
-        filename = fname.format(count)
+        filename = fname.format(self.date_start,count)
         if not os.path.isfile(filename) and count > 0:
             np.save(filename, self.hist.H)
 
     def _save_every_k_sims(self):
         "Saves history every kth sim step"
-        self._save_every_k('libE_history_after_sim_{}.npy',
+        self._save_every_k('libE_history_for_run_starting_{}_after_sim_{}.npy',
                            self.hist.sim_count,
                            self.libE_specs['save_every_k_sims'])
 
     def _save_every_k_gens(self):
         "Saves history every kth gen step"
-        self._save_every_k('libE_history_after_gen_{}.npy',
+        self._save_every_k('libE_history_for_run_starting_{}_after_gen_{}.npy',
                            self.hist.index,
                            self.libE_specs['save_every_k_gens'])
 

--- a/libensemble/tests/unit_tests/test_launcher.py
+++ b/libensemble/tests/unit_tests/test_launcher.py
@@ -54,7 +54,7 @@ def xtest_launch():
 
     # Launch finite loop, wait for termination
     process = launcher.launch([py_exe, "launch_busy.py", "0", "0.1"])
-    assert launcher.process_is_stopped(process, 0.5), "Process should have stopped earlier."
+    assert launcher.process_is_stopped(process, 1.5), "Process should have stopped earlier."
 
     # Try simple kill
     process = launcher.launch([py_exe, "launch_busy.py", "1"])


### PR DESCRIPTION
There is no reason to keep previous checkpointing files. 

Any later history will already contain anything saved in an earlier history.

This also prevents libE from filling up a disk when, for example, running with `libE_specs['save_every_k_sims'] = 1` and `sim_max` is large. 