### PR TITLE
move default alloc_specs from libE() definition to alloc_funcs.defaults

### DIFF
--- a/docs/data_structures/alloc_specs.rst
+++ b/docs/data_structures/alloc_specs.rst
@@ -18,9 +18,19 @@ to main ``libE()`` routine::
             Default: {'batch_mode': True}
 
 .. note::
-
-  * The alloc_specs has the default keys as given above but may be overidden by the user.
   * The tuples defined in the 'out' list are entered into the master :ref:`history array<datastruct-history-array>`.
+  * libEnsemble uses the following defaults if the user doesn't provide their own ``alloc_specs``:
+
+  ..  literalinclude:: ../../libensemble/alloc_funcs/defaults.py
+      :end-before: end_alloc_specs_rst_tag
+      :caption: /libensemble/alloc_funcs/defaults.py
+
+  * Users can import and adjust these defaults using:
+
+  ..  code-block:: python
+
+      from libensemble.alloc_funcs import defaults
+      alloc_specs = defaults.alloc_specs
 
 .. seealso::
   - `test_chwirut_uniform_sampling_one_residual_at_a_time.py`_ specifies fields

--- a/libensemble/alloc_funcs/defaults.py
+++ b/libensemble/alloc_funcs/defaults.py
@@ -1,0 +1,5 @@
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
+
+alloc_specs = {'alloc_f': give_sim_work_first,
+               'out': [('allocated', bool)],
+               'user': {'batch_mode': True, 'num_active_gens': 1}}

--- a/libensemble/alloc_funcs/defaults.py
+++ b/libensemble/alloc_funcs/defaults.py
@@ -3,3 +3,4 @@ from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 alloc_specs = {'alloc_f': give_sim_work_first,
                'out': [('allocated', bool)],
                'user': {'batch_mode': True, 'num_active_gens': 1}}
+# end_alloc_specs_rst_tag

--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -27,7 +27,7 @@ from libensemble.util.timer import Timer
 from libensemble.history import History
 from libensemble.libE_manager import manager_main, ManagerException
 from libensemble.libE_worker import worker_main
-from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
+from libensemble.alloc_funcs import defaults
 from libensemble.comms.comms import QCommProcess, Timeout
 from libensemble.comms.logs import manager_logging_config
 from libensemble.comms.tcp_mgr import ServerQCommManager, ClientQCommManager
@@ -41,9 +41,7 @@ logger = logging.getLogger(__name__)
 
 def libE(sim_specs, gen_specs, exit_criteria,
          persis_info={},
-         alloc_specs={'alloc_f': give_sim_work_first,
-                      'out': [('allocated', bool)],
-                      'user': {'batch_mode': True, 'num_active_gens': 1}},
+         alloc_specs=None,
          libE_specs={},
          H0=[]):
     """
@@ -110,6 +108,10 @@ def libE(sim_specs, gen_specs, exit_criteria,
             2 = Manager timed out and ended simulation
             3 = Current process is not in libEnsemble MPI communicator
     """
+
+    # Set default alloc_specs
+    if not alloc_specs:
+        alloc_specs = defaults.alloc_specs
 
     # Set default comms
     if 'comms' not in libE_specs:


### PR DESCRIPTION
Possibly addresses #325 

This simple approach tries to address the concerns laid out in the above issue where the default `alloc_specs` were defined in the `libE` function definition.

This moves the default `alloc_specs` to `/alloc_funcs`. They are imported in `libE.py`, and can be imported and adjusted within calling scripts through:

`from libensemble.alloc_funcs import defaults`
`alloc_specs = defaults.alloc_specs`

Potentially, other default settings throughout typical libE projects can be imported and adjusted in this manner. Or, the default `alloc_specs` could be returned by `parse_args()`.