### PR TITLE
Docs/excessive memory

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
-conda:
-    environment: install/environment.yml
+# conda:
+#     environment: install/environment.yml
 
 sphinx:
     configuration: docs/conf.py
@@ -13,8 +13,11 @@ formats:
   - pdf
 
 python:
+    version: 3.7
     install:
+      - requirements: docs/requirements.txt
       - method: pip
         path: .
         extra_requirements:
          - docs
+    system_packages: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,4 +20,4 @@ python:
         path: .
         extra_requirements:
          - docs
-    system_packages: true
+    system_packages: false

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx>=2.4.1
+sphinx==2.4.1
 sphinxcontrib-bibtex

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
+sphinx>=2.4.1
 sphinxcontrib-bibtex


### PR DESCRIPTION
Addresses #354 

`virtualenv` and `pip` are now used to build the docs instead of `conda`.

I built the docs several times with these new settings and didn't receive any memory (or other) issues:

https://readthedocs.org/projects/libensemble/builds/

Is there anything I missed that this breaks?
