### PR TITLE
Feature/mpi closeout

### DIFF
--- a/libensemble/comms/logs.py
+++ b/libensemble/comms/logs.py
@@ -92,15 +92,21 @@ class ErrorFilter(logging.Filter):
 def worker_logging_config(comm, worker_id=None):
     """Add a comm handler with worker ID filter to the indicated logger.
     """
+
     logconfig = LogConfig.config
-    if not logconfig.logger_set:
-        ch = CommLogHandler(comm, pack=lambda rec: (0, rec))
-        ch.addFilter(WorkerIDFilter(worker_id or comm.rank))
-        logger = logging.getLogger(logconfig.name)
+    logger = logging.getLogger(logconfig.name)
+    ch = CommLogHandler(comm, pack=lambda rec: (0, rec))
+    ch.addFilter(WorkerIDFilter(worker_id or comm.rank))
+
+    if logconfig.logger_set:
+        for hdl in logger.handlers[:]:
+            logger.removeHandler(hdl)
+    else:
         logger.propagate = False
         logger.setLevel(logconfig.log_level)
-        logger.addHandler(ch)
         logconfig.logger_set = True
+
+    logger.addHandler(ch)
 
 
 def manager_logging_config():

--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -200,11 +200,11 @@ def libE_mpi(sim_specs, gen_specs, exit_criteria,
     "MPI version of the libE main routine"
 
     libE_specs, mpi_comm_null = libE_mpi_defaults(libE_specs)
-    comm = libE_specs['comm'].Dup()
 
-    if comm == mpi_comm_null:
+    if libE_specs['comm'] == mpi_comm_null:
         return [], persis_info, 3  # Process not in comm
 
+    comm = libE_specs['comm'].Dup()
     rank = comm.Get_rank()
     is_master = (rank == 0)
     check_inputs(libE_specs, alloc_specs, sim_specs, gen_specs, exit_criteria, H0)

--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -190,7 +190,7 @@ def libE_mpi_defaults(libE_specs):
     from mpi4py import MPI
 
     if 'comm' not in libE_specs:
-        libE_specs['comm'] = MPI.COMM_WORLD
+        libE_specs['comm'] = MPI.COMM_WORLD  # Will be duplicated immediately
 
     return libE_specs, MPI.COMM_NULL
 

--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -223,7 +223,7 @@ def libE_mpi(sim_specs, gen_specs, exit_criteria,
                                                      libE_specs, H0)
     else:
         # Worker returns a subset of MPI output
-        libE_mpi_worker(sim_specs, gen_specs, libE_specs)
+        libE_mpi_worker(comm, sim_specs, gen_specs, libE_specs)
         H = []
         exit_flag = []
 

--- a/libensemble/tests/unit_tests/test_libE_main.py
+++ b/libensemble/tests/unit_tests/test_libE_main.py
@@ -32,6 +32,9 @@ class Fake_MPI:
     def Barrier(self):
         return 0
 
+    def Dup(self):
+        return self
+
     def isend(self, msg, dest, tag):
         raise MPISendException()
 


### PR DESCRIPTION
This implements MPI communicator duplication as discussed in #387.

This should ensure a clean exit. We can follow up later on whether we should have a better close-down algorithm.