### PR TITLE
Debugging/persis aposmm comms test

### DIFF
--- a/libensemble/tests/regression_tests/test_persistent_aposmm_dfols.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_dfols.py
@@ -10,7 +10,7 @@
 # """
 
 # Do not change these lines - they are parsed by run-tests.sh
-# TESTSUITE_COMMS: local mpi
+# TESTSUITE_COMMS: local mpi tcp
 # TESTSUITE_NPROCS: 4
 
 import sys

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_dfols.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_dfols.py
@@ -10,7 +10,7 @@
 # """
 
 # Do not change these lines - they are parsed by run-tests.sh
-# TESTSUITE_COMMS: local
+# TESTSUITE_COMMS: local mpi
 # TESTSUITE_NPROCS: 4
 
 import sys

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_external_localopt.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_external_localopt.py
@@ -17,7 +17,7 @@
 # """
 
 # Do not change these lines - they are parsed by run-tests.sh
-# TESTSUITE_COMMS: local mpi
+# TESTSUITE_COMMS: mpi
 # TESTSUITE_NPROCS: 4
 
 import sys

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_external_localopt.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_external_localopt.py
@@ -17,7 +17,7 @@
 # """
 
 # Do not change these lines - they are parsed by run-tests.sh
-# TESTSUITE_COMMS: mpi
+# TESTSUITE_COMMS: local mpi tcp
 # TESTSUITE_NPROCS: 4
 
 import sys
@@ -36,9 +36,6 @@ from time import time
 np.set_printoptions(precision=16)
 
 nworkers, is_master, libE_specs, _ = parse_args()
-
-if libE_specs['comms'] != 'mpi':
-    sys.exit("We recommend using 'mpi' communication when using persistent_aposmm with an external localopt.")
 
 if is_master:
     start_time = time()

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_external_localopt.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_external_localopt.py
@@ -17,7 +17,7 @@
 # """
 
 # Do not change these lines - they are parsed by run-tests.sh
-# TESTSUITE_COMMS: mpi
+# TESTSUITE_COMMS: local mpi
 # TESTSUITE_NPROCS: 4
 
 import sys

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_external_localopt.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_external_localopt.py
@@ -17,7 +17,7 @@
 # """
 
 # Do not change these lines - they are parsed by run-tests.sh
-# TESTSUITE_COMMS: mpi tcp
+# TESTSUITE_COMMS: mpi
 # TESTSUITE_NPROCS: 4
 
 import sys

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_external_localopt.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_external_localopt.py
@@ -17,7 +17,7 @@
 # """
 
 # Do not change these lines - they are parsed by run-tests.sh
-# TESTSUITE_COMMS: mpi
+# TESTSUITE_COMMS: mpi tcp
 # TESTSUITE_NPROCS: 4
 
 import sys

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_nlopt.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_nlopt.py
@@ -11,7 +11,7 @@
 # """
 
 # Do not change these lines - they are parsed by run-tests.sh
-# TESTSUITE_COMMS: local mpi
+# TESTSUITE_COMMS: local mpi tcp
 # TESTSUITE_NPROCS: 3
 
 import sys

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_nlopt.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_nlopt.py
@@ -11,7 +11,7 @@
 # """
 
 # Do not change these lines - they are parsed by run-tests.sh
-# TESTSUITE_COMMS: local
+# TESTSUITE_COMMS: local mpi
 # TESTSUITE_NPROCS: 3
 
 import sys

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_periodic.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_periodic.py
@@ -11,7 +11,7 @@
 # """
 
 # Do not change these lines - they are parsed by run-tests.sh
-# TESTSUITE_COMMS: local mpi tcp
+# TESTSUITE_COMMS: local mpi
 # TESTSUITE_NPROCS: 4
 
 import sys

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_periodic.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_periodic.py
@@ -11,7 +11,7 @@
 # """
 
 # Do not change these lines - they are parsed by run-tests.sh
-# TESTSUITE_COMMS: local mpi
+# TESTSUITE_COMMS: local mpi tcp
 # TESTSUITE_NPROCS: 4
 
 import sys

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_pounders.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_pounders.py
@@ -10,7 +10,7 @@
 # """
 
 # Do not change these lines - they are parsed by run-tests.sh
-# TESTSUITE_COMMS: local mpi
+# TESTSUITE_COMMS: local mpi tcp
 # TESTSUITE_NPROCS: 4
 
 import sys

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_pounders.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_pounders.py
@@ -10,7 +10,7 @@
 # """
 
 # Do not change these lines - they are parsed by run-tests.sh
-# TESTSUITE_COMMS: local
+# TESTSUITE_COMMS: local mpi
 # TESTSUITE_NPROCS: 4
 
 import sys

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_scipy.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_scipy.py
@@ -11,7 +11,7 @@
 # """
 
 # Do not change these lines - they are parsed by run-tests.sh
-# TESTSUITE_COMMS: local
+# TESTSUITE_COMMS: local mpi
 # TESTSUITE_NPROCS: 4
 
 import sys

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_scipy.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_scipy.py
@@ -11,7 +11,7 @@
 # """
 
 # Do not change these lines - they are parsed by run-tests.sh
-# TESTSUITE_COMMS: local mpi
+# TESTSUITE_COMMS: local mpi tcp
 # TESTSUITE_NPROCS: 4
 
 import sys

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_tao.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_tao.py
@@ -11,7 +11,7 @@
 # """
 
 # Do not change these lines - they are parsed by run-tests.sh
-# TESTSUITE_COMMS: local
+# TESTSUITE_COMMS: local mpi
 # TESTSUITE_NPROCS: 4
 
 import sys

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_tao.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_tao.py
@@ -11,7 +11,7 @@
 # """
 
 # Do not change these lines - they are parsed by run-tests.sh
-# TESTSUITE_COMMS: local mpi
+# TESTSUITE_COMMS: local mpi tcp
 # TESTSUITE_NPROCS: 4
 
 import sys

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_with_grad.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_with_grad.py
@@ -11,7 +11,7 @@
 # """
 
 # Do not change these lines - they are parsed by run-tests.sh
-# TESTSUITE_COMMS: local
+# TESTSUITE_COMMS: local mpi
 # TESTSUITE_NPROCS: 4
 
 import sys

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_with_grad.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_with_grad.py
@@ -11,7 +11,7 @@
 # """
 
 # Do not change these lines - they are parsed by run-tests.sh
-# TESTSUITE_COMMS: local mpi
+# TESTSUITE_COMMS: local mpi tcp
 # TESTSUITE_NPROCS: 4
 
 import sys


### PR DESCRIPTION
Increasing the comms testing of persistent aposmm. `local` comms doesn't work with the external localopt regression test, perhaps something in the `subprocess` call.