### PR TITLE
Testing/skipping os in run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,11 @@ jobs:
       language: generic
       python: 3.7
 
-addons:
-    homebrew:
-        packages:
-        - octave
-        update: true
+# addons:
+#     homebrew:
+#         packages:
+#         - octave
+#         update: true
 
 services:
     - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,11 @@ jobs:
       language: generic
       python: 3.7
 
-# addons:
-#     homebrew:
-#         packages:
-#         - octave
-#         update: true
+addons:
+    homebrew:
+        packages:
+        - octave
+        update: true
 
 services:
     - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ jobs:
 
 addons:
     homebrew:
+        packages:
+        - octave
         update: true
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ jobs:
 
 addons:
     homebrew:
-        packages:
-        - octave
         update: true
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,6 @@ jobs:
       language: generic
       python: 3.7
 
-addons:
-    homebrew:
-        packages:
-        - octave
-        update: true
-
 services:
     - postgresql
 

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_external_localopt.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_external_localopt.py
@@ -19,6 +19,7 @@
 # Do not change these lines - they are parsed by run-tests.sh
 # TESTSUITE_COMMS: mpi
 # TESTSUITE_NPROCS: 4
+# TESTSUITE_OS_SKIP: OSX
 
 import sys
 import numpy as np

--- a/libensemble/tests/regression_tests/test_persistent_fd_param_finder.py
+++ b/libensemble/tests/regression_tests/test_persistent_fd_param_finder.py
@@ -10,6 +10,7 @@
 # Do not change these lines - they are parsed by run-tests.sh
 # TESTSUITE_COMMS: mpi
 # TESTSUITE_NPROCS: 4
+# TESTSUITE_OS_SKIP: OSX
 
 import sys
 import numpy as np

--- a/libensemble/tests/run-tests.sh
+++ b/libensemble/tests/run-tests.sh
@@ -416,16 +416,23 @@ if [ "$root_found" = true ]; then
       COMMS_LIST=$(sed -n '/# TESTSUITE_COMMS/s/# TESTSUITE_COMMS: //p' $TEST_SCRIPT)
       for LAUNCHER in $COMMS_LIST
       do
-        if [ "$RUN_ONLY_MPI" = true ] && [ "$LAUNCHER" != mpi ]; then
-          echo "Skipping non MPI testnumber 5"
-          continue
-        fi
         #Need proc count here for now - still stop on failure etc.
         NPROCS_LIST=$(sed -n '/# TESTSUITE_NPROCS/s/# TESTSUITE_NPROCS: //p' $TEST_SCRIPT)
+        OS_SKIP_LIST=$(sed -n '/# TESTSUITE_OS_SKIP/s/# TESTSUITE_OS_SKIP: //p' $TEST_SCRIPT)
         for NPROCS in $NPROCS_LIST
         do
           test_num=$((test_num+1))
           NWORKERS=$((NPROCS-1))
+
+          if [ "$RUN_ONLY_MPI" = true ] && [ "$LAUNCHER" != mpi ]; then
+            echo "Skipping non-mpi test number: " $test_num
+            continue
+          fi
+
+          if [ "$OSTYPE" == *"darwin"* ] && [ "$OS_SKIP_LIST" = "OSX" ]; then
+            echo "Skipping test number for OSX: " $test_num
+            continue
+          fi
 
           RUN_TEST=true
           if [ $REG_STOP_ON_FAILURE = "true" ]; then

--- a/libensemble/tests/run-tests.sh
+++ b/libensemble/tests/run-tests.sh
@@ -429,7 +429,7 @@ if [ "$root_found" = true ]; then
             continue
           fi
 
-          if [ "$OSTYPE" == *"darwin"* ] && [ "$OS_SKIP_LIST" = "OSX" ]; then
+          if [[ "$OSTYPE" = *"darwin"* ]] && [[ "$OS_SKIP_LIST" = "OSX" ]]; then
             echo "Skipping test number for OSX: " $test_num
             continue
           fi


### PR DESCRIPTION
Proposing a `TESTSUITE_OS_SKIP` field that will allow us to skip certain tests on certain operating systems. Currently planning on using this to skip one test which requires building `octave` on Travis. 