### PR TITLE
Add missing import libensemble.utils in local sine tutorial

### DIFF
--- a/docs/tutorials/local_sine_tutorial.rst
+++ b/docs/tutorials/local_sine_tutorial.rst
@@ -175,6 +175,7 @@ multiprocessing.
     from libensemble.libE import libE
     from generator import gen_random_sample
     from simulator import sim_find_sine
+    from libensemble.utils import add_unique_random_streams
 
     nworkers = 4
     libE_specs = {'nworkers': nworkers, 'comms': 'local'}
@@ -324,6 +325,7 @@ of the calling script as follows:
     from libensemble.libE import libE
     from generator import gen_random_sample
     from simulator import sim_find_sine
+    from libensemble.utils import add_unique_random_streams
     from mpi4py import MPI
 
     # nworkers = 4                                # nworkers will come from MPI

--- a/docs/tutorials/local_sine_tutorial.rst
+++ b/docs/tutorials/local_sine_tutorial.rst
@@ -175,7 +175,7 @@ multiprocessing.
     from libensemble.libE import libE
     from generator import gen_random_sample
     from simulator import sim_find_sine
-    from libensemble.utils import add_unique_random_streams
+    from libensemble.tools import add_unique_random_streams
 
     nworkers = 4
     libE_specs = {'nworkers': nworkers, 'comms': 'local'}
@@ -325,7 +325,7 @@ of the calling script as follows:
     from libensemble.libE import libE
     from generator import gen_random_sample
     from simulator import sim_find_sine
-    from libensemble.utils import add_unique_random_streams
+    from libensemble.tools import add_unique_random_streams
     from mpi4py import MPI
 
     # nworkers = 4                                # nworkers will come from MPI


### PR DESCRIPTION
The Simple Local Sine Tutorial is great and very smooth! In file `calling_script.py` though, `add_unique_random_streams` is used without explicit import of the required module. This PR fixes this.