### PR TITLE
fix typo in MPIExecutor __init__ arguments description

### DIFF
--- a/libensemble/executors/mpi_executor.py
+++ b/libensemble/executors/mpi_executor.py
@@ -55,7 +55,7 @@ class MPIExecutor(Executor):
             detected by auto_resources. Larger node counts are not allowed.
             When auto_resources is off, this argument is ignored.
 
-        central_mode, boolean, optional
+        central_mode: boolean, optional
             If true, then running in central mode, otherwise in distributed
             mode. Central mode means libE processes (manager and workers) are
             grouped together and do not share nodes with applications.


### PR DESCRIPTION
The description of `central_mode` argument at https://libensemble.readthedocs.io/en/develop/executor/mpi_executor.html looks weird because of a typo. This PR proposes a fix.