### PR TITLE
Experimental/aposmm rc

### DIFF
--- a/libensemble/gen_funcs/__init__.py
+++ b/libensemble/gen_funcs/__init__.py
@@ -1,0 +1,19 @@
+def rc(**kargs):
+    """Runtime configuration options.
+
+    Parameters
+    ----------
+    aposmm_optimizer : string
+        Set the aposmm optimizer (to prevent all options being imported).
+
+
+    """
+    for key in kargs:
+        if not hasattr(rc, key):
+            raise TypeError("unexpected argument '{0}'".format(key))
+    for key, value in kargs.items():
+        setattr(rc, key, value)
+
+
+rc.aposmm_optimizer = True
+__import__('sys').modules[__name__ + '.rc'] = rc

--- a/libensemble/gen_funcs/persistent_aposmm.py
+++ b/libensemble/gen_funcs/persistent_aposmm.py
@@ -12,14 +12,24 @@ __all__ = ['initialize_APOSMM', 'decide_where_to_start_localopt', 'update_histor
 import numpy as np
 from scipy.spatial.distance import cdist
 from scipy import optimize as sp_opt
-from petsc4py import PETSc
-
-from mpi4py import MPI
-
 from math import log, gamma, pi, sqrt
 
-import nlopt
-import dfols
+import libensemble.gen_funcs
+optimizer = libensemble.gen_funcs.rc.aposmm_optimizer
+if optimizer == 'petsc':
+    from petsc4py import PETSc
+elif optimizer == 'nlopt':
+    import nlopt
+elif optimizer == 'dfols':
+    import dfols
+else:
+    if optimizer is not None:
+        print('APOSMM Warning: {} optimizer not recognized. Loading all')
+    from mpi4py import MPI
+    from petsc4py import PETSc
+    import nlopt
+    import dfols
+
 
 from libensemble.message_numbers import STOP_TAG, PERSIS_STOP
 from libensemble.tools.gen_support import send_mgr_worker_msg

--- a/libensemble/gen_funcs/persistent_aposmm.py
+++ b/libensemble/gen_funcs/persistent_aposmm.py
@@ -22,6 +22,8 @@ elif optimizer == 'nlopt':
     import nlopt
 elif optimizer == 'dfols':
     import dfols
+elif optimizer in ['scipy', 'external']:
+    pass
 else:
     if optimizer is not None:
         print('APOSMM Warning: {} optimizer not recognized. Loading all')

--- a/libensemble/tests/scaling_tests/warpx/run_libE_on_warpX_aposmm.py
+++ b/libensemble/tests/scaling_tests/warpx/run_libE_on_warpX_aposmm.py
@@ -13,7 +13,11 @@ from warpX_simf import run_warpX  # Sim func from current dir
 
 # Import libEnsemble modules
 from libensemble.libE import libE
+
+import libensemble.gen_funcs
+libensemble.gen_funcs.rc.aposmm_optimizer = 'nlopt'
 from libensemble.gen_funcs.persistent_aposmm import aposmm as gen_f
+
 from libensemble.alloc_funcs.persistent_aposmm_alloc import persistent_aposmm_alloc as alloc_f
 from libensemble.tools import parse_args, save_libE_output, add_unique_random_streams
 from libensemble import libE_logger


### PR DESCRIPTION
A provisional method to prevent unnecessary imports in persistent_aposmm. By specifying the optimizer as a configuration option, other optimizers do not need to be imported. This also means mpi4py is not imported in APOSMM unless it is being used.

It would be interesting to see if this helps if there are issues with OpenMPI.