### PR TITLE
Fix links and references in "see more" sections throughout docs

### DIFF
--- a/docs/data_structures/alloc_specs.rst
+++ b/docs/data_structures/alloc_specs.rst
@@ -33,7 +33,7 @@ to main ``libE()`` routine::
       alloc_specs = defaults.alloc_specs
 
 .. seealso::
-  - `test_chwirut_uniform_sampling_one_residual_at_a_time.py`_ specifies fields
+  - `test_uniform_sampling_one_residual_at_a_time.py`_ specifies fields
     to be used by the allocation function ``give_sim_work_first`` from
     fast_alloc_and_pausing.py_.
 
@@ -41,5 +41,5 @@ to main ``libE()`` routine::
       :start-at: alloc_specs
       :end-before: end_alloc_specs_rst_tag
 
-.. _test_chwirut_uniform_sampling_one_residual_at_a_time.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_chwirut_uniform_sampling_one_residual_at_a_time.py
+.. _test_chwirut_uniform_sampling_one_residual_at_a_time.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_uniform_sampling_one_residual_at_a_time.py
 .. _fast_alloc_and_pausing.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/alloc_funcs/fast_alloc_and_pausing.py

--- a/docs/data_structures/alloc_specs.rst
+++ b/docs/data_structures/alloc_specs.rst
@@ -41,5 +41,5 @@ to main ``libE()`` routine::
       :start-at: alloc_specs
       :end-before: end_alloc_specs_rst_tag
 
-.. _test_chwirut_uniform_sampling_one_residual_at_a_time.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_uniform_sampling_one_residual_at_a_time.py
+.. _test_uniform_sampling_one_residual_at_a_time.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_uniform_sampling_one_residual_at_a_time.py
 .. _fast_alloc_and_pausing.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/alloc_funcs/fast_alloc_and_pausing.py

--- a/docs/data_structures/exit_criteria.rst
+++ b/docs/data_structures/exit_criteria.rst
@@ -19,10 +19,10 @@ Exit criteria for libEnsemble::
             Stop when H[str] < float for the given (str, float pair)
 
 .. seealso::
-  From `test_branin_aposmm_nlopt_and_then_scipy.py`_.
+  From `test_sim_dirs.py`_.
 
   ..  literalinclude:: ../../libensemble/tests/regression_tests/test_sim_dirs.py
       :start-at: exit_criteria
       :end-before: end_exit_criteria_rst_tag
 
-.. _test_branin_aposmm_nlopt_and_then_scipy.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_branin_aposmm_nlopt_and_then_scipy.py
+.. _test_sim_dirs.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_sim_dirs.py

--- a/docs/data_structures/gen_specs.rst
+++ b/docs/data_structures/gen_specs.rst
@@ -31,7 +31,7 @@ to main ``libE()`` routine::
 
   .. _gen-specs-exmple1:
 
-  - test_6-hump_camel_uniform_sampling.py_ In this example, the
+  - test_uniform_sampling.py_ In this example, the
     generation function ``uniform_random_sample`` in sampling.py_ will generate 500 random
     points uniformly over the 2D domain defined by ``gen_specs['ub']`` and
     ``gen_specs['lb']``.
@@ -41,4 +41,4 @@ to main ``libE()`` routine::
       :end-before: end_gen_specs_rst_tag
 
 .. _sampling.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/gen_funcs/sampling.py
-.. _test_6-hump_camel_uniform_sampling.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_6-hump_camel_uniform_sampling.py
+.. _test_uniform_sampling.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_uniform_sampling.py

--- a/docs/data_structures/sim_specs.rst
+++ b/docs/data_structures/sim_specs.rst
@@ -26,7 +26,7 @@ Used to specify the simulation function, its inputs and outputs, and user data::
 
   .. _sim-specs-exmple1:
 
-  - test_6-hump_camel_uniform_sampling.py_ has a ``sim_specs``  that declares
+  - test_uniform_sampling.py_ has a ``sim_specs``  that declares
     the name of the ``'in'`` field variable, ``'x'`` (as specified by the
     corresponding generator ``'out'`` field ``'x'`` from the :ref:`gen_specs
     example<gen-specs-exmple1>`).  Only the field name is required in
@@ -46,4 +46,4 @@ Used to specify the simulation function, its inputs and outputs, and user data::
 
 .. _forces_simf.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/scaling_tests/forces/forces_simf.py
 .. _run_libe_forces.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/scaling_tests/forces/run_libe_forces.py
-.. _test_6-hump_camel_uniform_sampling.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_6-hump_camel_uniform_sampling.py
+.. _test_6-hump_camel_uniform_sampling.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_uniform_sampling.py

--- a/docs/data_structures/sim_specs.rst
+++ b/docs/data_structures/sim_specs.rst
@@ -46,4 +46,4 @@ Used to specify the simulation function, its inputs and outputs, and user data::
 
 .. _forces_simf.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/scaling_tests/forces/forces_simf.py
 .. _run_libe_forces.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/scaling_tests/forces/run_libe_forces.py
-.. _test_6-hump_camel_uniform_sampling.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_uniform_sampling.py
+.. _test_uniform_sampling.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_uniform_sampling.py

--- a/docs/data_structures/work_dict.rst
+++ b/docs/data_structures/work_dict.rst
@@ -24,8 +24,8 @@ given to worker ``i``. ``Work[i]`` has the following form::
   see `start_only_persistent.py`_ or `start_persistent_local_opt_gens.py`_.
   For a use case where the allocation and generator functions combine to do
   simulation evaluations with different resources (blocking some workers), see
-  `test_6-hump_camel_with_different_nodes_uniform_sample.py`_.
+  `test_uniform_sampling_with_different_resources.py`_.
 
 .. _start_only_persistent.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/alloc_funcs/start_only_persistent.py
 .. _start_persistent_local_opt_gens.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/alloc_funcs/start_persistent_local_opt_gens.py
-.. _test_6-hump_camel_with_different_nodes_uniform_sample.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_6-hump_camel_with_different_nodes_uniform_sample.py
+.. _test_uniform_sampling_with_different_resources.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_uniform_sampling_with_different_resources.py

--- a/docs/examples/calling_scripts.rst
+++ b/docs/examples/calling_scripts.rst
@@ -8,6 +8,8 @@ example. Non-highlighted portions may include setup routines, compilation steps
 for user applications, or output processing. The first two scripts correspond to
 random sampling calculations, while the third corresponds to an optimization routine.
 
+Many other examples of calling scripts can be found in libEnsemble's `regression tests`_.
+
 Local Sine Tutorial
 -------------------
 
@@ -44,3 +46,6 @@ persistent run via a custom allocation function.
     :language: python
     :caption: tests/regression_tests/test_persistent_aposmm_with_grad.py
     :linenos:
+
+
+.. _`regression tests`: https://github.com/Libensemble/libensemble/tree/develop/libensemble/tests/regression_tests

--- a/docs/examples/calling_scripts.rst
+++ b/docs/examples/calling_scripts.rst
@@ -33,9 +33,8 @@ for execution in the ``sim_f``. Note the use of the ``parse_args()`` and
     :language: python
     :caption: tests/scaling_tests/forces/run_libe_forces.py
     :linenos:
-    :emphasize-lines: 16, 39-92
 
-Six-Hump-Camel Persistent APOSMM
+Persistent APOSMM with Gradients
 --------------------------------
 
 This example is also from the regression tests and demonstrates configuring a
@@ -43,6 +42,5 @@ persistent run via a custom allocation function.
 
 ..  literalinclude:: ../../libensemble/tests/regression_tests/test_persistent_aposmm_with_grad.py
     :language: python
-    :caption: tests/regression_tests/test_6-hump_camel_persistent_aposmm_1.py
+    :caption: tests/regression_tests/test_persistent_aposmm_with_grad.py
     :linenos:
-    :emphasize-lines: 29, 42-72, 85

--- a/docs/tutorials/executor_forces_tutorial.rst
+++ b/docs/tutorials/executor_forces_tutorial.rst
@@ -124,7 +124,7 @@ After some additions to ``libE_specs`` and defining our ``exit_criteria`` and
     :linenos:
 
     libE_specs['save_every_k_gens'] = 1000  # Save every K steps
-    libE_specs['sim_input_dir'] = './sim'         # Sim dir to be copied for each worker
+    libE_specs['sim_input_dir'] = './sim'   # Sim dir to be copied for each worker
 
     exit_criteria = {'sim_max': 8}
 

--- a/libensemble/alloc_funcs/fast_alloc_and_pausing.py
+++ b/libensemble/alloc_funcs/fast_alloc_and_pausing.py
@@ -22,7 +22,7 @@ def give_sim_work_first(W, H, sim_specs, gen_specs, alloc_specs, persis_info):
         combine_component_func is larger than a known upper bound on the objective.
 
     .. seealso::
-        `test_chwirut_uniform_sampling_one_residual_at_a_time.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_chwirut_uniform_sampling_one_residual_at_a_time.py>`_ # noqa
+        `test_uniform_sampling_one_residual_at_a_time.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_uniform_sampling_one_residual_at_a_time.py>`_ # noqa
     """
 
     Work = {}

--- a/libensemble/alloc_funcs/fast_alloc_to_aposmm.py
+++ b/libensemble/alloc_funcs/fast_alloc_to_aposmm.py
@@ -13,7 +13,7 @@ def give_sim_work_first(W, H, sim_specs, gen_specs, alloc_specs, persis_info):
     for a ``'batch_mode'``.
 
     .. seealso::
-        `test_6-hump_camel_aposmm_LD_MMA.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_6-hump_camel_aposmm_LD_MMA.py>`_ # noqa
+        `test_aposmm_with_gradients.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_aposmm_with_gradients.py>`_ # noqa
     """
 
     Work = {}

--- a/libensemble/alloc_funcs/give_sim_work_first.py
+++ b/libensemble/alloc_funcs/give_sim_work_first.py
@@ -21,7 +21,7 @@ def give_sim_work_first(W, H, sim_specs, gen_specs, alloc_specs, persis_info):
     This is the default allocation function if one is not defined.
 
     .. seealso::
-        `test_6-hump_camel_uniform_sampling.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_6-hump_camel_uniform_sampling.py>`_ # noqa
+        `test_uniform_sampling.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_uniform_sampling.py>`_ # noqa
     """
 
     Work = {}

--- a/libensemble/alloc_funcs/persistent_aposmm_alloc.py
+++ b/libensemble/alloc_funcs/persistent_aposmm_alloc.py
@@ -14,7 +14,7 @@ def persistent_aposmm_alloc(W, H, sim_specs, gen_specs, alloc_specs, persis_info
     stopped (until some exit_criterion is satisfied).
 
     .. seealso::
-        `test_6-hump_camel_persistent_aposmm.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_6-hump_camel_persistent_aposmm.py>`_ # noqa
+        `test_persistent_aposmm_with_grad.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_persistent_aposmm_with_grad.py>`_ # noqa
     """
 
     Work = {}

--- a/libensemble/alloc_funcs/start_fd_persistent.py
+++ b/libensemble/alloc_funcs/start_fd_persistent.py
@@ -12,7 +12,7 @@ def finite_diff_alloc(W, H, sim_specs, gen_specs, alloc_specs, persis_info):
     persistent generator (where x_ind is in range(n) and f_ind is in range(p))
 
     .. seealso::
-        `test_persist_fd_param_finder.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_persist_fd_param_finder.py>`_ # noqa
+        `test_persistent_fd_param_finder.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_persistent_fd_param_finder.py>`_ # noqa
     """
 
     Work = {}

--- a/libensemble/alloc_funcs/start_only_persistent.py
+++ b/libensemble/alloc_funcs/start_only_persistent.py
@@ -11,7 +11,7 @@ def only_persistent_gens(W, H, sim_specs, gen_specs, alloc_specs, persis_info):
     then this information is given back to the persistent generator.
 
     .. seealso::
-        `test_6-hump_camel_persistent_uniform_sampling.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_6-hump_camel_persistent_uniform_sampling.py>`_ # noqa
+        `test_persistent_uniform_sampling.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_persistent_uniform_sampling.py>`_ # noqa
     """
 
     Work = {}

--- a/libensemble/alloc_funcs/start_persistent_local_opt_gens.py
+++ b/libensemble/alloc_funcs/start_persistent_local_opt_gens.py
@@ -20,7 +20,7 @@ def start_persistent_local_opt_gens(W, H, sim_specs, gen_specs, alloc_specs, per
     - If no points are left, call the generation function.
 
     .. seealso::
-        `test_6-hump_camel_uniform_sampling_with_persistent_localopt_gens.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_6-hump_camel_uniform_sampling_with_persistent_localopt_gens.py>`_ # noqa
+        `test_uniform_sampling_then_persistent_localopt_runs.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_uniform_sampling_then_persistent_localopt_runs.py>`_ # noqa
     """
 
     Work = {}

--- a/libensemble/gen_funcs/aposmm.py
+++ b/libensemble/gen_funcs/aposmm.py
@@ -133,11 +133,11 @@ def aposmm_logic(H, persis_info, gen_specs, _):
         must ensure that it is always given.
 
     .. seealso::
-        `test_branin_aposmm_nlopt_and_then_scipy.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_branin_aposmm_nlopt_and_then_scipy.py>`_
+        `test_sim_dirs.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_sim_dirs.py>`_
         for basic APOSMM usage.
 
     .. seealso::
-        `test_chwirut_aposmm_one_residual_at_a_time.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_chwirut_aposmm_one_residual_at_a_time.py>`_
+        `test_aposmm_one_residual_at_a_time.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_aposmm_one_residual_at_a_time.py>`_
         for an example of APOSMM coordinating multiple local optimization runs
         for an objective with more than one component.
     """

--- a/libensemble/gen_funcs/persistent_aposmm.py
+++ b/libensemble/gen_funcs/persistent_aposmm.py
@@ -148,11 +148,11 @@ def aposmm(H, persis_info, gen_specs, libE_info):
         must ensure it's always given.
 
     .. seealso::
-        `test_branin_aposmm_nlopt_and_then_scipy.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_branin_aposmm_nlopt_and_then_scipy.py>`_
+        `test_sim_dirs.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_sim_dirs.py>`_
         for basic APOSMM usage.
 
     .. seealso::
-        `test_chwirut_aposmm_one_residual_at_a_time.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_chwirut_aposmm_one_residual_at_a_time.py>`_
+        `test_aposmm_one_residual_at_a_time.py<https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_aposmm_one_residual_at_a_time.py>`_
         for an example of APOSMM coordinating multiple local optimization runs
         for an objective with more than one component.
     """

--- a/libensemble/gen_funcs/persistent_uniform_sampling.py
+++ b/libensemble/gen_funcs/persistent_uniform_sampling.py
@@ -10,7 +10,7 @@ def persistent_uniform(H, persis_info, gen_specs, libE_info):
     ``gen_specs['gen_batch_size']`` uniformly sampled points.
 
     .. seealso::
-        `test_6-hump_camel_persistent_uniform_sampling.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_6-hump_camel_persistent_uniform_sampling.py>`_ # noqa
+        `test_persistent_uniform_sampling.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_persistent_uniform_sampling.py>`_ # noqa
     """
     ub = gen_specs['user']['ub']
     lb = gen_specs['user']['lb']

--- a/libensemble/gen_funcs/sampling.py
+++ b/libensemble/gen_funcs/sampling.py
@@ -13,7 +13,7 @@ def uniform_random_sample_with_different_nodes_and_ranks(H, persis_info, gen_spe
     and ``ranks_per_node`` to be used in the evaluation of the generated point.
 
     .. seealso::
-        `test_6-hump_camel_with_different_nodes_uniform_sample.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_6-hump_camel_with_different_nodes_uniform_sample.py>`_ # noqa
+        `test_uniform_sampling_with_different_resources.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_uniform_sampling_with_different_resources.py>`_ # noqa
     """
     ub = gen_specs['user']['ub']
     lb = gen_specs['user']['lb']
@@ -47,7 +47,7 @@ def uniform_random_sample_obj_components(H, persis_info, gen_specs, _):
     separately.
 
     .. seealso::
-        `test_chwirut_uniform_sampling_one_residual_at_a_time.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_chwirut_uniform_sampling_one_residual_at_a_time.py>`_ # noqa
+        `test_uniform_sampling_one_residual_at_a_time.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_uniform_sampling_one_residual_at_a_time.py>`_ # noqa
     """
     ub = gen_specs['user']['ub']
     lb = gen_specs['user']['lb']
@@ -75,7 +75,7 @@ def uniform_random_sample(H, persis_info, gen_specs, _):
     defined by ``gen_specs['user']['ub']`` and ``gen_specs['user']['lb']``.
 
     .. seealso::
-        `test_6-hump_camel_uniform_sampling.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_6-hump_camel_uniform_sampling.py>`_ # noqa
+        `test_uniform_sampling.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_uniform_sampling.py>`_ # noqa
     """
     ub = gen_specs['user']['ub']
     lb = gen_specs['user']['lb']

--- a/libensemble/gen_funcs/uniform_or_localopt.py
+++ b/libensemble/gen_funcs/uniform_or_localopt.py
@@ -16,7 +16,7 @@ def uniform_or_localopt(H, persis_info, gen_specs, libE_info):
     function starts a persistent nlopt local optimization run.
 
     .. seealso::
-        `test_6-hump_camel_uniform_sampling_with_persistent_localopt_gens.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_6-hump_camel_uniform_sampling_with_persistent_localopt_gens.py>`_ # noqa
+        `test_uniform_sampling_then_persistent_localopt_runs.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_uniform_sampling_then_persistent_localopt_runs.py>`_ # noqa
     """
 
     if libE_info.get('persistent'):

--- a/libensemble/sim_funcs/chwirut1.py
+++ b/libensemble/sim_funcs/chwirut1.py
@@ -265,7 +265,7 @@ def chwirut_eval(H, persis_info, sim_specs, _):
         for an example where the entire fvec is computed each call.
 
     .. seealso::
-        `test_aposmm_one_residual_at_a_time.py  <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_aposmm_one_residual_at_a_time.py >`_
+        `test_aposmm_one_residual_at_a_time.py  <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_aposmm_one_residual_at_a_time.py>`_
         for an example where one component of fvec is computed per call
     """
 

--- a/libensemble/sim_funcs/chwirut1.py
+++ b/libensemble/sim_funcs/chwirut1.py
@@ -261,11 +261,11 @@ def chwirut_eval(H, persis_info, sim_specs, _):
     are evaluated and returned in the ``'fvec'`` field.
 
     .. seealso::
-        `test_chwirut_pounders.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_chwirut_pounders.py>`_
+        `test_aposmm_pounders.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_aposmm_pounders.py>`_
         for an example where the entire fvec is computed each call.
 
     .. seealso::
-        `test_chwirut_aposmm_one_residual_at_a_time.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_chwirut_aposmm_one_residual_at_a_time.py>`_
+        `test_aposmm_one_residual_at_a_time.py  <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_aposmm_one_residual_at_a_time.py >`_
         for an example where one component of fvec is computed per call
     """
 

--- a/libensemble/sim_funcs/six_hump_camel.py
+++ b/libensemble/sim_funcs/six_hump_camel.py
@@ -94,7 +94,7 @@ def six_hump_camel(H, persis_info, sim_specs, _):
     defined.
 
     .. seealso::
-        `test_aposmm_with_gradients.py  <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_aposmm_with_gradients.py >`_ # noqa
+        `test_aposmm_with_gradients.py  <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_aposmm_with_gradients.py>`_ # noqa
     """
 
     batch = len(H['x'])

--- a/libensemble/sim_funcs/six_hump_camel.py
+++ b/libensemble/sim_funcs/six_hump_camel.py
@@ -18,7 +18,7 @@ def six_hump_camel_with_different_ranks_and_nodes(H, persis_info, sim_specs, lib
     using a machinefile (to show one way of evaluating a compiled simulation).
 
     .. seealso::
-        `test_6-hump_camel_with_different_nodes_uniform_sample.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_6-hump_camel_with_different_nodes_uniform_sample.py>`_ # noqa
+        `test_uniform_sampling_with_different_resources.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_uniform_sampling_with_different_resources.py>`_ # noqa
     """
 
     from mpi4py import MPI
@@ -94,7 +94,7 @@ def six_hump_camel(H, persis_info, sim_specs, _):
     defined.
 
     .. seealso::
-        `test_6-hump_camel_aposmm_LD_MMA.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_6-hump_camel_aposmm_LD_MMA.py>`_ # noqa
+        `test_aposmm_with_gradients.py  <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_aposmm_with_gradients.py >`_ # noqa
     """
 
     batch = len(H['x'])

--- a/libensemble/tests/scaling_tests/forces/run_libe_forces.py
+++ b/libensemble/tests/scaling_tests/forces/run_libe_forces.py
@@ -95,7 +95,6 @@ else:
 libE_specs['save_every_k_gens'] = 1000  # Save every K steps
 libE_specs['sim_input_dir'] = './sim'   # Sim dir to be copied for each worker
 libE_specs['profile_worker'] = False    # Whether to have libE profile on (default False)
-libE_specs['use_worker_dirs'] = False   # Whether to create separate worker directories (default False)
 
 # Maximum number of simulations
 sim_max = 8


### PR DESCRIPTION
And other notable but small changes:

- Adds link to regression tests for examples of calling scripts

-  Removes ``libE_specs['use_worker_dirs'] = False`` in Forces (since default is already False)

- whitespace