### PR TITLE
Making a standalone persistent_aposmm example

### DIFF
--- a/docs/advanced_installation.rst
+++ b/docs/advanced_installation.rst
@@ -36,7 +36,6 @@ To pip install libEnsemble from the latest develop branch::
 
     python -m pip install --upgrade git+https://github.com/Libensemble/libensemble.git@develop
 
-
 Installing with mpi4py
 ^^^^^^^^^^^^^^^^^^^^^^
 
@@ -57,7 +56,6 @@ On Summit, the following line is recommended (with gcc compilers)::
 
     CC=mpicc MPICC=mpicc pip install mpi4py --no-binary mpi4py
 
-
 Conda
 -----
 
@@ -68,7 +66,6 @@ Install libEnsemble with Conda_ from the conda-forge channel::
 
 This package comes with some useful optional dependencies, including
 optimizers and will install quickly as ready binary packages.
-
 
 Installing with mpi4py with Conda
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -104,7 +101,6 @@ For a complete list of builds for libEnsemble on Conda::
 
     conda search libensemble --channel conda-forge
 
-
 Spack
 -----
 
@@ -137,7 +133,6 @@ These files are used to specify dependencies that Spack must obtain from
 the given system (rather than building from scratch). This may include
 ``Python`` and the packages distributed with it (e.g. ``numpy``), and will
 often include the system MPI library.
-
 
 .. _GitHub: https://github.com/Libensemble/libensemble
 .. _Conda: https://docs.conda.io/en/latest/

--- a/docs/executor/mpi_executor.rst
+++ b/docs/executor/mpi_executor.rst
@@ -34,7 +34,6 @@ Example. To increase resilience against submission failures::
     taskctrl.fail_time = 5
     taskctrl.retry_delay_incr = 10
 
-
 .. _customizer:
 
 Overriding Auto-detection
@@ -73,4 +72,3 @@ For example::
 
     from libensemble.executors.mpi_executor import MPIExecutor
     exctr = MPIExecutor(custom_info=customizer)
-

--- a/docs/platforms/platforms_index.rst
+++ b/docs/platforms/platforms_index.rst
@@ -1,7 +1,6 @@
 Running on HPC Systems
 ======================
 
-
 Central v Distributed
 ---------------------
 
@@ -30,7 +29,6 @@ they launch. There may be multiple nodes per worker, or multiple workers per nod
 
 The distributed approach allows the libEnsemble worker to read files produced by the
 application on local node storage.
-
 
 Configuring the Run
 -------------------
@@ -77,7 +75,6 @@ per worker, and adding the manager onto the first node.
 HPC systems that only allow one application to be launched to a node at any one time,
 will not allow a distributed configuration.
 
-
 Systems with Launch/MOM nodes
 -----------------------------
 
@@ -106,7 +103,6 @@ computational work or I/O.
 
 Submission scripts for running on launch/MOM nodes and for using Balsam, can be be found in
 the :doc:`examples<example_scripts>`.
-
 
 Mapping Tasks to Resources
 --------------------------
@@ -137,14 +133,12 @@ available nodes where possible. ``jsrun`` can also queue runs. However, on
 other cluster and multi-node systems, if auto-resources is disabled, then runs without
 a hostlist or machinefile supplied may be undesirably scheduled to the same nodes.
 
-
 Overriding Auto-detection
 -------------------------
 
 libEnsemble detects node-lists, MPI runners, and the number of cores on the node through various
 means. When using the MPI Executor it is possible to override the detected information using the
 :ref:`custom_info<customizer>` argument. See the :doc:`MPI Executor<../executor/mpi_executor>` for more.
-
 
 Instructions for Specific Platforms
 -----------------------------------

--- a/docs/running_libE.rst
+++ b/docs/running_libE.rst
@@ -18,7 +18,6 @@ and Workers communicate). These are ``mpi``, ``local``, ``tcp``. The default is 
     The communications modes described here only refer to how the libEnsemble manager and
     workers communicate.
 
-
 MPI Comms
 ---------
 
@@ -48,7 +47,6 @@ with MPICH and it's derivative MPI implementations.
 It is also unsuitable to use this mode when running on the **launch** nodes of three-tier
 systems (e.g. Theta/Summit). In that case ``local`` mode is recommended.
 
-
 Local Comms
 -----------
 
@@ -76,15 +74,12 @@ systems (e.g. Theta/Summit), allowing the whole node allocation for
 worker-launched application runs. In this scenario, make sure there are
 no imports of ``mpi4py`` in your Python scripts.
 
-
-
 Limitations of local mode
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - You cannot run in :doc:`distributed mode<platforms/platforms_index>` on multi-node systems.
 - In some scenarios, any import of ``mpi4py`` will cause this to break.
 - It does not have the potential scaling of MPI mode, but is sufficient for most users.
-
 
 TCP Comms
 ---------
@@ -107,7 +102,6 @@ The ``libE_specs`` options for TCP are::
         port
     'authkey' [String]:
         authkey
-
 
 Persistent Workers
 ------------------
@@ -134,7 +128,6 @@ If this example was run as::
 
 No simulations will be able to run.
 
-
 Environment Variables
 ---------------------
 
@@ -144,8 +137,6 @@ For example::
     os.environ["OMP_NUM_THREADS"] = 4
 
 set in your simulation script before the Executor submit command will export the setting to your run.
-
-
 
 Further run information
 -----------------------

--- a/libensemble/alloc_funcs/only_one_gen_alloc.py
+++ b/libensemble/alloc_funcs/only_one_gen_alloc.py
@@ -5,7 +5,7 @@ def ensure_one_active_gen(W, H, sim_specs, gen_specs, alloc_specs, persis_info):
     """
     This allocation function gives (in order) entries in ``H`` to idle workers
     to evaluate in the simulation function. The fields in ``sim_specs['in']``
-    are given. If there is no active generator, then one is started. 
+    are given. If there is no active generator, then one is started.
 
     .. seealso::
         `test_fast_alloc.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_fast_alloc.py>`_ # noqa

--- a/libensemble/tests/unit_tests/test_persistent_aposmm.py
+++ b/libensemble/tests/unit_tests/test_persistent_aposmm.py
@@ -41,6 +41,56 @@ def test_update_history_optimal():
     assert opt_ind == 9, "Wrong point declared minimum"
 
 
+def test_standalone_persistent_aposmm():
+
+    from libensemble.tests.regression_tests.support import six_hump_camel_minima as minima
+    from libensemble.sim_funcs.six_hump_camel import six_hump_camel_func, six_hump_camel_grad
+    from math import gamma, pi, sqrt
+    from libensemble.message_numbers import FINISHED_PERSISTENT_GEN_TAG
+
+    persis_info = {'rand_stream': np.random.RandomState(1), 'nworkers': 4}
+
+    n = 2
+    eval_max = 2000
+
+    gen_out = [('x', float, n), ('x_on_cube', float, n), ('sim_id', int),
+               ('local_min', bool), ('local_pt', bool)]
+    gen_specs = {'in': ['x', 'f', 'grad', 'local_pt', 'sim_id', 'returned', 'x_on_cube', 'local_min'],
+                 'out': gen_out,
+                 'user': {'initial_sample_size': 100,
+                          # 'localopt_method': 'LD_MMA', # Needs gradients
+                          'sample_points': np.round(minima, 1),
+                          'localopt_method': 'LN_BOBYQA',
+                          'standalone': {'eval_max': eval_max,
+                                         'obj_func': six_hump_camel_func,
+                                         'grad_func': six_hump_camel_grad,
+                                         },
+                          'rk_const': 0.5*((gamma(1+(n/2))*5)**(1/n))/sqrt(pi),
+                          'xtol_abs': 1e-6,
+                          'ftol_abs': 1e-6,
+                          'dist_to_bound_multiple': 0.5,
+                          'max_active_runs': 6,
+                          'lb': np.array([-3, -2]),
+                          'ub': np.array([3, 2])}
+                 }
+    H = []
+    H, persis_info, exit_code = al.aposmm(H, persis_info, gen_specs, {})
+    assert exit_code == FINISHED_PERSISTENT_GEN_TAG, "Standalone persistent_aposmm didn't exit correctly"
+    assert np.sum(H['returned']) >= eval_max, "Standalone persistent_aposmm, didn't evaluate enough points"
+    assert persis_info.get('run_order'), "Standalone persistent_aposmm didn't do any localopt runs"
+
+    tol = 1e-3
+    min_found = 0
+    for m in minima:
+        # The minima are known on this test problem.
+        # We use their values to test APOSMM has identified all minima
+        print(np.min(np.sum((H[H['local_min']]['x'] - m)**2, 1)), flush=True)
+        if np.min(np.sum((H[H['local_min']]['x'] - m)**2, 1)) < tol:
+            min_found += 1
+    assert min_found >= 6, "Found {} minima".format(min_found)
+
+
 if __name__ == "__main__":
     test_persis_apossm_localopt_test()
     test_update_history_optimal()
+    test_standalone_persistent_aposmm()


### PR DESCRIPTION
Modifies `persistent_aposmm` to perform its own gradient and function evaluations when in standalone mode. To make this change minimally invasive, this is accomplished by having `persistent_aposmm` make the data structures that should be received from the manager.