### PR TITLE
Enforce multiprocessing start method as 'fork' on macOS

### DIFF
--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -309,6 +309,15 @@ def libE_local(sim_specs, gen_specs, exit_criteria,
 
     hist = History(alloc_specs, sim_specs, gen_specs, exit_criteria, H0)
 
+    # On Python 3.8 on macOS, the default start method for new processes was
+    #  switched to 'spawn' by default due to 'fork' potentially causing crashes.
+    # These crashes haven't yet been observed with libE, but with 'spawn' runs,
+    #  warnings about leaked semaphore objects are displayed instead.
+    # The next several statements enforce 'fork' on macOS (Python 3.8)
+    if os.uname().sysname == 'Darwin':
+        from multiprocessing import set_start_method
+        set_start_method('fork', force=True)
+
     # Launch worker team and set up logger
     wcomms = start_proc_team(nworkers, sim_specs, gen_specs, libE_specs)
 


### PR DESCRIPTION
Addresses #502 

This fix should address the problem in the above issue.

As stated on the issue, Python 3.8's multiprocessing module on macOS sets the new default launch method to 'spawn' instead of 'fork'. They made this change due to potential crashes on newer versions of macOS with 'fork'. However, I haven't observed any such crashes locally or on Travis, nor have users reported any (yet). Furthermore, in my limited testing 'spawn' produced semaphore leaking errors or RuntimeErrors, and it's my understanding that properly supporting 'spawn' would require mac users to refactor their calling scripts.

Please feel free to provide feedback or additional information about this issue.


