### PR TITLE
Conda-install PETSc / petsc4py, add OSX Python 3.8 jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,8 @@ install:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.8" ]]; then
       conda install nlopt mpi4py scipy mpich;
       export PETSC_CONFIGURE_OPTIONS='--with-batch';
-      pip install petsc petsc4py;
+      # pip install petsc petsc4py;
+      conda install petsc4py
     else
       conda install nlopt petsc4py petsc $MUMPS mpi4py scipy $MPI;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ before_install:
   - conda info -a # For debugging conda issues
   - conda config --add channels conda-forge
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      conda create --yes --name condaenv python=3.7;
+      conda create --yes --name condaenv python=$PY;
     else
       conda create --yes --name condaenv python=$TRAVIS_PYTHON_VERSION;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,19 +36,30 @@ jobs:
       env: MPI=mpich PY=3.7 COMMS_TYPE=t  # tcp
       language: generic
       python: 3.7
+    - os: osx
+      osx_image: xcode11.3
+      env: MPI=mpich PY=3.8 COMMS_TYPE=m  # mpi
+      language: generic
+      python: 3.8
+    - os: osx
+      osx_image: xcode11.3
+      env: MPI=mpich PY=3.8 COMMS_TYPE=l  # local
+      language: generic
+      python: 3.8
+    - os: osx
+      osx_image: xcode11.3
+      env: MPI=mpich PY=3.8 COMMS_TYPE=t  # tcp
+      language: generic
+      python: 3.8
+  fast_finish: true
   allow_failures:
       - python: 3.8
-  fast_finish: true  # So a build can be marked as complete if required jobs
-                     #  succeed before nonrequired jobs (py 3.8) timeout.
-
-# Below will update the OSX octave used on Travis.  This was so slow that we
-# were hitting the 50 minute limit on Travis. We no longer update octave in
-# homebrew, and can no longer run regression # tests using octave on OSX.
-# addons:
-#   homebrew:
-#     packages:
-#     - octave
-#     update: true
+      - os: osx
+        env: MPI=mpich PY=3.8 COMMS_TYPE=m  # mpi
+      - os: osx
+        env: MPI=mpich PY=3.8 COMMS_TYPE=l  # mpi
+      - os: osx
+        env: MPI=mpich PY=3.8 COMMS_TYPE=t  # mpi
 
 services:
     - postgresql
@@ -94,8 +105,7 @@ install:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.8" ]]; then
       conda install nlopt mpi4py scipy mpich;
       export PETSC_CONFIGURE_OPTIONS='--with-batch';
-      # pip install petsc petsc4py;
-      conda install petsc4py
+      conda install petsc4py;
     else
       conda install nlopt petsc4py petsc $MUMPS mpi4py scipy $MPI;
     fi

--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -309,6 +309,15 @@ def libE_local(sim_specs, gen_specs, exit_criteria,
 
     hist = History(alloc_specs, sim_specs, gen_specs, exit_criteria, H0)
 
+    # On Python 3.8 on macOS, the default start method for new processes was
+    #  switched to 'spawn' by default due to 'fork' potentially causing crashes.
+    # These crashes haven't yet been observed with libE, but with 'spawn' runs,
+    #  warnings about leaked semaphore objects are displayed instead.
+    # The next several statements enforce 'fork' on macOS (Python 3.8)
+    if os.uname().sysname == 'Darwin':
+        from multiprocessing import set_start_method
+        set_start_method('fork', force=True)
+
     # Launch worker team and set up logger
     wcomms = start_proc_team(nworkers, sim_specs, gen_specs, libE_specs)
 


### PR DESCRIPTION
Conda-installing petsc4py seems to work on Python 3.8. OSX Python 3.8 jobs added (and allowed to fail).