### PR TITLE
Handling of large history arrays

### DIFF
--- a/examples/misc/ps_nodes.sh
+++ b/examples/misc/ps_nodes.sh
@@ -27,4 +27,3 @@ do
     ssh $hname "hostname; ps aux|grep $uname|grep '$appname'"
   fi
 done
-

--- a/libensemble/libE_manager.py
+++ b/libensemble/libE_manager.py
@@ -9,6 +9,7 @@ import glob
 import logging
 import socket
 import numpy as np
+import copy
 
 from libensemble.utils.timer import Timer
 from libensemble.message_numbers import \
@@ -258,7 +259,8 @@ class Manager:
         self.wcomms[w-1].send(Work['tag'], Work)
         work_rows = Work['libE_info']['H_rows']
         if len(work_rows):
-            self.wcomms[w-1].send(0, self.hist.H[Work['H_fields']][work_rows])
+            A = copy.deepcopy(self.hist.H[Work['H_fields']][work_rows])
+            self.wcomms[w-1].send(0, A)
 
     def _update_state_on_alloc(self, Work, w):
         """Updates a workers' active/idle status following an allocation order"""

--- a/libensemble/libE_manager.py
+++ b/libensemble/libE_manager.py
@@ -9,7 +9,6 @@ import glob
 import logging
 import socket
 import numpy as np
-import copy
 
 from libensemble.utils.timer import Timer
 from libensemble.message_numbers import \
@@ -261,12 +260,12 @@ class Manager:
         if len(work_rows):
             d = self.hist.H[Work['H_fields']][work_rows].dtype
             k = list(d.fields.keys())
-            w = list(d.fields.values())
-            v = [i[0] for i in w]
-            A = np.zeros(len(work_rows),dtype=list(zip(k,v)))
+            v1 = list(d.fields.values())
+            v = [i[0] for i in v1]
+            A = np.zeros(len(work_rows), dtype=list(zip(k, v)))
             for f in k:
                 A[f] = self.hist.H[f][work_rows]
-            
+
             self.wcomms[w-1].send(0, A)
 
     def _update_state_on_alloc(self, Work, w):

--- a/libensemble/libE_manager.py
+++ b/libensemble/libE_manager.py
@@ -9,7 +9,6 @@ import glob
 import logging
 import socket
 import numpy as np
-from numpy.lib.recfunctions import repack_fields
 
 from libensemble.utils.timer import Timer
 from libensemble.message_numbers import \
@@ -25,6 +24,9 @@ from libensemble.tools.tools import _USER_CALC_DIR_WARNING
 from libensemble.tools.fields_keys import libE_spec_calc_dir_combined
 import cProfile
 import pstats
+
+if tuple(np.__version__.split('.')) >= ('1', '15'):
+    from numpy.lib.recfunctions import repack_fields
 
 logger = logging.getLogger(__name__)
 # For debug messages - uncomment
@@ -259,7 +261,10 @@ class Manager:
         self.wcomms[w-1].send(Work['tag'], Work)
         work_rows = Work['libE_info']['H_rows']
         if len(work_rows):
-            self.wcomms[w-1].send(0, repack_fields(self.hist.H[Work['H_fields']][work_rows]))
+            if 'repack_fields' in dir():
+                self.wcomms[w-1].send(0, repack_fields(self.hist.H[Work['H_fields']][work_rows]))
+            else:
+                self.wcomms[w-1].send(0, self.hist.H[Work['H_fields']][work_rows])
 
     def _update_state_on_alloc(self, Work, w):
         """Updates a workers' active/idle status following an allocation order"""

--- a/libensemble/libE_manager.py
+++ b/libensemble/libE_manager.py
@@ -259,7 +259,13 @@ class Manager:
         self.wcomms[w-1].send(Work['tag'], Work)
         work_rows = Work['libE_info']['H_rows']
         if len(work_rows):
-            A = copy.deepcopy(self.hist.H[Work['H_fields']][work_rows])
+            d = self.hist.H[Work['H_fields']][work_rows].dtype
+            k = list(d.fields.keys())
+            v = list(d.fields.values())
+            A = np.zeros(len(work_rows),dtype=list(zip(k,v)))
+            for f in k:
+                A[f] = self.hist.H[f][work_rows]
+            
             self.wcomms[w-1].send(0, A)
 
     def _update_state_on_alloc(self, Work, w):

--- a/libensemble/libE_manager.py
+++ b/libensemble/libE_manager.py
@@ -259,14 +259,6 @@ class Manager:
         self.wcomms[w-1].send(Work['tag'], Work)
         work_rows = Work['libE_info']['H_rows']
         if len(work_rows):
-            # d = self.hist.H[Work['H_fields']][work_rows].dtype
-            # k = list(d.fields.keys())
-            # v1 = list(d.fields.values())
-            # v = [i[0] for i in v1]
-            # A = np.zeros(len(work_rows), dtype=list(zip(k, v)))
-            # for f in k:
-            #     A[f] = self.hist.H[f][work_rows]
-            # self.wcomms[w-1].send(0, A)
             self.wcomms[w-1].send(0, repack_fields(self.hist.H[Work['H_fields']][work_rows]))
 
     def _update_state_on_alloc(self, Work, w):

--- a/libensemble/libE_manager.py
+++ b/libensemble/libE_manager.py
@@ -261,7 +261,8 @@ class Manager:
         if len(work_rows):
             d = self.hist.H[Work['H_fields']][work_rows].dtype
             k = list(d.fields.keys())
-            v = list(d.fields.values())
+            w = list(d.fields.values())
+            v = [i[0] for i in w]
             A = np.zeros(len(work_rows),dtype=list(zip(k,v)))
             for f in k:
                 A[f] = self.hist.H[f][work_rows]

--- a/libensemble/libE_manager.py
+++ b/libensemble/libE_manager.py
@@ -9,6 +9,7 @@ import glob
 import logging
 import socket
 import numpy as np
+from numpy.lib.recfunctions import repack_fields
 
 from libensemble.utils.timer import Timer
 from libensemble.message_numbers import \
@@ -258,15 +259,15 @@ class Manager:
         self.wcomms[w-1].send(Work['tag'], Work)
         work_rows = Work['libE_info']['H_rows']
         if len(work_rows):
-            d = self.hist.H[Work['H_fields']][work_rows].dtype
-            k = list(d.fields.keys())
-            v1 = list(d.fields.values())
-            v = [i[0] for i in v1]
-            A = np.zeros(len(work_rows), dtype=list(zip(k, v)))
-            for f in k:
-                A[f] = self.hist.H[f][work_rows]
-
-            self.wcomms[w-1].send(0, A)
+            # d = self.hist.H[Work['H_fields']][work_rows].dtype
+            # k = list(d.fields.keys())
+            # v1 = list(d.fields.values())
+            # v = [i[0] for i in v1]
+            # A = np.zeros(len(work_rows), dtype=list(zip(k, v)))
+            # for f in k:
+            #     A[f] = self.hist.H[f][work_rows]
+            # self.wcomms[w-1].send(0, A)
+            self.wcomms[w-1].send(0, repack_fields(self.hist.H[Work['H_fields']][work_rows]))
 
     def _update_state_on_alloc(self, Work, w):
         """Updates a workers' active/idle status following an allocation order"""

--- a/libensemble/tests/regression_tests/test_fast_alloc.py
+++ b/libensemble/tests/regression_tests/test_fast_alloc.py
@@ -48,7 +48,7 @@ if libE_specs['comms'] == 'tcp':
     # each time, and the worker will not know what port to connect to.
     sys.exit("Cannot run with tcp when repeated calls to libE -- aborting...")
 
-for time in [0]:
+for time in np.append([0], np.logspace(-5, -1, 5)):
     if time == 0:
         alloc_specs = {'alloc_f': alloc_f2, 'out': []}
     else:

--- a/libensemble/tests/regression_tests/test_fast_alloc.py
+++ b/libensemble/tests/regression_tests/test_fast_alloc.py
@@ -28,7 +28,7 @@ nworkers, is_master, libE_specs, _ = parse_args()
 
 num_pts = 30*(nworkers - 1)
 
-sim_specs = {'sim_f': sim_f, 'in': ['x'], 'out': [('f', float)], 'user': {}}
+sim_specs = {'sim_f': sim_f, 'in': ['x'], 'out': [('f', float),('large',float,5000000)], 'user': {}}
 
 gen_specs = {'gen_f': gen_f,
              'in': ['sim_id'],
@@ -40,7 +40,7 @@ gen_specs = {'gen_f': gen_f,
 
 persis_info = add_unique_random_streams({}, nworkers + 1)
 
-exit_criteria = {'sim_max': num_pts, 'elapsed_wallclock_time': 300}
+exit_criteria = {'sim_max': 2*num_pts, 'elapsed_wallclock_time': 300}
 
 if libE_specs['comms'] == 'tcp':
     # Can't use the same interface for manager and worker if we want
@@ -48,7 +48,7 @@ if libE_specs['comms'] == 'tcp':
     # each time, and the worker will not know what port to connect to.
     sys.exit("Cannot run with tcp when repeated calls to libE -- aborting...")
 
-for time in np.append([0], np.logspace(-5, -1, 5)):
+for time in [0]:
     if time == 0:
         alloc_specs = {'alloc_f': alloc_f2, 'out': []}
     else:
@@ -69,4 +69,4 @@ for time in np.append([0], np.logspace(-5, -1, 5)):
 
         if is_master:
             assert flag == 0
-            assert len(H) == num_pts
+            assert len(H) == 2*num_pts

--- a/libensemble/tests/regression_tests/test_fast_alloc.py
+++ b/libensemble/tests/regression_tests/test_fast_alloc.py
@@ -28,7 +28,7 @@ nworkers, is_master, libE_specs, _ = parse_args()
 
 num_pts = 30*(nworkers - 1)
 
-sim_specs = {'sim_f': sim_f, 'in': ['x'], 'out': [('f', float), ('large', float, 5000000)], 'user': {}}
+sim_specs = {'sim_f': sim_f, 'in': ['x'], 'out': [('f', float), ('large', float, 1000000)], 'user': {}}
 
 gen_specs = {'gen_f': gen_f,
              'in': ['sim_id'],

--- a/libensemble/tests/regression_tests/test_fast_alloc.py
+++ b/libensemble/tests/regression_tests/test_fast_alloc.py
@@ -28,7 +28,7 @@ nworkers, is_master, libE_specs, _ = parse_args()
 
 num_pts = 30*(nworkers - 1)
 
-sim_specs = {'sim_f': sim_f, 'in': ['x'], 'out': [('f', float),('large',float,5000000)], 'user': {}}
+sim_specs = {'sim_f': sim_f, 'in': ['x'], 'out': [('f', float), ('large', float, 5000000)], 'user': {}}
 
 gen_specs = {'gen_f': gen_f,
              'in': ['sim_id'],


### PR DESCRIPTION
Numpy now returns a view for the entire history array when indexing multiple fields. From the numpy [documentation:](https://numpy.org/doc/stable/user/basics.rec.html#accessing-multiple-fields)

>  Note that unlike for single-field indexing, the dtype of the view has the same itemsize as the original array, and has fields at the same offsets as in the original array, and unindexed fields are merely missing.
 
So an object the size of the entire history is communicate every time we send multiple fields. This can be slow (or prohibitive) when the history is large, we could send a sequence of single-fields out of the history. Or we can apply the [repack_fields](https://numpy.org/doc/stable/user/basics.rec.html#numpy.lib.recfunctions.repack_fields) option.

- A downside of this option is that it creates a structure containing copy of the fields to be sent. 
- A downside of a sequence of single-field sends is the communication cost. 

I vote for the copy approach, which is what will be in this pull request.