### PR TITLE
Trying to add a flag so regression tests can be run with warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -142,7 +142,7 @@ before_script:
 
 # Run test (-z show output)
 script:
-  - ./libensemble/tests/run-tests.sh -W error -z -$COMMS_TYPE
+  - ./libensemble/tests/run-tests.sh -A "-W error" -z -$COMMS_TYPE
 
 # Track code coverage
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -142,7 +142,7 @@ before_script:
 
 # Run test (-z show output)
 script:
-  - ./libensemble/tests/run-tests.sh -z -$COMMS_TYPE
+  - ./libensemble/tests/run-tests.sh -W error -z -$COMMS_TYPE
 
 # Track code coverage
 after_success:

--- a/libensemble/gen_funcs/persistent_deap_nsga2.py
+++ b/libensemble/gen_funcs/persistent_deap_nsga2.py
@@ -31,6 +31,16 @@ def nsga2_toolbox(gen_specs):
     lb = gen_specs['user']['lb']
     ub = gen_specs['user']['ub']
 
+    try:
+        del creator.MyFitness
+    except Exception:
+        pass
+
+    try:
+        del creator.Individual
+    except Exception:
+        pass
+
     creator.create('MyFitness', base.Fitness, weights=w)
     creator.create('Individual', array.array, typecode='d', fitness=creator.MyFitness)
     toolbox = base.Toolbox()

--- a/libensemble/libE_worker.py
+++ b/libensemble/libE_worker.py
@@ -287,7 +287,7 @@ class Worker:
 
             # If not using calc dirs, likely miscellaneous files to copy back
             if no_calc_dirs:
-                p = re.compile("((^sim)|(^gen))\d+_worker\d+")
+                p = re.compile(r"((^sim)|(^gen))\d+_worker\d+")
                 for file in [i for i in os.listdir(self.prefix) if not p.match(i)]:  # each non-calc_dir file
                     source_path = os.path.join(self.prefix, file)
                     dest_path = os.path.join(copybackdir, file)

--- a/libensemble/tests/run-tests.sh
+++ b/libensemble/tests/run-tests.sh
@@ -203,7 +203,7 @@ usage() {
   echo "  -t              Run the regression tests using TCP comms"
   echo "  -p {version}    Select a version of python. E.g. -p 2 will run with the python2 exe"
   echo "                  Note: This will literally run the python2/python3 exe. Default runs python"
-  echo "  -W {name}       Supply warnings level for tests"
+  echo "  -A {-flag arg}  Supply arguments to python"
   echo "  -n {name}       Supply a name to this test run"
   echo "  -a {args}       Supply a string of args to add to mpiexec line"
   echo "  -y {args}       Supply a list of regression tests as a reg. expression  e.g. '-y test_persistent_aposmm*'"

--- a/libensemble/tests/run-tests.sh
+++ b/libensemble/tests/run-tests.sh
@@ -265,7 +265,7 @@ while getopts ":p:n:a:y:W:hcszurmlt" opt; do
       ;;
     W)
       echo "Warning level parameter: $OPTARG" >&2
-      PYTHON_FLAGS='-W error'
+      PYTHON_FLAGS="-W $OPTARG"
       ;;
     h)
       usage

--- a/libensemble/tests/run-tests.sh
+++ b/libensemble/tests/run-tests.sh
@@ -213,7 +213,7 @@ usage() {
   exit 1
 }
 
-while getopts ":p:n:a:y:W:hcszurmlt" opt; do
+while getopts ":p:n:a:y:A:hcszurmlt" opt; do
   case $opt in
     p)
       echo "Parameter supplied for Python version: $OPTARG" >&2
@@ -263,9 +263,9 @@ while getopts ":p:n:a:y:W:hcszurmlt" opt; do
       echo "Running with user supplied test list"
       export REG_TEST_LIST="$OPTARG"
       ;;
-    W)
-      echo "Warning level parameter: $OPTARG" >&2
-      PYTHON_FLAGS="-W $OPTARG"
+    A)
+      echo "Python arguments passed: $OPTARG" >&2
+      PYTHON_FLAGS="$PYTHON_FLAGS $OPTARG"
       ;;
     h)
       usage
@@ -326,7 +326,7 @@ if [ $CLEAN_ONLY = "true" ]; then
 fi;
 
 #If not supplied will go to just python (no number) - eg. with tox/virtual envs
-PYTHON_RUN=python$PYTHON_VER
+PYTHON_RUN="python$PYTHON_VER $PYTHON_FLAGS"
 echo -e "Python run: $PYTHON_RUN"
 
 textreset=$(tput sgr0)
@@ -385,9 +385,9 @@ if [ "$root_found" = true ]; then
     cd $ROOT_DIR/$DIR
 #     $PYTHON_RUN -m pytest --fulltrace $COV_LINE_SERIAL
     if [ "$PYTEST_SHOW_OUT_ERR" = true ]; then
-      $PYTHON_RUN $PYTHON_FLAGS -m pytest --capture=no --timeout=100 $COV_LINE_SERIAL #To see std out/err while running
+      $PYTHON_RUN -m pytest --capture=no --timeout=100 $COV_LINE_SERIAL #To see std out/err while running
     else
-      $PYTHON_RUN $PYTHON_FLAGS -m pytest --timeout=100 $COV_LINE_SERIAL
+      $PYTHON_RUN -m pytest --timeout=100 $COV_LINE_SERIAL
     fi;
 
     code=$?
@@ -487,26 +487,26 @@ if [ "$root_found" = true ]; then
 
              if [ "$REG_USE_PYTEST" = true ]; then
                if [ "$LAUNCHER" = mpi ]; then
-                 mpiexec -np $NPROCS $MPIEXEC_FLAGS $PYTHON_RUN $PYTHON_FLAGS -m pytest $TEST_SCRIPT >> $TEST_SCRIPT.$NPROCS'procs'.$REG_TEST_OUTPUT_EXT 2>test.err
+                 mpiexec -np $NPROCS $MPIEXEC_FLAGS $PYTHON_RUN -m pytest $TEST_SCRIPT >> $TEST_SCRIPT.$NPROCS'procs'.$REG_TEST_OUTPUT_EXT 2>test.err
                  test_code=$?
                else
-                 $TIMEOUT $PYTHON_RUN $PYTHON_FLAGS -m pytest $TEST_SCRIPT --comms $LAUNCHER --nworkers $NWORKERS >> $TEST_SCRIPT.$NPROCS'procs'-$LAUNCHER.$REG_TEST_OUTPUT_EXT 2>test.err
+                 $TIMEOUT $PYTHON_RUN -m pytest $TEST_SCRIPT --comms $LAUNCHER --nworkers $NWORKERS >> $TEST_SCRIPT.$NPROCS'procs'-$LAUNCHER.$REG_TEST_OUTPUT_EXT 2>test.err
                fi
              else
                if [ "$LAUNCHER" = mpi ]; then
                  if [ "$RTEST_SHOW_OUT_ERR" = "true" ]; then
-                   mpiexec -np $NPROCS $MPIEXEC_FLAGS $PYTHON_RUN $PYTHON_FLAGS $COV_LINE_PARALLEL $TEST_SCRIPT
+                   mpiexec -np $NPROCS $MPIEXEC_FLAGS $PYTHON_RUN $COV_LINE_PARALLEL $TEST_SCRIPT
                    test_code=$?
                  else
-                   mpiexec -np $NPROCS $MPIEXEC_FLAGS $PYTHON_RUN $PYTHON_FLAGS $COV_LINE_PARALLEL $TEST_SCRIPT >> $TEST_SCRIPT.$NPROCS'procs'.$REG_TEST_OUTPUT_EXT 2>test.err
+                   mpiexec -np $NPROCS $MPIEXEC_FLAGS $PYTHON_RUN $COV_LINE_PARALLEL $TEST_SCRIPT >> $TEST_SCRIPT.$NPROCS'procs'.$REG_TEST_OUTPUT_EXT 2>test.err
                    test_code=$?
                  fi
                else
                  if [ "$RTEST_SHOW_OUT_ERR" = "true" ]; then
-                   $TIMEOUT $PYTHON_RUN $PYTHON_FLAGS $COV_LINE_PARALLEL $TEST_SCRIPT --comms $LAUNCHER --nworkers $NWORKERS
+                   $TIMEOUT $PYTHON_RUN $COV_LINE_PARALLEL $TEST_SCRIPT --comms $LAUNCHER --nworkers $NWORKERS
                    test_code=$?
                  else
-                   $TIMEOUT $PYTHON_RUN $PYTHON_FLAGS $COV_LINE_PARALLEL $TEST_SCRIPT --comms $LAUNCHER --nworkers $NWORKERS >> $TEST_SCRIPT.$NPROCS'procs'-$LAUNCHER.$REG_TEST_OUTPUT_EXT 2>test.err
+                   $TIMEOUT $PYTHON_RUN $COV_LINE_PARALLEL $TEST_SCRIPT --comms $LAUNCHER --nworkers $NWORKERS >> $TEST_SCRIPT.$NPROCS'procs'-$LAUNCHER.$REG_TEST_OUTPUT_EXT 2>test.err
                    test_code=$?
                  fi
                fi


### PR DESCRIPTION
Appending to `$PYTHON_FLAGS` variable may not be the best way to start passing flags to python.

If there is a more robust or scalable way to do this, feel free to adjust or harmonize the various arguments in this script. (It seems to be getting a bit large, but perhaps that's necessary for a unified testing script with many options.)