### PR TITLE
Making consistent our use of manager

### DIFF
--- a/docs/tutorials/aposmm_tutorial.rst
+++ b/docs/tutorials/aposmm_tutorial.rst
@@ -156,7 +156,7 @@ and :doc:`alloc_specs<../data_structures/alloc_specs>`:
 .. code-block:: python
     :linenos:
 
-    nworkers, is_master, libE_specs, _ = parse_args()
+    nworkers, is_manager, libE_specs, _ = parse_args()
 
     sim_specs = {'sim_f': six_hump_camel, # Simulation function
                  'in': ['x'],             # Accepts 'x' values
@@ -230,7 +230,7 @@ check calculated minima:
 
     H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                                 alloc_specs, libE_specs)
-    if is_master:
+    if is_manager:
         print('Minima:', H[np.where(H['local_min'])]['x'])
 
 Final Setup, Run, and Output

--- a/docs/tutorials/executor_forces_tutorial.rst
+++ b/docs/tutorials/executor_forces_tutorial.rst
@@ -50,7 +50,7 @@ generation functions and call libEnsemble. Create a Python file containing:
     from libensemble.tools import parse_args, add_unique_random_streams
     from libensemble.executors.mpi_executor import MPIExecutor
 
-    nworkers, is_master, libE_specs, _ = parse_args()  # Convenience function
+    nworkers, is_manager, libE_specs, _ = parse_args()  # Convenience function
 
     # Create executor and register sim to it
     exctr = MPIExecutor()  # Use auto_resources=False to oversubscribe
@@ -66,7 +66,7 @@ generation functions and call libEnsemble. Create a Python file containing:
 On line 4 we import our not-yet-written ``sim_f``. We also import necessary
 libEnsemble components and some :doc:`convenience functions<../utilities>`.
 For example, our script can use the number of workers (``nworkers``), a boolean
-determining if the process is the master process (``is_master``), and a default
+determining if the process is the manager process (``is_manager``), and a default
 :ref:`libE_specs<datastruct-libe-specs>` with a call to the ``parse_args()``
 convenience function.
 

--- a/docs/tutorials/local_sine_tutorial.rst
+++ b/docs/tutorials/local_sine_tutorial.rst
@@ -332,7 +332,7 @@ of the calling script as follows:
     libE_specs = {'comms': 'mpi'}                 # 'nworkers' removed, 'comms' now 'mpi'
 
     nworkers = MPI.COMM_WORLD.Get_size() - 1
-    is_master = (MPI.COMM_WORLD.Get_rank() == 0)  # master process has MPI rank 0
+    is_manager = (MPI.COMM_WORLD.Get_rank() == 0)  # master process has MPI rank 0
 
 So that only one process executes the graphing and printing portion of our code,
 modify the bottom of the calling script like this:
@@ -344,7 +344,7 @@ modify the bottom of the calling script like this:
     H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                                 libE_specs=libE_specs)
 
-    if is_master:
+    if is_manager:
         # Some (optional) statements to visualize our history array
         print([i for i in H.dtype.fields])
         print(H)

--- a/examples/libE_submission_scripts/bebop_submit_slurm_distrib.sh
+++ b/examples/libE_submission_scripts/bebop_submit_slurm_distrib.sh
@@ -46,7 +46,7 @@ fi;
 #-----------------------------------------------------------------------------
 
 # A little useful information
-echo -e "Master process running on: $HOSTNAME"
+echo -e "Manager process running on: $HOSTNAME"
 echo -e "Directory is:  $PWD"
 
 # Generate a node list with 1 node per line:

--- a/examples/libE_submission_scripts/blues_script.pbs
+++ b/examples/libE_submission_scripts/blues_script.pbs
@@ -33,7 +33,7 @@
 cd $PBS_O_WORKDIR
 
 # A little useful information for the log file...
-echo Master process running on: $HOSTNAME
+echo Manager process running on: $HOSTNAME
 echo Directory is:  $PWD
 echo PBS has allocated the following nodes:
 cat $PBS_NODEFILE

--- a/examples/tutorials/tutorial_aposmm.py
+++ b/examples/tutorials/tutorial_aposmm.py
@@ -10,7 +10,7 @@ from libensemble.tools import parse_args, add_unique_random_streams
 import libensemble.gen_funcs
 libensemble.gen_funcs.rc.aposmm_optimizers = 'scipy'
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 sim_specs = {'sim_f': six_hump_camel,  # Simulation function
              'in': ['x'],              # Accepts 'x' values
@@ -41,5 +41,5 @@ persis_info = add_unique_random_streams({}, nworkers + 1)
 
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             alloc_specs, libE_specs)
-if is_master:
+if is_manager:
     print('Minima:', H[np.where(H['local_min'])]['x'])

--- a/examples/tutorials/tutorial_calling_mpi.py
+++ b/examples/tutorials/tutorial_calling_mpi.py
@@ -9,7 +9,7 @@ from mpi4py import MPI
 libE_specs = {'comms': 'mpi'}                   # 'nworkers' removed, 'comms' now 'mpi'
 
 nworkers = MPI.COMM_WORLD.Get_size() - 1        # one process belongs to manager
-is_master = (MPI.COMM_WORLD.Get_rank() == 0)    # master process has MPI rank 0
+is_manager = (MPI.COMM_WORLD.Get_rank() == 0)   # manager process has MPI rank 0
 
 gen_specs = {'gen_f': gen_random_sample,        # Our generator function
              'out': [('x', float, (1,))],       # gen_f output (name, type, size).
@@ -31,8 +31,8 @@ H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             libE_specs=libE_specs)
 
 # Some (optional) statements to visualize our History array
-# Only the master process should execute this
-if is_master:
+# Only the manager process should execute this
+if is_manager:
     print([i for i in H.dtype.fields])
     print(H)
 

--- a/examples/tutorials/tutorial_run_libe_forces.py
+++ b/examples/tutorials/tutorial_run_libe_forces.py
@@ -8,7 +8,7 @@ from libensemble.gen_funcs.sampling import uniform_random_sample
 from libensemble.tools import parse_args, add_unique_random_streams
 from libensemble.executors.mpi_executor import MPIExecutor
 
-nworkers, is_master, libE_specs, _ = parse_args()  # Convenience function
+nworkers, is_manager, libE_specs, _ = parse_args()  # Convenience function
 
 # Create executor and register sim to it
 exctr = MPIExecutor(auto_resources=False)  # Use auto_resources=False to oversubscribe

--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -221,16 +221,16 @@ def libE_mpi(sim_specs, gen_specs, exit_criteria,
 
     with DupComm(libE_specs['comm']) as comm:
         rank = comm.Get_rank()
-        is_master = (rank == 0)
+        is_manager = (rank == 0)
 
         exctr = Executor.executor
         if exctr is not None:
             local_host = socket.gethostname()
             libE_nodes = list(set(comm.allgather(local_host)))
-            exctr.add_comm_info(libE_nodes=libE_nodes, serial_setup=is_master)
+            exctr.add_comm_info(libE_nodes=libE_nodes, serial_setup=is_manager)
 
         # Run manager or worker code, depending
-        if is_master:
+        if is_manager:
             return libE_mpi_manager(comm, sim_specs, gen_specs, exit_criteria,
                                     persis_info, alloc_specs, libE_specs, H0)
 

--- a/libensemble/tests/regression_tests/script_test_balsam_hworld.py
+++ b/libensemble/tests/regression_tests/script_test_balsam_hworld.py
@@ -32,7 +32,7 @@ libE_specs = {'comm': MPI.COMM_WORLD,
               }
 
 nworkers = MPI.COMM_WORLD.Get_size() - 1
-is_master = MPI.COMM_WORLD.Get_rank() == 0
+is_manager = MPI.COMM_WORLD.Get_rank() == 0
 
 cores_per_task = 1
 
@@ -68,7 +68,7 @@ exit_criteria = {'elapsed_wallclock_time': 60}
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria,
                             persis_info, libE_specs=libE_specs)
 
-if is_master:
+if is_manager:
     print('\nChecking expected task status against Workers ...\n')
     calc_status_list_in = np.asarray([WORKER_DONE, WORKER_KILL_ON_ERR,
                                       WORKER_DONE, WORKER_KILL_ON_TIMEOUT,

--- a/libensemble/tests/regression_tests/test_1d_sampling.py
+++ b/libensemble/tests/regression_tests/test_1d_sampling.py
@@ -21,7 +21,7 @@ from libensemble.sim_funcs.one_d_func import one_d_example as sim_f
 from libensemble.gen_funcs.sampling import latin_hypercube_sample as gen_f
 from libensemble.tools import parse_args, save_libE_output, add_unique_random_streams
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 libE_specs['save_every_k_gens'] = 300
 
 sim_specs = {'sim_f': sim_f, 'in': ['x'], 'out': [('f', float)]}
@@ -42,7 +42,7 @@ exit_criteria = {'gen_max': 501}
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             libE_specs=libE_specs)
 
-if is_master:
+if is_manager:
     assert len(H) >= 501
     print("\nlibEnsemble with random sampling has generated enough points")
     save_libE_output(H, persis_info, __file__, nworkers)

--- a/libensemble/tests/regression_tests/test_1d_uniform_sampling_with_comm_dup.py
+++ b/libensemble/tests/regression_tests/test_1d_uniform_sampling_with_comm_dup.py
@@ -25,7 +25,7 @@ from libensemble.sim_funcs.one_d_func import one_d_example as sim_f
 from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
 from libensemble.tools import parse_args, save_libE_output, add_unique_random_streams
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 if libE_specs['comms'] != 'mpi':
     sys.exit("This test only runs with MPI -- aborting...")
@@ -37,7 +37,7 @@ libE_specs = None  # Let MPI use defaults
 
 # Check independence of default communicator from MPI.COMM_WORLD
 world = MPI.COMM_WORLD
-if not is_master:
+if not is_manager:
     world.isend(world.Get_rank(), dest=0, tag=0)
 
 sim_specs = {'sim_f': sim_f, 'in': ['x'], 'out': [('f', float)]}
@@ -59,7 +59,7 @@ exit_criteria = {'gen_max': 501}
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             libE_specs=libE_specs)
 
-if is_master:
+if is_manager:
     # assert libE_specs['comms'] == 'mpi', 'MPI default comms should be set'
     # Potential to cause a hang
     worker_ids = []

--- a/libensemble/tests/regression_tests/test_1d_with_profile_sampling.py
+++ b/libensemble/tests/regression_tests/test_1d_with_profile_sampling.py
@@ -22,7 +22,7 @@ from libensemble.sim_funcs.one_d_func import one_d_example as sim_f
 from libensemble.gen_funcs.sampling import latin_hypercube_sample as gen_f
 from libensemble.tools import parse_args, add_unique_random_streams
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 libE_specs['profile_worker'] = True
 
@@ -44,7 +44,7 @@ exit_criteria = {'gen_max': 501}
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             libE_specs=libE_specs)
 
-if is_master:
+if is_manager:
     assert len(H) >= 501
     print("\nlibEnsemble with random sampling has generated enough points")
 

--- a/libensemble/tests/regression_tests/test_active_persistent_worker_abort.py
+++ b/libensemble/tests/regression_tests/test_active_persistent_worker_abort.py
@@ -25,7 +25,7 @@ from libensemble.alloc_funcs.start_persistent_local_opt_gens import start_persis
 from libensemble.tools import parse_args, save_libE_output, add_unique_random_streams
 from libensemble.tests.regression_tests.support import uniform_or_localopt_gen_out as gen_out
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 sim_specs = {'sim_f': sim_f, 'in': ['x'], 'out': [('f', float)]}
 
@@ -57,6 +57,6 @@ if nworkers < 2:
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             alloc_specs, libE_specs)
 
-if is_master:
+if is_manager:
     assert flag == 0
     save_libE_output(H, persis_info, __file__, nworkers)

--- a/libensemble/tests/regression_tests/test_calc_exception.py
+++ b/libensemble/tests/regression_tests/test_calc_exception.py
@@ -20,7 +20,7 @@ from libensemble.libE_manager import ManagerException
 from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
 from libensemble.tools import parse_args, add_unique_random_streams
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 
 # Define sim_func
@@ -53,5 +53,5 @@ except ManagerException as e:
     print("Caught deliberate exception: {}".format(e))
     return_flag = 0
 
-if is_master:
+if is_manager:
     assert return_flag == 0

--- a/libensemble/tests/regression_tests/test_comms.py
+++ b/libensemble/tests/regression_tests/test_comms.py
@@ -24,7 +24,7 @@ from libensemble.tools import parse_args, save_libE_output, add_unique_random_st
 from libensemble.executors.mpi_executor import MPIExecutor  # Only used to get workerID in float_x1000
 exctr = MPIExecutor(auto_resources=False)
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 array_size = int(1e6)  # Size of large array in sim_specs
 rounds = 2  # Number of work units for each worker
@@ -50,7 +50,7 @@ exit_criteria = {'sim_max': sim_max, 'elapsed_wallclock_time': 300}
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             libE_specs=libE_specs)
 
-if is_master:
+if is_manager:
     assert flag == 0
     for i in range(sim_max):
         x1 = H['x'][i][0]*1000.0

--- a/libensemble/tests/regression_tests/test_deap_nsga2.py
+++ b/libensemble/tests/regression_tests/test_deap_nsga2.py
@@ -16,7 +16,7 @@ from libensemble.tools import parse_args, add_unique_random_streams
 from libensemble.sim_funcs.six_hump_camel import six_hump_camel_func
 from libensemble.gen_funcs.persistent_deap_nsga2 import deap_nsga2 as gen_f
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 
 def deap_six_hump(H, persis_info, sim_specs, _):
@@ -28,7 +28,7 @@ def deap_six_hump(H, persis_info, sim_specs, _):
     return Out, persis_info
 
 
-if is_master:
+if is_manager:
     start_time = time()
 
 assert nworkers >= 2, "Cannot run with a persistent gen_f if only one worker."
@@ -103,7 +103,7 @@ for run in range(2):
     # Perform the run
     H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs, libE_specs, H0=H0)
 
-    if is_master:
+    if is_manager:
         script_name = os.path.splitext(os.path.basename(__file__))[0]
         assert flag == 0, script_name + " didn't exit correctly"
         assert sum(H['returned']) >= exit_criteria['sim_max'], script_name + " didn't evaluate the sim_max points."

--- a/libensemble/tests/regression_tests/test_elapsed_time_abort.py
+++ b/libensemble/tests/regression_tests/test_elapsed_time_abort.py
@@ -23,7 +23,7 @@ from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
 from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.tools import parse_args, save_libE_output, add_unique_random_streams, eprint
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 sim_specs = {'sim_f': sim_f,
              'in': ['x'],
@@ -52,7 +52,7 @@ exit_criteria = {'elapsed_wallclock_time': 1}
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             libE_specs=libE_specs, alloc_specs=alloc_specs)
 
-if is_master:
+if is_manager:
     eprint(flag)
     eprint(H)
     assert flag == 2

--- a/libensemble/tests/regression_tests/test_evaluate_existing_sample.py
+++ b/libensemble/tests/regression_tests/test_evaluate_existing_sample.py
@@ -22,7 +22,7 @@ from libensemble.sim_funcs.borehole import borehole as sim_f, gen_borehole_input
 from libensemble.alloc_funcs.give_pregenerated_work import give_pregenerated_sim_work as alloc_f
 from libensemble.tools import parse_args, save_libE_output
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 sim_specs = {'sim_f': sim_f, 'in': ['x'], 'out': [('f', float)]}
 
@@ -46,7 +46,7 @@ H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria,
                             alloc_specs=alloc_specs, libE_specs=libE_specs,
                             H0=H0)
 
-if is_master:
+if is_manager:
     assert len(H) == len(H0)
     assert np.array_equal(H0['x'], H['x'])
     assert np.all(H['returned'])

--- a/libensemble/tests/regression_tests/test_executor_hworld.py
+++ b/libensemble/tests/regression_tests/test_executor_hworld.py
@@ -29,7 +29,7 @@ from libensemble.tests.regression_tests.common import build_simfunc
 # TESTSUITE_COMMS: mpi local tcp
 # TESTSUITE_NPROCS: 2 3 4
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 USE_BALSAM = False
 
@@ -47,7 +47,7 @@ else:
     use_auto_resources = True
     mess_resources = 'Auto_resources set to True'
 
-if is_master:
+if is_manager:
     print('\nCores req: {} Cores avail: {}\n  {}\n'.format(cores_all_tasks, logical_cores, mess_resources))
 
 sim_app = './my_simtask.x'
@@ -92,7 +92,7 @@ exit_criteria = {'elapsed_wallclock_time': 20}
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             libE_specs=libE_specs)
 
-if is_master:
+if is_manager:
     print('\nChecking expected task status against Workers ...\n')
 
     # Expected list: Last is zero as will not be entered into H array on

--- a/libensemble/tests/regression_tests/test_fast_alloc.py
+++ b/libensemble/tests/regression_tests/test_fast_alloc.py
@@ -24,7 +24,7 @@ from libensemble.alloc_funcs.fast_alloc import give_sim_work_first as alloc_f
 from libensemble.alloc_funcs.only_one_gen_alloc import ensure_one_active_gen as alloc_f2
 from libensemble.tools import parse_args, add_unique_random_streams
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 num_pts = 30*(nworkers - 1)
 
@@ -67,6 +67,6 @@ for time in np.append([0], np.logspace(-5, -1, 5)):
         H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria,
                                     persis_info, alloc_specs, libE_specs)
 
-        if is_master:
+        if is_manager:
             assert flag == 0
             assert len(H) == 2*num_pts

--- a/libensemble/tests/regression_tests/test_inverse_bayes_example.py
+++ b/libensemble/tests/regression_tests/test_inverse_bayes_example.py
@@ -27,7 +27,7 @@ from libensemble.alloc_funcs.inverse_bayes_allocf import only_persistent_gens_fo
 from libensemble.tools import parse_args, add_unique_random_streams
 
 # Parse args for test code
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 if nworkers < 2:
     sys.exit("Cannot run with a persistent worker if only one worker -- aborting...")
@@ -58,7 +58,7 @@ alloc_specs = {'out': [], 'alloc_f': alloc_f}
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             alloc_specs, libE_specs)
 
-if is_master:
+if is_manager:
     assert flag == 0
     # Change the last weights to correct values (H is a list on other cores and only array on manager)
     ind = 2*gen_specs['user']['subbatch_size']*gen_specs['user']['num_subbatches']

--- a/libensemble/tests/regression_tests/test_mpi_comms.py
+++ b/libensemble/tests/regression_tests/test_mpi_comms.py
@@ -15,7 +15,7 @@ from libensemble.tools import parse_args
 # TESTSUITE_COMMS: mpi
 # TESTSUITE_NPROCS: 2 4
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 assert libE_specs['comms'] == 'mpi', "This test can only be run with mpi comms -- aborting..."
 
@@ -90,8 +90,8 @@ test_exp = {1: all_ranks,
 for test_num in range(1, len(tests)+1):
     mpi_comm = tests[test_num]()
     if check_ranks(mpi_comm, test_exp, test_num):
-        is_master = (mpi_comm.Get_rank() == 0)
-        if is_master:
+        is_manager = (mpi_comm.Get_rank() == 0)
+        if is_manager:
             manager_main(mpi_comm)
         else:
             worker_main(mpi_comm)

--- a/libensemble/tests/regression_tests/test_mpi_runners.py
+++ b/libensemble/tests/regression_tests/test_mpi_runners.py
@@ -85,7 +85,7 @@ def runline_check(H, persis_info, sim_specs, libE_info):
 # --------------------------------------------------------------------
 
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 rounds = 1
 sim_app = '/path/to/fakeapp.x'
 comms = libE_specs['comms']
@@ -96,7 +96,7 @@ libE_logger.set_filename(log_file)
 
 # For varying size test - relate node count to nworkers
 node_file = 'nodelist_mpi_runnerscomms_' + str(comms) + '_wrks_' + str(nworkers)
-if is_master:
+if is_manager:
     if os.path.exists(node_file):
         os.remove(node_file)
     with open(node_file, 'w') as f:

--- a/libensemble/tests/regression_tests/test_nan_func_old_aposmm.py
+++ b/libensemble/tests/regression_tests/test_nan_func_old_aposmm.py
@@ -21,7 +21,7 @@ from support import nan_func as sim_f, aposmm_gen_out as gen_out
 from libensemble.gen_funcs.old_aposmm import aposmm_logic as gen_f
 from libensemble.tools import parse_args, save_libE_output, add_unique_random_streams
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 n = 2
 
 sim_specs = {'sim_f': sim_f,
@@ -51,7 +51,7 @@ exit_criteria = {'sim_max': 100, 'elapsed_wallclock_time': 300}
 # Perform the run
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             libE_specs=libE_specs)
-if is_master:
+if is_manager:
     assert flag == 0
     assert np.all(~H['local_pt'])
 

--- a/libensemble/tests/regression_tests/test_old_aposmm_one_residual_at_a_time.py
+++ b/libensemble/tests/regression_tests/test_old_aposmm_one_residual_at_a_time.py
@@ -27,7 +27,7 @@ from libensemble.alloc_funcs.fast_alloc_and_pausing import give_sim_work_first a
 from libensemble.tools import parse_args, save_libE_output, add_unique_random_streams
 from libensemble.tests.regression_tests.support import persis_info_3 as persis_info, aposmm_gen_out as gen_out
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 # Declare the run parameters/functions
 m = 214
@@ -76,7 +76,7 @@ exit_criteria = {'sim_max': budget}
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             alloc_specs, libE_specs)
 
-if is_master:
+if is_manager:
     assert flag == 0
     assert len(H) >= budget
     save_libE_output(H, persis_info, __file__, nworkers)

--- a/libensemble/tests/regression_tests/test_old_aposmm_pounders.py
+++ b/libensemble/tests/regression_tests/test_old_aposmm_pounders.py
@@ -26,7 +26,7 @@ from libensemble.gen_funcs.old_aposmm import aposmm_logic as gen_f
 from libensemble.tests.regression_tests.support import persis_info_2 as persis_info, aposmm_gen_out as gen_out
 from libensemble.tools import parse_args, save_libE_output, add_unique_random_streams
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 # Declare the run parameters/functions
 m = 214
@@ -63,7 +63,7 @@ exit_criteria = {'sim_max': budget}
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             libE_specs=libE_specs)
 
-if is_master:
+if is_manager:
     assert flag == 0
     assert len(H) >= budget
 

--- a/libensemble/tests/regression_tests/test_old_aposmm_pounders_splitcomm.py
+++ b/libensemble/tests/regression_tests/test_old_aposmm_pounders_splitcomm.py
@@ -29,9 +29,9 @@ from libensemble.tests.regression_tests.common import mpi_comm_split
 from libensemble.tools import parse_args, save_libE_output, add_unique_random_streams
 
 num_comms = 2  # Must have atleast num_comms*2 processors
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 libE_specs['comm'], sub_comm_number = mpi_comm_split(num_comms)
-is_master = (libE_specs['comm'].Get_rank() == 0)
+is_manager = (libE_specs['comm'].Get_rank() == 0)
 
 # Declare the run parameters/functions
 m = 214
@@ -68,7 +68,7 @@ exit_criteria = {'sim_max': budget}
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             libE_specs=libE_specs)
 
-if is_master:
+if is_manager:
     assert flag == 0
     assert len(H) >= budget
 

--- a/libensemble/tests/regression_tests/test_old_aposmm_pounders_subcomm.py
+++ b/libensemble/tests/regression_tests/test_old_aposmm_pounders_subcomm.py
@@ -27,14 +27,14 @@ from libensemble.tests.regression_tests.support import persis_info_2 as persis_i
 from libensemble.tests.regression_tests.common import mpi_comm_excl
 from libensemble.tools import parse_args, save_libE_output, add_unique_random_streams
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 libE_specs['comm'], mpi_comm_null = mpi_comm_excl()
 
 if libE_specs['comm'] == mpi_comm_null:
     is_excluded = True
-    is_master = False
+    is_manager = False
 else:
-    is_master = (libE_specs['comm'].Get_rank() == 0)
+    is_manager = (libE_specs['comm'].Get_rank() == 0)
     is_excluded = False
 
 # Declare the run parameters/functions
@@ -72,7 +72,7 @@ exit_criteria = {'sim_max': budget}
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             libE_specs=libE_specs)
 
-if is_master:
+if is_manager:
     assert flag == 0
     assert len(H) >= budget
 

--- a/libensemble/tests/regression_tests/test_old_aposmm_sim_dirs.py
+++ b/libensemble/tests/regression_tests/test_old_aposmm_sim_dirs.py
@@ -30,7 +30,7 @@ from libensemble.tests.regression_tests.support import (persis_info_2 as persis_
                                                         branin_vals_and_minima as M)
 from libensemble.tools import parse_args, save_libE_output, add_unique_random_streams
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 libE_specs['sim_input_dir'] = resource_filename('libensemble.sim_funcs.branin', '')  # to be copied by each worker
 
@@ -81,7 +81,7 @@ for run in range(2):
     H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria,
                                 persis_info, libE_specs=libE_specs)
 
-    if is_master:
+    if is_manager:
         M = M[M[:, -1].argsort()]  # Sort by function values (last column)
         k = M.shape[0]
         tol = 1e-5

--- a/libensemble/tests/regression_tests/test_old_aposmm_with_gradients.py
+++ b/libensemble/tests/regression_tests/test_old_aposmm_with_gradients.py
@@ -31,7 +31,7 @@ from libensemble.tests.regression_tests.support import (persis_info_1 as persis_
                                                         aposmm_gen_out as gen_out,
                                                         six_hump_camel_minima as minima)
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 n = 2
 sim_specs = {'sim_f': sim_f,
@@ -71,14 +71,14 @@ if libE_specs['comms'] == 'mpi':
     libE_abort = libE_mpi_abort
 
 # Perform the run (TCP worker mode)
-if libE_specs['comms'] == 'tcp' and not is_master:
+if libE_specs['comms'] == 'tcp' and not is_manager:
     run = int(sys.argv[-1])
     libE_tcp_worker(sim_specs, gen_specs[run], libE_specs)
     quit()
 
 # Perform the run
 for run in range(3):
-    if libE_specs['comms'] == 'tcp' and is_master:
+    if libE_specs['comms'] == 'tcp' and is_manager:
         libE_specs['worker_cmd'].append(str(run))
 
     if run == 1:
@@ -111,7 +111,7 @@ for run in range(3):
     H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria,
                                 persis_info, alloc_specs, libE_specs)
 
-    if is_master:
+    if is_manager:
         if flag != 0:
             print("Exit was not on convergence (code {})".format(flag), flush=True)
             libE_abort()

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_dfols.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_dfols.py
@@ -27,7 +27,7 @@ from libensemble.gen_funcs.persistent_aposmm import aposmm as gen_f
 from libensemble.alloc_funcs.persistent_aposmm_alloc import persistent_aposmm_alloc as alloc_f
 from libensemble.tools import parse_args, save_libE_output, add_unique_random_streams
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 if nworkers < 2:
     sys.exit("Cannot run with a persistent worker if only one worker -- aborting...")
@@ -72,7 +72,7 @@ exit_criteria = {'sim_max': 1000}
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             alloc_specs, libE_specs)
 
-if is_master:
+if is_manager:
     assert persis_info[1].get('run_order'), "Run_order should have been given back"
     assert flag == 0
     assert len(H) >= budget

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_exception.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_exception.py
@@ -43,7 +43,7 @@ def assertion(passed):
         print("\n\nException received as expected")
 
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 if nworkers < 2:
     sys.exit("Cannot run with a persistent worker if only one worker -- aborting...")
@@ -79,11 +79,11 @@ try:
     H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                                 alloc_specs, libE_specs)
 except Exception as e:
-    if is_master:
+    if is_manager:
         if e.args[1] == 'NLopt roundoff-limited':
             assertion(True)
         else:
             assertion(False)
 else:
-    if is_master:
+    if is_manager:
         assertion(False)

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_external_localopt.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_external_localopt.py
@@ -40,9 +40,9 @@ from time import time
 
 np.set_printoptions(precision=16)
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
-if is_master:
+if is_manager:
     start_time = time()
 
 if nworkers < 2:
@@ -79,7 +79,7 @@ exit_criteria = {'sim_max': 500}
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             alloc_specs, libE_specs)
 
-if is_master:
+if is_manager:
     print('[Manager]:', H[np.where(H['local_min'])]['x'])
     print('[Manager]: Time taken =', time() - start_time, flush=True)
 

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_nlopt.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_nlopt.py
@@ -31,9 +31,9 @@ from libensemble.tools import parse_args, save_libE_output, add_unique_random_st
 from libensemble.tests.regression_tests.support import six_hump_camel_minima as minima
 from time import time
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
-if is_master:
+if is_manager:
     start_time = time()
 
 if nworkers < 2:
@@ -72,7 +72,7 @@ exit_criteria = {'sim_max': 1000}
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             alloc_specs, libE_specs)
 
-if is_master:
+if is_manager:
     print('[Manager]:', H[np.where(H['local_min'])]['x'])
     print('[Manager]: Time taken =', time() - start_time, flush=True)
 

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_periodic.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_periodic.py
@@ -28,7 +28,7 @@ from libensemble.alloc_funcs.persistent_aposmm_alloc import persistent_aposmm_al
 from libensemble.tools import parse_args, add_unique_random_streams
 
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 if nworkers < 2:
     sys.exit("Cannot run with a persistent worker if only one worker -- aborting...")
@@ -73,7 +73,7 @@ for run in range(2):
     H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                                 alloc_specs, libE_specs)
 
-    if is_master:
+    if is_manager:
         assert persis_info[1].get('run_order'), "Run_order should have been given back"
         min_ids = np.where(H['local_min'])
 

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_pounders.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_pounders.py
@@ -29,7 +29,7 @@ from libensemble.gen_funcs.sampling import lhs_sample
 from libensemble.alloc_funcs.persistent_aposmm_alloc import persistent_aposmm_alloc as alloc_f
 from libensemble.tools import parse_args, save_libE_output, add_unique_random_streams
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 if nworkers < 2:
     sys.exit("Cannot run with a persistent worker if only one worker -- aborting...")
@@ -84,7 +84,7 @@ gen_specs['user']['sample_points'] = sample_points*(ub-lb) + lb
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             alloc_specs, libE_specs)
 
-if is_master:
+if is_manager:
     assert flag == 0
     assert len(H) >= budget
 

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_scipy.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_scipy.py
@@ -30,9 +30,9 @@ from libensemble.tools import parse_args, save_libE_output, add_unique_random_st
 from libensemble.tests.regression_tests.support import six_hump_camel_minima as minima
 from time import time
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
-if is_master:
+if is_manager:
     start_time = time()
 
 if nworkers < 2:
@@ -79,7 +79,7 @@ for run in range(2):
     H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                                 alloc_specs, libE_specs)
 
-    if is_master:
+    if is_manager:
         print('[Manager]:', H[np.where(H['local_min'])]['x'])
         print('[Manager]: Time taken =', time() - start_time, flush=True)
 
@@ -111,5 +111,5 @@ sim_specs['out'] = [('f', float)]
 
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs, libE_specs)
 
-if is_master:
+if is_manager:
     assert np.sum(H['returned']) >= exit_criteria['sim_max'], "Run didn't finish"

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_tao_blmvm.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_tao_blmvm.py
@@ -31,9 +31,9 @@ from libensemble.tools import parse_args, save_libE_output, add_unique_random_st
 from libensemble.tests.regression_tests.support import six_hump_camel_minima as minima
 from time import time
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
-if is_master:
+if is_manager:
     start_time = time()
 
 if nworkers < 2:
@@ -72,7 +72,7 @@ exit_criteria = {'sim_max': 1000}
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             alloc_specs, libE_specs)
 
-if is_master:
+if is_manager:
     print('[Manager]:', H[np.where(H['local_min'])]['x'])
     print('[Manager]: Time taken =', time() - start_time, flush=True)
 

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_tao_nm.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_tao_nm.py
@@ -28,7 +28,7 @@ from libensemble.gen_funcs.persistent_aposmm import aposmm as gen_f
 from libensemble.alloc_funcs.persistent_aposmm_alloc import persistent_aposmm_alloc as alloc_f
 from libensemble.tools import parse_args, add_unique_random_streams
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 if nworkers < 2:
     sys.exit("Cannot run with a persistent worker if only one worker -- aborting...")
@@ -60,7 +60,7 @@ exit_criteria = {'sim_max': 1000}
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             alloc_specs, libE_specs)
 
-if is_master:
+if is_manager:
     print('[Manager]:', H[np.where(H['local_min'])]['x'])
     assert np.sum(~H['local_pt']) > 100, "Had to do at least 100 sample points"
     assert np.sum(H['local_pt']) > 100, "Why didn't at least 100 local points occur?"

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_timeout.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_timeout.py
@@ -23,7 +23,7 @@ from libensemble.gen_funcs.persistent_aposmm import aposmm as gen_f
 from libensemble.alloc_funcs.persistent_aposmm_alloc import persistent_aposmm_alloc as alloc_f
 from libensemble.tools import parse_args, add_unique_random_streams, save_libE_output
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 if nworkers < 2:
     sys.exit("Cannot run with a persistent worker if only one worker -- aborting...")
@@ -62,7 +62,7 @@ persis_info = add_unique_random_streams({}, nworkers + 1)
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             alloc_specs, libE_specs)
 
-if is_master:
+if is_manager:
     assert flag == 2, "Test should have timed out"
     assert persis_info[1].get('run_order'), "Run_order should have been given back"
     min_ids = np.where(H['local_min'])

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_with_grad.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_with_grad.py
@@ -31,9 +31,9 @@ from libensemble.tools import parse_args, save_libE_output, add_unique_random_st
 from libensemble.tests.regression_tests.support import six_hump_camel_minima as minima
 from time import time
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
-if is_master:
+if is_manager:
     start_time = time()
 
 if nworkers < 2:
@@ -89,7 +89,7 @@ for i in range(sample_size):
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             alloc_specs, libE_specs, H0=H0)
 
-if is_master:
+if is_manager:
     print('[Manager]:', H[np.where(H['local_min'])]['x'])
     print('[Manager]: Time taken =', time() - start_time, flush=True)
 

--- a/libensemble/tests/regression_tests/test_persistent_fd_param_finder.py
+++ b/libensemble/tests/regression_tests/test_persistent_fd_param_finder.py
@@ -23,7 +23,7 @@ from libensemble.gen_funcs.persistent_fd_param_finder import fd_param_finder as 
 from libensemble.alloc_funcs.start_fd_persistent import finite_diff_alloc as alloc_f
 from libensemble.tools import parse_args, save_libE_output, add_unique_random_streams
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 if nworkers < 2:
     sys.exit("Cannot run with a persistent worker if only one worker -- aborting...")
@@ -62,7 +62,7 @@ exit_criteria = {'gen_max': 1000}
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             alloc_specs, libE_specs)
 
-if is_master:
+if is_manager:
     assert len(H) < exit_criteria['gen_max'], "Problem didn't stop early, which should have been the case."
     assert np.all(persis_info[1]['Fnoise'] > 0), "gen_f didn't find noise for all F_i components."
 

--- a/libensemble/tests/regression_tests/test_persistent_tasmanian.py
+++ b/libensemble/tests/regression_tests/test_persistent_tasmanian.py
@@ -20,9 +20,9 @@ from libensemble.alloc_funcs.start_only_persistent import only_persistent_gens a
 from libensemble.tools import parse_args, save_libE_output, add_unique_random_streams
 from time import time
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
-if is_master:
+if is_manager:
     start_time = time()
 
 if nworkers < 2:
@@ -56,7 +56,7 @@ for run in range(2):
     H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                                 alloc_specs, libE_specs)
 
-    if is_master:
+    if is_manager:
         if run == 0:
             true_val = six_hump_camel_func(gen_specs['user']['x0'])
 

--- a/libensemble/tests/regression_tests/test_persistent_uniform_sampling.py
+++ b/libensemble/tests/regression_tests/test_persistent_uniform_sampling.py
@@ -24,7 +24,7 @@ from libensemble.gen_funcs.persistent_uniform_sampling import persistent_uniform
 from libensemble.alloc_funcs.start_only_persistent import only_persistent_gens as alloc_f
 from libensemble.tools import parse_args, save_libE_output, add_unique_random_streams
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 if nworkers < 2:
     sys.exit("Cannot run with a persistent worker if only one worker -- aborting...")
@@ -52,7 +52,7 @@ exit_criteria = {'gen_max': 40, 'elapsed_wallclock_time': 300}
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             alloc_specs, libE_specs)
 
-if is_master:
+if is_manager:
     assert len(np.unique(H['gen_time'])) == 2
 
     save_libE_output(H, persis_info, __file__, nworkers)

--- a/libensemble/tests/regression_tests/test_persistent_uniform_sampling_async.py
+++ b/libensemble/tests/regression_tests/test_persistent_uniform_sampling_async.py
@@ -24,7 +24,7 @@ from libensemble.gen_funcs.persistent_uniform_sampling import persistent_uniform
 from libensemble.alloc_funcs.start_only_persistent import only_persistent_gens as alloc_f
 from libensemble.tools import parse_args, save_libE_output, add_unique_random_streams
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 if nworkers < 2:
     sys.exit("Cannot run with a persistent worker if only one worker -- aborting...")
@@ -55,7 +55,7 @@ exit_criteria = {'gen_max': 100, 'elapsed_wallclock_time': 300}
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             alloc_specs, libE_specs)
 
-if is_master:
+if is_manager:
     [_, counts] = np.unique(H['gen_time'], return_counts=True)
     assert counts[0] == nworkers - 1, "The first gen_time should be common among gen_batch_size number of points"
     assert len(np.unique(counts)) > 1, "There is no variablitiy in the gen_times but there should be for the async case"

--- a/libensemble/tests/regression_tests/test_sim_dirs_per_calc.py
+++ b/libensemble/tests/regression_tests/test_sim_dirs_per_calc.py
@@ -22,7 +22,7 @@ from libensemble.tests.regression_tests.support import write_sim_func as sim_f
 from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
 from libensemble.tools import parse_args, add_unique_random_streams
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 sim_input_dir = './sim_input_dir'
 dir_to_copy = sim_input_dir + '/copy_this'
@@ -31,7 +31,7 @@ c_ensemble = './ensemble_calcdirs_w' + str(nworkers) + '_' + libE_specs.get('com
 print('creating ensemble dir: ', c_ensemble, flush=True)
 
 for dir in [sim_input_dir, dir_to_copy, dir_to_symlink]:
-    if is_master and not os.path.isdir(dir):
+    if is_manager and not os.path.isdir(dir):
         os.makedirs(dir, exist_ok=True)
 
 libE_specs['sim_dirs_make'] = True
@@ -58,7 +58,7 @@ exit_criteria = {'sim_max': 21}
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria,
                             persis_info, libE_specs=libE_specs)
 
-if is_master:
+if is_manager:
     assert os.path.isdir(c_ensemble), 'Ensemble directory {} not created.'.format(c_ensemble)
     dir_sum = sum(['worker' in i for i in os.listdir(c_ensemble)])
     assert dir_sum == exit_criteria['sim_max'], \

--- a/libensemble/tests/regression_tests/test_sim_dirs_per_worker.py
+++ b/libensemble/tests/regression_tests/test_sim_dirs_per_worker.py
@@ -22,7 +22,7 @@ from libensemble.tests.regression_tests.support import write_sim_func as sim_f
 from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
 from libensemble.tools import parse_args, add_unique_random_streams
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 sim_input_dir = './sim_input_dir'
 dir_to_copy = sim_input_dir + '/copy_this'
@@ -31,7 +31,7 @@ w_ensemble = '../ensemble_workdirs_w' + str(nworkers) + '_' + libE_specs.get('co
 print('creating ensemble dir: ', w_ensemble, flush=True)
 
 for dir in [sim_input_dir, dir_to_copy, dir_to_symlink]:
-    if is_master and not os.path.isdir(dir):
+    if is_manager and not os.path.isdir(dir):
         os.makedirs(dir, exist_ok=True)
 
 libE_specs['sim_dirs_make'] = True
@@ -58,7 +58,7 @@ exit_criteria = {'sim_max': 21}
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria,
                             persis_info, libE_specs=libE_specs)
 
-if is_master:
+if is_manager:
     assert os.path.isdir(w_ensemble), 'Ensemble directory {} not created.'\
                                       .format(w_ensemble)
     worker_dir_sum = sum(['worker' in i for i in os.listdir(w_ensemble)])

--- a/libensemble/tests/regression_tests/test_sim_dirs_with_exception.py
+++ b/libensemble/tests/regression_tests/test_sim_dirs_with_exception.py
@@ -23,7 +23,7 @@ from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
 from libensemble.tools import parse_args, add_unique_random_streams
 from libensemble.libE_manager import ManagerException
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 sim_input_dir = './sim_input_dir'
 dir_to_copy = sim_input_dir + '/copy_this'
@@ -67,5 +67,5 @@ except ManagerException as e:
     print("Caught deliberate exception: {}".format(e))
     return_flag = 0
 
-if is_master:
+if is_manager:
     assert return_flag == 0

--- a/libensemble/tests/regression_tests/test_sim_dirs_with_gen_dirs.py
+++ b/libensemble/tests/regression_tests/test_sim_dirs_with_gen_dirs.py
@@ -22,7 +22,7 @@ from libensemble.tests.regression_tests.support import write_sim_func as sim_f
 from libensemble.tests.regression_tests.support import write_uniform_gen_func as gen_f
 from libensemble.tools import parse_args, add_unique_random_streams
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 sim_input_dir = './sim_input_dir'
 dir_to_copy_sim = sim_input_dir + '/copy_this_sim'
@@ -37,7 +37,7 @@ print('creating ensemble dir: ', c_ensemble, flush=True)
 
 for dir in [sim_input_dir, dir_to_copy_sim, dir_to_symlink_sim,
             gen_input_dir, dir_to_copy_gen, dir_to_symlink_gen]:
-    if is_master and not os.path.isdir(dir):
+    if is_manager and not os.path.isdir(dir):
         os.makedirs(dir, exist_ok=True)
 
 libE_specs['sim_dirs_make'] = True
@@ -85,7 +85,7 @@ def check_copied(type):
         'All input files not copied or symlinked to each {} calc dir'.format(type)
 
 
-if is_master:
+if is_manager:
     assert os.path.isdir(c_ensemble), 'Ensemble directory {} not created.'.format(c_ensemble)
     sim_dir_sum = sum(['sim' in i for i in os.listdir(c_ensemble)])
     assert sim_dir_sum == exit_criteria['sim_max'], \

--- a/libensemble/tests/regression_tests/test_sim_input_dir_option.py
+++ b/libensemble/tests/regression_tests/test_sim_input_dir_option.py
@@ -22,14 +22,14 @@ from libensemble.tests.regression_tests.support import write_sim_func as sim_f
 from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
 from libensemble.tools import parse_args, add_unique_random_streams
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 sim_input_dir = './sim_input_dir'
 dir_to_copy = sim_input_dir + '/copy_this'
 o_ensemble = './ensemble_inputdir_w' + str(nworkers) + '_' + libE_specs.get('comms')
 
 for dir in [sim_input_dir, dir_to_copy]:
-    if is_master and not os.path.isdir(dir):
+    if is_manager and not os.path.isdir(dir):
         os.makedirs(dir, exist_ok=True)
 
 libE_specs['sim_input_dir'] = sim_input_dir
@@ -55,7 +55,7 @@ exit_criteria = {'sim_max': 21}
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria,
                             persis_info, libE_specs=libE_specs)
 
-if is_master:
+if is_manager:
     assert os.path.isdir(o_ensemble), \
         'Ensemble directory {} not created.'.format(o_ensemble)
     assert os.path.basename(dir_to_copy) in os.listdir(o_ensemble), \

--- a/libensemble/tests/regression_tests/test_uniform_sampling.py
+++ b/libensemble/tests/regression_tests/test_uniform_sampling.py
@@ -23,7 +23,7 @@ from libensemble.gen_funcs.sampling import uniform_random_sample
 from libensemble.tools import parse_args, save_libE_output, add_unique_random_streams
 from libensemble.tests.regression_tests.support import six_hump_camel_minima as minima
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 libE_specs['save_every_k_sims'] = 400
 libE_specs['save_every_k_gens'] = 300
 
@@ -50,7 +50,7 @@ exit_criteria = {'gen_max': 501, 'elapsed_wallclock_time': 300}
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             libE_specs=libE_specs)
 
-if is_master:
+if is_manager:
     assert flag == 0
 
     tol = 0.1

--- a/libensemble/tests/regression_tests/test_uniform_sampling_one_residual_at_a_time.py
+++ b/libensemble/tests/regression_tests/test_uniform_sampling_one_residual_at_a_time.py
@@ -29,7 +29,7 @@ from libensemble.alloc_funcs.fast_alloc_and_pausing import give_sim_work_first
 from libensemble.tests.regression_tests.support import persis_info_3 as persis_info
 from libensemble.tools import parse_args, save_libE_output, add_unique_random_streams
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 if libE_specs['comms'] == 'tcp':
     # Can't use the same interface for manager and worker if we want
     # repeated calls to libE -- the manager sets up a different server
@@ -80,7 +80,7 @@ exit_criteria = {'sim_max': budget, 'elapsed_wallclock_time': 300}
 # Perform the run
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             alloc_specs, libE_specs)
-if is_master:
+if is_manager:
     assert flag == 0
     save_libE_output(H, persis_info, __file__, nworkers)
 
@@ -89,7 +89,7 @@ alloc_specs['user'].pop('stop_on_NaNs')
 persis_info = deepcopy(persis_info_safe)
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             alloc_specs, libE_specs)
-if is_master:
+if is_manager:
     assert flag == 0
 
 # Perform the run also not stopping on partial fvec evals
@@ -97,5 +97,5 @@ alloc_specs['user'].pop('stop_partial_fvec_eval')
 persis_info = deepcopy(persis_info_safe)
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             alloc_specs, libE_specs)
-if is_master:
+if is_manager:
     assert flag == 0

--- a/libensemble/tests/regression_tests/test_uniform_sampling_then_persistent_localopt_runs.py
+++ b/libensemble/tests/regression_tests/test_uniform_sampling_then_persistent_localopt_runs.py
@@ -26,7 +26,7 @@ from libensemble.tests.regression_tests.support import uniform_or_localopt_gen_o
 from libensemble.tools import parse_args, save_libE_output, add_unique_random_streams
 from libensemble.tests.regression_tests.support import six_hump_camel_minima as minima
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 if nworkers < 2:
     sys.exit("Cannot run with a persistent worker if only one worker -- aborting...")
@@ -58,7 +58,7 @@ exit_criteria = {'sim_max': 1000, 'elapsed_wallclock_time': 300}
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             alloc_specs, libE_specs)
 
-if is_master:
+if is_manager:
     assert flag == 0
 
     tol = 0.1

--- a/libensemble/tests/regression_tests/test_uniform_sampling_with_different_resources.py
+++ b/libensemble/tests/regression_tests/test_uniform_sampling_with_different_resources.py
@@ -30,7 +30,7 @@ from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.tools import parse_args, save_libE_output, add_unique_random_streams
 from libensemble.executors.mpi_executor import MPIExecutor
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 libE_specs['sim_dirs_make'] = True
 libE_specs['ensemble_dir_path'] = './ensemble_diff_nodes_w' + str(nworkers)
@@ -48,7 +48,7 @@ args = parser.parse_args()
 try:
     libE_machinefile = open(args.machinefile).read().splitlines()
 except (TypeError, NameError):
-    if is_master:
+    if is_manager:
         print("WARNING: No machine file provided - defaulting to local node")
     libE_machinefile = [MPI.Get_processor_name()]*MPI.COMM_WORLD.Get_size()
 
@@ -91,7 +91,7 @@ exit_criteria = {'sim_max': 40, 'elapsed_wallclock_time': 300}
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             libE_specs=libE_specs, alloc_specs=alloc_specs)
 
-if is_master:
+if is_manager:
     assert flag == 0
 
     save_libE_output(H, persis_info, __file__, nworkers)

--- a/libensemble/tests/regression_tests/test_vtmop.py
+++ b/libensemble/tests/regression_tests/test_vtmop.py
@@ -57,7 +57,7 @@ def sim_f(H, *unused):
 
 
 # Set up the problem
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 lower_bounds = lower*np.ones(num_dims)
 upper_bounds = upper*np.ones(num_dims)
 
@@ -156,7 +156,7 @@ for run in range(3):
         except OSError:
             pass
 
-        if is_master:
+        if is_manager:
             os.rename('vtmop.chkpt_finishing_' + s1, 'vtmop.chkpt')
             np.save('H_for_vtmop_restart.npy', H)
             open('manager_done_file', 'w').close()
@@ -186,8 +186,8 @@ for run in range(3):
     H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                                 alloc_specs=alloc_specs, libE_specs=libE_specs, H0=H0)
 
-    # The master takes care of checkpointing/output
-    if is_master:
+    # The manager takes care of checkpointing/output
+    if is_manager:
         # Renaming vtmop checkpointing file, if needed for later use.
         timer.start()
         s1 = timer.date_start.replace(' ', '_')

--- a/libensemble/tests/regression_tests/test_worker_exceptions.py
+++ b/libensemble/tests/regression_tests/test_worker_exceptions.py
@@ -21,7 +21,7 @@ from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
 from libensemble.libE_manager import ManagerException
 from libensemble.tools import parse_args, add_unique_random_streams
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 n = 2
 
 sim_specs = {'sim_f': sim_f, 'in': ['x'], 'out': [('f', float)]}
@@ -50,5 +50,5 @@ except ManagerException as e:
     print("Caught deliberate exception: {}".format(e))
     return_flag = 0
 
-if is_master:
+if is_manager:
     assert return_flag == 0

--- a/libensemble/tests/regression_tests/test_zero_resource_workers.py
+++ b/libensemble/tests/regression_tests/test_zero_resource_workers.py
@@ -87,7 +87,7 @@ def runline_check(H, persis_info, sim_specs, libE_info):
 # --------------------------------------------------------------------
 
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 rounds = 1
 sim_app = '/path/to/fakeapp.x'
 comms = libE_specs['comms']
@@ -104,7 +104,7 @@ nsim_workers = nworkers-len(in_place)
 comms = libE_specs['comms']
 nodes_per_worker = 2
 node_file = 'nodelist_zero_resource_workers_' + str(comms) + '_wrks_' + str(nworkers)
-if is_master:
+if is_manager:
     if os.path.exists(node_file):
         os.remove(node_file)
     with open(node_file, 'w') as f:

--- a/libensemble/tests/scaling_tests/forces/run_libe_forces.py
+++ b/libensemble/tests/scaling_tests/forces/run_libe_forces.py
@@ -23,9 +23,9 @@ else:
 
 libE_logger.set_level('INFO')  # INFO is now default
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
-if is_master:
+if is_manager:
     print('\nRunning with {} workers\n'.format(nworkers))
 
 sim_app = os.path.join(os.getcwd(), 'forces.x')
@@ -101,11 +101,11 @@ try:
                                 libE_specs=libE_specs)
 
 except ManagerException:
-    if is_master and sim_specs['user']['fail_on_sim']:
+    if is_manager and sim_specs['user']['fail_on_sim']:
         check_log_exception()
         test_libe_stats('Exception occurred\n')
 else:
-    if is_master:
+    if is_manager:
         save_libE_output(H, persis_info, __file__, nworkers)
         if sim_specs['user']['fail_on_submit']:
             test_libe_stats('Task Failed\n')

--- a/libensemble/tests/scaling_tests/warpx/run_libensemble_on_warpx.py
+++ b/libensemble/tests/scaling_tests/warpx/run_libensemble_on_warpx.py
@@ -58,7 +58,7 @@ else:
 
 libE_logger.set_level('INFO')
 
-nworkers, is_master, libE_specs, _ = parse_args()
+nworkers, is_manager, libE_specs, _ = parse_args()
 
 # Set to full path of warp executable
 sim_app = machine_specs['sim_app']
@@ -219,5 +219,5 @@ H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria,
                             persis_info, alloc_specs, libE_specs)
 
 # Save results to numpy file
-if is_master:
+if is_manager:
     save_libE_output(H, persis_info, __file__, nworkers)

--- a/libensemble/tools/parse_args.py
+++ b/libensemble/tools/parse_args.py
@@ -33,9 +33,9 @@ def _mpi_parse_args(args):
     "Parses arguments for MPI comms."
     from mpi4py import MPI
     nworkers = MPI.COMM_WORLD.Get_size()-1
-    is_master = MPI.COMM_WORLD.Get_rank() == 0
+    is_manager = MPI.COMM_WORLD.Get_rank() == 0
     libE_specs = {'comm': MPI.COMM_WORLD, 'comms': 'mpi'}
-    return nworkers, is_master, libE_specs, args.tester_args
+    return nworkers, is_manager, libE_specs, args.tester_args
 
 
 def _local_parse_args(args):
@@ -100,7 +100,7 @@ def parse_args():
     .. code-block:: python
 
         from libensemble.tools import parse_args
-        nworkers, is_master, libE_specs, misc_args = parse_args()
+        nworkers, is_manager, libE_specs, misc_args = parse_args()
 
     From the shell::
 
@@ -123,7 +123,7 @@ def parse_args():
     nworkers: :obj:`int`
         Number of workers libEnsemble will inititate
 
-    is_master: :obj:`boolean`
+    is_manager: :obj:`boolean`
         Indicates whether the current process is the manager process
 
     libE_specs: :obj:`dict`
@@ -140,7 +140,7 @@ def parse_args():
         'client': _client_parse_args}
     if args.pwd is not None:
         os.chdir(args.pwd)
-    nworkers, is_master, libE_specs, tester_args = front_ends[args.comms or 'mpi'](args)
-    if is_master and unknown:
+    nworkers, is_manager, libE_specs, tester_args = front_ends[args.comms or 'mpi'](args)
+    if is_manager and unknown:
         logger.warning('parse_args ignoring unrecognized arguments: {}'.format(' '.join(unknown)))
-    return nworkers, is_master, libE_specs, tester_args
+    return nworkers, is_manager, libE_specs, tester_args


### PR DESCRIPTION
In libEnsemble, we've been using "manager" instead of "master" for the central process coordinating the "workers" work. Just trying to be consistent with this.