### PR TITLE
Fix crash when running on Windows

### DIFF
--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -16,6 +16,7 @@ is dumped to file, and MPI abort is called.
 __all__ = ['libE']
 
 import os
+import platform
 import logging
 import random
 import socket
@@ -314,7 +315,7 @@ def libE_local(sim_specs, gen_specs, exit_criteria,
     # These crashes haven't yet been observed with libE, but with 'spawn' runs,
     #  warnings about leaked semaphore objects are displayed instead.
     # The next several statements enforce 'fork' on macOS (Python 3.8)
-    if os.uname().sysname == 'Darwin':
+    if platform.system() == 'Darwin':
         from multiprocessing import set_start_method
         set_start_method('fork', force=True)
 


### PR DESCRIPTION
Hi all,

I have been testing a bit libEnsemble for a project here at DESY and so far I'm very impressed with it. I have however found a small issue when trying to run it also on my Windows laptop.

This PR fixes a small bug that causes libEnsemble to crash when running on a Windows system.

The crash happens because of a call to `os.uname` (introduced in https://github.com/Libensemble/libensemble/pull/503), which is only available in Unix systems. The fix here simply changes this call to `platform.system`, which works also on Windows. I have not been able to test this myself, but in principle `platform.system()` should still return `'Darwin'` when running on a Mac.