### PR TITLE
Feature/better h0 support

### DIFF
--- a/libensemble/alloc_funcs/give_pregenerated_work.py
+++ b/libensemble/alloc_funcs/give_pregenerated_work.py
@@ -11,8 +11,8 @@ def give_pregenerated_sim_work(W, H, sim_specs, gen_specs, alloc_specs, persis_i
     """
 
     Work = {}
-    if not persis_info:
-        persis_info['next_to_give'] = 0
+    # Unless already defined, initialize next_to_give to be the first point in H
+    persis_info['next_to_give'] = persis_info.get('next_to_give', 0)
 
     if persis_info['next_to_give'] >= len(H):
         return Work, persis_info, 1

--- a/libensemble/alloc_funcs/give_pregenerated_work.py
+++ b/libensemble/alloc_funcs/give_pregenerated_work.py
@@ -14,11 +14,15 @@ def give_pregenerated_sim_work(W, H, sim_specs, gen_specs, alloc_specs, persis_i
     if not persis_info:
         persis_info['next_to_give'] = 0
 
-    assert persis_info['next_to_give'] < len(H), 'No more work to give inside give_pregenerated_sim_work.'
+    if persis_info['next_to_give'] >= len(H):
+        return Work, persis_info, 1
 
     for i in avail_worker_ids(W):
         # Give sim work
         sim_work(Work, i, sim_specs['in'], [persis_info['next_to_give']], [])
         persis_info['next_to_give'] += 1
+
+        if persis_info['next_to_give'] >= len(H):
+            break
 
     return Work, persis_info

--- a/libensemble/history.py
+++ b/libensemble/history.py
@@ -51,7 +51,7 @@ class History:
 
         # Combine all 'out' fields (if they exist) in sim_specs, gen_specs, or alloc_specs
         dtype_list = list(set(libE_fields + sum([k['out'] for k in [sim_specs, alloc_specs, gen_specs] if k], [])))
-        H = np.zeros(L + len(H0), dtype=dtype_list)
+        H = np.zeros(L + len(H0), dtype=dtype_list)  # This may be more history than is needed if H0 has un-given points
 
         if len(H0):
             # Prepend H with H0
@@ -63,15 +63,15 @@ class History:
                 #     H[field][ind] = val
 
             if 'given' not in fields:
-                print("Marking entries in H0 as having been given and returned", flush=True)
+                logger.manager_warning("Marking entries in H0 as having been 'given' and 'returned'")
                 H['given'][:len(H0)] = 1
                 H['returned'][:len(H0)] = 1
             elif 'returned' not in fields:
-                print("Marking entries in H0 as having been returned", flush=True)
-                H['returned'][:len(H0)] = 1
+                logger.manager_warning("Marking entries in H0 as having been 'returned' if 'given'")
+                H['returned'][:len(H0)] = H0['given']
 
             if 'sim_id' not in fields:
-                print("Assigning sim_ids to entries in H0", flush=True)
+                logger.manager_warning("Assigning sim_ids to entries in H0")
                 H['sim_id'][:len(H0)] = np.arange(0, len(H0))
 
         H['sim_id'][-L:] = -1

--- a/libensemble/history.py
+++ b/libensemble/history.py
@@ -82,9 +82,9 @@ class History:
         self.offset = len(H0)
         self.index = self.offset
 
-        self.given_count = np.sum(H0['given'])
+        self.given_count = np.sum(H['given'])
 
-        self.sim_count = np.sum(H0['returned'])
+        self.sim_count = np.sum(H['returned'])
 
     def update_history_f(self, D):
         """

--- a/libensemble/history.py
+++ b/libensemble/history.py
@@ -54,6 +54,7 @@ class History:
         H = np.zeros(L + len(H0), dtype=dtype_list)
 
         if len(H0):
+            # Prepend H with H0
             fields = H0.dtype.names
 
             for field in fields:
@@ -61,10 +62,17 @@ class History:
                 # for ind, val in np.ndenumerate(H0[field]):  # Works if H0[field] has arbitrary dimension but is slow
                 #     H[field][ind] = val
 
-        # Prepend H with H0
-        H['sim_id'][:len(H0)] = np.arange(0, len(H0))
-        H['given'][:len(H0)] = 1
-        H['returned'][:len(H0)] = 1
+            if 'given' not in fields:
+                print("Marking entries in H0 as having been given and returned", flush=True)
+                H['given'][:len(H0)] = 1
+                H['returned'][:len(H0)] = 1
+            elif 'returned' not in fields:
+                print("Marking entries in H0 as having been returned", flush=True)
+                H['returned'][:len(H0)] = 1
+
+            if 'sim_id' not in fields:
+                print("Assigning sim_ids to entries in H0", flush=True)
+                H['sim_id'][:len(H0)] = np.arange(0, len(H0))
 
         H['sim_id'][-L:] = -1
         H['given_time'][-L:] = np.inf
@@ -74,12 +82,9 @@ class History:
         self.offset = len(H0)
         self.index = self.offset
 
-        # libE.check_inputs also checks that all points in H0 are 'returned', so gen and sim have been run.
-        # assert np.all(H0['given']), "H0 contains unreturned points. Exiting"
-        self.given_count = self.offset
+        self.given_count = np.sum(H0['given'])
 
-        # assert np.all(H0['returned']), "H0 contains unreturned points. Exiting"
-        self.sim_count = self.offset
+        self.sim_count = np.sum(H0['returned'])
 
     def update_history_f(self, D):
         """

--- a/libensemble/tests/regression_tests/test_evaluate_existing_sample.py
+++ b/libensemble/tests/regression_tests/test_evaluate_existing_sample.py
@@ -31,13 +31,12 @@ gen_specs = {}
 n_samp = 1000
 n = 8
 
-H0 = np.zeros(n_samp, dtype=[('x', float, 8), ('sim_id', int), ('given', bool), ('returned', bool)])
+H0 = np.zeros(n_samp, dtype=[('x', float, 8), ('sim_id', int), ('given', bool)])
 
 np.random.seed(0)
 H0['x'] = gen_borehole_input(n_samp)
 H0['sim_id'] = range(n_samp)
 H0['given'] = False
-H0['returned'] = False
 
 alloc_specs = {'alloc_f': alloc_f, 'out': [('x', float, n)]}
 

--- a/libensemble/tests/regression_tests/test_evaluate_existing_sample.py
+++ b/libensemble/tests/regression_tests/test_evaluate_existing_sample.py
@@ -31,11 +31,13 @@ gen_specs = {}
 n_samp = 1000
 n = 8
 
-H0 = np.zeros(n_samp, dtype=[('x', float, 8), ('sim_id', int)])
+H0 = np.zeros(n_samp, dtype=[('x', float, 8), ('sim_id', int), ('given', bool), ('returned', bool)])
 
 np.random.seed(0)
 H0['x'] = gen_borehole_input(n_samp)
 H0['sim_id'] = range(n_samp)
+H0['given'] = False
+H0['returned'] = False
 
 alloc_specs = {'alloc_f': alloc_f, 'out': [('x', float, n)]}
 


### PR DESCRIPTION
Before `H0` was assumed to contain only points with `given` and `returned` as `True`. 

A way to do simulation evaluations at some pre-existing set of points is to put them into `H0` and have an `alloc_f` give them out (without needed a `gen_f` call). 

In this regression test, libEnsemble was marking them as `given` and `returned` but the `alloc_f` was giving them out anyway (so the test was performing correctly).  