### PR TITLE
Experimental/protecting libE fields

### DIFF
--- a/libensemble/history.py
+++ b/libensemble/history.py
@@ -96,7 +96,7 @@ class History:
 
         for j, ind in enumerate(new_inds):
             for field in returned_H.dtype.names:
-                assert field not in protected_libE_fields, "The field " + field + " is protected"
+                assert field not in protected_libE_fields, "The field '" + field + "' is protected"
                 if np.isscalar(returned_H[field][j]):
                     self.H[field][ind] = returned_H[field][j]
                 else:
@@ -175,7 +175,7 @@ class History:
             update_inds = D['sim_id']
 
         for field in D.dtype.names:
-            assert field not in protected_libE_fields, "The field " + field + " is protected"
+            assert field not in protected_libE_fields, "The field '" + field + "' is protected"
             self.H[field][update_inds] = D[field]
 
         self.H['gen_time'][update_inds] = time.time()

--- a/libensemble/history.py
+++ b/libensemble/history.py
@@ -2,7 +2,7 @@ import numpy as np
 import time
 import logging
 
-from libensemble.tools.fields_keys import libE_fields
+from libensemble.tools.fields_keys import libE_fields, protected_libE_fields
 
 logger = logging.getLogger(__name__)
 
@@ -96,7 +96,7 @@ class History:
 
         for j, ind in enumerate(new_inds):
             for field in returned_H.dtype.names:
-
+                assert field not in protected_libE_fields, "The field " + field + " is protected"
                 if np.isscalar(returned_H[field][j]):
                     self.H[field][ind] = returned_H[field][j]
                 else:
@@ -175,6 +175,7 @@ class History:
             update_inds = D['sim_id']
 
         for field in D.dtype.names:
+            assert field not in protected_libE_fields, "The field " + field + " is protected"
             self.H[field][update_inds] = D[field]
 
         self.H['gen_time'][update_inds] = time.time()

--- a/libensemble/tests/unit_tests/test_history.py
+++ b/libensemble/tests/unit_tests/test_history.py
@@ -188,6 +188,15 @@ def test_update_history_x_in():
     assert hist.index == 10
     assert hist.sim_count == 0
 
+    # Force assertion error when a libE protected field appears in gen_worker
+    H_o = np.zeros(size, dtype=gen_specs['out'] + [('given', bool)])
+    try:
+        hist.update_history_x_in(gen_worker, H_o)
+    except AssertionError:
+        assert 1, "Failed like it should have"
+    else:
+        assert 0, "Didn't fail like it should have"
+
 
 def test_update_history_x_in_sim_ids():
     hist, _, gen_specs, _, _ = setup.hist_setup2A_genout_sim_ids(7)

--- a/libensemble/tools/fields_keys.py
+++ b/libensemble/tools/fields_keys.py
@@ -12,6 +12,8 @@ libE_fields = [('sim_id', int),        # Unique id of entry in H that was genera
                ]
 # end_libE_fields_rst_tag
 
+protected_libE_fields = [e[0] for e in libE_fields]
+
 allowed_sim_spec_keys = ['sim_f',  #
                          'in',     #
                          'out',    #

--- a/libensemble/tools/fields_keys.py
+++ b/libensemble/tools/fields_keys.py
@@ -12,7 +12,12 @@ libE_fields = [('sim_id', int),        # Unique id of entry in H that was genera
                ]
 # end_libE_fields_rst_tag
 
-protected_libE_fields = [e[0] for e in libE_fields]
+protected_libE_fields = ['gen_worker',
+                         'gen_time',
+                         'given',
+                         'returned',
+                         'given_time',
+                         'sim_worker']
 
 allowed_sim_spec_keys = ['sim_f',  #
                          'in',     #


### PR DESCRIPTION
This proposed change checks that any field returned from a `sim_f` or `gen_f` is not protected. (We could do a check in `check_inputs` that `gen_specs['out']` and `sim_specs['out']` aren't protected.)

Also, the default is to deepcopy the protected libE fields and ensure they aren't changed by the `alloc_f`. (This can be overwritten by setting `libE_specs['safe_mode'] = False`)
