### PR TITLE
Feature/explicitly seeded random streams

### DIFF
--- a/libensemble/gen_funcs/sampling.py
+++ b/libensemble/gen_funcs/sampling.py
@@ -38,8 +38,8 @@ def uniform_random_sample_with_different_nodes_and_ranks(H, persis_info, gen_spe
     else:
         H_o = np.zeros(1, dtype=gen_specs['out'])
         H_o['x'] = len(H)*np.ones(n)
-        H_o['num_nodes'] = np.random.randint(1, gen_specs['user']['max_num_nodes']+1)
-        H_o['ranks_per_node'] = np.random.randint(1, gen_specs['user']['max_ranks_per_node']+1)
+        H_o['num_nodes'] = persis_info['rand_stream'].randint(1, gen_specs['user']['max_num_nodes']+1)
+        H_o['ranks_per_node'] = persis_info['rand_stream'].randint(1, gen_specs['user']['max_ranks_per_node']+1)
         H_o['priority'] = 10*H_o['num_nodes']
 
     return H_o, persis_info
@@ -113,18 +113,18 @@ def latin_hypercube_sample(H, persis_info, gen_specs, _):
 
     H_o = np.zeros(b, dtype=gen_specs['out'])
 
-    A = lhs_sample(n, b)
+    A = lhs_sample(n, b, persis_info['rand_stream'])
 
     H_o['x'] = A*(ub-lb)+lb
 
     return H_o, persis_info
 
 
-def lhs_sample(n, k):
+def lhs_sample(n, k, stream):
 
     # Generate the intervals and random values
     intervals = np.linspace(0, 1, k+1)
-    rand_source = np.random.uniform(0, 1, (k, n))
+    rand_source = stream.uniform(0, 1, (k, n))
     rand_pts = np.zeros((k, n))
     sample = np.zeros((k, n))
 
@@ -136,6 +136,6 @@ def lhs_sample(n, k):
 
     # Randomly perturb
     for j in range(n):
-        sample[:, j] = rand_pts[np.random.permutation(k), j]
+        sample[:, j] = rand_pts[stream.permutation(k), j]
 
     return sample

--- a/libensemble/tests/regression_tests/test_1d_sampling.py
+++ b/libensemble/tests/regression_tests/test_1d_sampling.py
@@ -34,7 +34,7 @@ gen_specs = {'gen_f': gen_f,
                       }
              }
 
-persis_info = add_unique_random_streams({}, nworkers + 1)
+persis_info = add_unique_random_streams({}, nworkers + 1, seed=1234)
 
 exit_criteria = {'gen_max': 501}
 

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_pounders.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_pounders.py
@@ -75,8 +75,9 @@ persis_info = add_unique_random_streams({}, nworkers + 1)
 exit_criteria = {'sim_max': 500}
 
 sample_points = np.zeros((0, n))
+rand_stream = np.random.RandomState(0)
 for i in range(ceil(exit_criteria['sim_max']/gen_specs['user']['lhs_divisions'])):
-    sample_points = np.append(sample_points, lhs_sample(n, gen_specs['user']['lhs_divisions']), axis=0)
+    sample_points = np.append(sample_points, lhs_sample(n, gen_specs['user']['lhs_divisions'], rand_stream), axis=0)
 
 gen_specs['user']['sample_points'] = sample_points*(ub-lb) + lb
 

--- a/libensemble/tools/tools.py
+++ b/libensemble/tools/tools.py
@@ -107,12 +107,13 @@ def save_libE_output(H, persis_info, calling_file, nworkers, mess='Run completed
 # ===================== per-process numpy random-streams =======================
 
 
-def add_unique_random_streams(persis_info, nstreams):
+def add_unique_random_streams(persis_info, nstreams, seed=''):
     """
     Creates nstreams random number streams for the libE manager and workers
-    when nstreams is num_workers + 1. Stream i is initialized with seed i.
+    when nstreams is num_workers + 1. Stream i is initialized with seed i by default.
+    Otherwise the streams can be initialized with a provided seed.
 
-    The entries are appended to the existing persis_info dictionary.
+    The entries are appended to the provided persis_info dictionary.
 
     .. code-block:: python
 
@@ -130,16 +131,28 @@ def add_unique_random_streams(persis_info, nstreams):
 
         Number of independent random number streams to produce
 
+    seed: :obj:`int`
+
+        (Optional) Seed for identical random number streams for each worker. If
+        explicitly set to ``None``, random number streams are unique and seed
+        via other pseudorandom mechanisms.
+
     """
 
     for i in range(nstreams):
+
+        if isinstance(seed, int) or seed is None:
+            random_seed = seed
+        else:
+            random_seed = i
+
         if i in persis_info:
             persis_info[i].update({
-                'rand_stream': np.random.RandomState(i),
+                'rand_stream': np.random.RandomState(random_seed),
                 'worker_num': i})
         else:
             persis_info[i] = {
-                'rand_stream': np.random.RandomState(i),
+                'rand_stream': np.random.RandomState(random_seed),
                 'worker_num': i}
     return persis_info
 


### PR DESCRIPTION
new optional ``seed`` parameter for ``add_unique_random_streams()``. Can be set to an integer to initialize identical random streams for each worker for additional determinism, or set to ``None`` for completely unique random streams each run. Should not break existing behavior.

Closes #542 