### PR TITLE
Add generator function for discrete fidelities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ code/tests/regression_tests/output/
 libensemble.egg-info
 docs/_build
 x.log
+.vscode

--- a/libensemble/gen_funcs/persistent_gp.py
+++ b/libensemble/gen_funcs/persistent_gp.py
@@ -143,11 +143,11 @@ def persistent_gp_mf_gen_f( H, persis_info, gen_specs, libE_info ):
     return H_o, persis_info, FINISHED_PERSISTENT_GEN_TAG
 
 
-def persistent_gp_mfd_gen_f( H, persis_info, gen_specs, libE_info ):
+def persistent_gp_mf_disc_gen_f( H, persis_info, gen_specs, libE_info ):
     """
-    Create a Gaussian Process model, for multi-fidelity optimization,
-    and update it as new simulation results are available, and generate
-    inputs for the next simulations.
+    Create a Gaussian Process model, for multi-fidelity optimization
+    in a discrete fidelity space, and update it as new simulation results are
+    available, and generate inputs for the next simulations.
 
     This is a persistent `genf` i.e. this function is called by a dedicated
     worker and does not return until the end of the whole libEnsemble run.

--- a/libensemble/gen_funcs/persistent_gp.py
+++ b/libensemble/gen_funcs/persistent_gp.py
@@ -13,7 +13,7 @@ from libensemble.message_numbers import STOP_TAG, PERSIS_STOP, FINISHED_PERSISTE
 from libensemble.tools.gen_support import sendrecv_mgr_worker_msg
 
 # import dragonfly Gaussian Process functions
-from dragonfly.exd.domains import EuclideanDomain
+from dragonfly.exd.domains import EuclideanDomain, IntegralDomain
 from dragonfly.exd.experiment_caller import EuclideanFunctionCaller
 from dragonfly.opt.gp_bandit import EuclideanGPBandit
 from argparse import Namespace
@@ -97,6 +97,81 @@ def persistent_gp_mf_gen_f( H, persis_info, gen_specs, libE_info ):
     # Initialize the dragonfly GP optimizer
     domain = EuclideanDomain( [ [l,u] for l,u in zip(lb_list[:-1], ub_list[:-1]) ] )
     fidel_space = EuclideanDomain( [ [lb_list[-1], ub_list[-1]] ] )
+    func_caller = EuclideanFunctionCaller( None,
+                            raw_domain=domain,
+                            raw_fidel_space=fidel_space,
+                            fidel_cost_func=cost_func,
+                            raw_fidel_to_opt=ub_list[-1] )
+    opt = EuclideanGPBandit( func_caller,
+                            ask_tell_mode=True,
+                            is_mf=True,
+                            options=Namespace(acq='ts',
+                            build_new_model_every=number_of_gen_points) )
+    opt.initialise()
+
+    # Receive information from the manager (or a STOP_TAG)
+    tag = None
+    while tag not in [STOP_TAG, PERSIS_STOP]:
+
+        # Ask the optimizer to generate `batch_size` new points
+        # Store this information in the format expected by libE
+        H_o = np.zeros(number_of_gen_points, dtype=gen_specs['out'])
+        for i in range(number_of_gen_points):
+            resolution, input_vector = opt.ask()
+            H_o['x'][i] = np.concatenate( (input_vector, resolution) )
+
+        # Send data and get results from finished simulation
+        # Blocking call: waits for simulation results to be sent by the manager
+        tag, Work, calc_in = sendrecv_mgr_worker_msg(libE_info['comm'], H_o)
+        if calc_in is not None:
+            # Check how many simulations have returned
+            n = len(calc_in['f'])
+            # Update the GP with latest simulation results
+            for i in range(n):
+                x = calc_in['x'][i]
+                input_vector = x[:-1]
+                resolution = x[-1]
+                y = calc_in['f'][i]
+                opt.tell([ (resolution, input_vector, -y) ])
+            # Update hyperparameters
+            opt._build_new_model()
+            # Set the number of points to generate to that number:
+            number_of_gen_points = n
+        else:
+            number_of_gen_points = 0
+
+    return H_o, persis_info, FINISHED_PERSISTENT_GEN_TAG
+
+
+def persistent_gp_mfd_gen_f( H, persis_info, gen_specs, libE_info ):
+    """
+    Create a Gaussian Process model, for multi-fidelity optimization,
+    and update it as new simulation results are available, and generate
+    inputs for the next simulations.
+
+    This is a persistent `genf` i.e. this function is called by a dedicated
+    worker and does not return until the end of the whole libEnsemble run.
+    """
+    # Extract bounds of the parameter space, and batch size
+    ub_list = gen_specs['user']['ub']
+    lb_list = gen_specs['user']['lb']
+    # Note: the resolution should be the last variable
+    # TODO: Add a corresponding automated check
+
+    # Multifidelity settings.
+    cost_func = gen_specs['user']['cost_func']
+    discrete_fidel = gen_specs['user']['discrete']
+    fidel_range = gen_specs['user']['range']
+
+    # Number of points to generate initially
+    number_of_gen_points = gen_specs['user']['gen_batch_size']
+
+    # Initialize the dragonfly GP optimizer
+    domain = EuclideanDomain( [ [l,u] for l,u in zip(lb_list, ub_list) ] )
+    if discrete_fidel:
+        fidel_space = IntegralDomain([ fidel_range ])
+    else:
+        fidel_space = EuclideanDomain([ fidel_range ] )
     func_caller = EuclideanFunctionCaller( None,
                             raw_domain=domain,
                             raw_fidel_space=fidel_space,

--- a/libensemble/gen_funcs/persistent_gp.py
+++ b/libensemble/gen_funcs/persistent_gp.py
@@ -104,7 +104,7 @@ def persistent_gp_mf_gen_f( H, persis_info, gen_specs, libE_info ):
                             raw_domain=domain,
                             raw_fidel_space=fidel_space,
                             fidel_cost_func=cost_func,
-                            raw_fidel_to_opt=ub_list[-1] )
+                            raw_fidel_to_opt=fidel_range[-1] )
     opt = EuclideanGPBandit( func_caller,
                             ask_tell_mode=True,
                             is_mf=True,

--- a/libensemble/gen_funcs/persistent_gp.py
+++ b/libensemble/gen_funcs/persistent_gp.py
@@ -208,8 +208,9 @@ def persistent_gp_mf_disc_gen_f( H, persis_info, gen_specs, libE_info ):
         # Store this information in the format expected by libE
         H_o = np.zeros(number_of_gen_points, dtype=gen_specs['out'])
         for i in range(number_of_gen_points):
-            resolution, input_vector = opt.ask()
-            H_o['x'][i] = np.concatenate( (input_vector, resolution) )
+            z, input_vector = opt.ask()
+            H_o['x'][i] = input_vector
+            H_o['z'][i] = z[0]
 
         # Send data and get results from finished simulation
         # Blocking call: waits for simulation results to be sent by the manager
@@ -219,11 +220,10 @@ def persistent_gp_mf_disc_gen_f( H, persis_info, gen_specs, libE_info ):
             n = len(calc_in['f'])
             # Update the GP with latest simulation results
             for i in range(n):
-                x = calc_in['x'][i]
-                input_vector = x[:-1]
-                resolution = x[-1]
+                input_vector = calc_in['x'][i]
+                z = calc_in['z'][i]
                 y = calc_in['f'][i]
-                opt.tell([ (resolution, input_vector, -y) ])
+                opt.tell([ ([z], input_vector, -y) ])
             # Update hyperparameters
             opt._build_new_model()
             # Set the number of points to generate to that number:


### PR DESCRIPTION
This PR adds a new generator function `persistent_gp_mf_disc_gen_f` which can handle multi-fidelity optimization with Dragonfly when the fidelity space is discrete. It also modifies the current `persistent_gp_mf_gen_f` function to allow the cost function to be specified by the user (i.e., it is no longer hard-coded) and to handle that the fidelity is now separate from the other input parameters.