### PR TITLE
Removing 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 dist: xenial
 python:
-  - 3.5
   - 3.6
   - 3.7
   - 3.8

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ Dependencies
 
 Required dependencies:
 
-* Python_ 3.5 or above
+* Python_ 3.6 or above
 * NumPy_
 * psutil_
 

--- a/docs/data_structures/libE_specs.rst
+++ b/docs/data_structures/libE_specs.rst
@@ -23,13 +23,13 @@ Specifications for libEnsemble::
         'sim_dirs_make' [boolean]:
             Whether to make simulation-specific calculation directories for each sim call.
             This will create a directory for each simulation, even if no sim_input_dir is
-            specified. If False, all workers operate within the ensemble directory 
+            specified. If False, all workers operate within the ensemble directory
             described below.
             Default: True
         'gen_dirs_make' [boolean]:
-            Whether to make generator-instance specific calculation directories for each 
-            gen call. This will create a directory for each generator call, even if no 
-            gen_input_dir is specified. If False, all workers operate within the ensemble 
+            Whether to make generator-instance specific calculation directories for each
+            gen call. This will create a directory for each generator call, even if no
+            gen_input_dir is specified. If False, all workers operate within the ensemble
             directory.
             Default: True
         'ensemble_dir_path' [string]:

--- a/docs/platforms/cori.rst
+++ b/docs/platforms/cori.rst
@@ -170,7 +170,6 @@ user application. libEnsemble could be run on more than one node, but here the
 
 Example submission scripts are also given in the :doc:`examples<example_scripts>`.
 
-
 Cori FAQ
 --------
 
@@ -178,7 +177,6 @@ Cori FAQ
 
 This error has been encountered on Cori when running with an incorrect
 installation of ``mpi4py``. See instructions above.
-
 
 Additional Information
 ----------------------

--- a/docs/tutorials/local_sine_tutorial.rst
+++ b/docs/tutorials/local_sine_tutorial.rst
@@ -39,7 +39,7 @@ then ``python`` and ``pip`` will work in place of ``python3`` and ``pip3``.
 .. code-block:: bash
 
     $ python3 --version
-    Python 3.6.0            # This should be >= 3.5
+    Python 3.6.0            # This should be >= 3.6
 
 .. _Python: https://www.python.org/
 

--- a/install/run_travis_locally/quick_run.md
+++ b/install/run_travis_locally/quick_run.md
@@ -12,7 +12,7 @@ Window 2: Will create and run container.
 
 Windows 1 and 2 - name container. E.g:
 
-    export CONTAINER=travis-debug-2020-07-20-py3.5
+    export CONTAINER=travis-debug-2020-07-20-py3.6
 
 Window 2:
 
@@ -28,11 +28,11 @@ Window 1 Optional - user scripts to help navigate:
     docker cp ~/.bashrc  $CONTAINER:/home/travis
     docker cp ~/.alias   $CONTAINER:/home/travis
 
-WWindow 2 (Example: Do not run tests python 3.5 - git branch feature/register_apps):
+WWindow 2 (Example: Do not run tests python 3.6 - git branch feature/register_apps):
 
     chown travis:travis /home/travis/build_mpich_libE.sh
     su - travis
-    . ./build_mpich_libE.sh -p 3.5 -b feature/register_apps -i
+    . ./build_mpich_libE.sh -p 3.6 -b feature/register_apps -i
 
 Window 2 Optional - user scripts to help navigate:
 

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,6 @@ setup(
         'Operating System :: Unix',
         'Operating System :: MacOS',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
Python3.5 has reached end of life. https://www.python.org/dev/peps/pep-0478/

Numpy 1.19 says it will not compile with versions < 3.6 https://numpy.org/devdocs/release/1.19.0-notes.html

As such, we should remove support of 3.5 