### PR TITLE
Replace persis_info[i] with persis_info.get(i) in several alloc_f functions

### DIFF
--- a/libensemble/alloc_funcs/fast_alloc.py
+++ b/libensemble/alloc_funcs/fast_alloc.py
@@ -28,6 +28,6 @@ def give_sim_work_first(W, H, sim_specs, gen_specs, alloc_specs, persis_info):
             # Give gen work
             persis_info['total_gen_calls'] += 1
             gen_count += 1
-            gen_work(Work, i, gen_specs['in'], range(len(H)), persis_info[i])
+            gen_work(Work, i, gen_specs['in'], range(len(H)), persis_info.get(i))
 
     return Work, persis_info

--- a/libensemble/alloc_funcs/give_sim_work_first.py
+++ b/libensemble/alloc_funcs/give_sim_work_first.py
@@ -55,7 +55,7 @@ def give_sim_work_first(W, H, sim_specs, gen_specs, alloc_specs, persis_info):
                 break
 
             # Assign resources and mark tasks as allocated to workers
-            sim_work(Work, i, sim_specs['in'], sim_ids_to_send, persis_info[i])
+            sim_work(Work, i, sim_specs['in'], sim_ids_to_send, persis_info.get(i))
             H['allocated'][sim_ids_to_send] = True
 
             # Update resource records
@@ -79,8 +79,8 @@ def give_sim_work_first(W, H, sim_specs, gen_specs, alloc_specs, persis_info):
             # Give gen work
             gen_count += 1
             if 'in' in gen_specs and len(gen_specs['in']):
-                gen_work(Work, i, gen_specs['in'], range(len(H)), persis_info[i])
+                gen_work(Work, i, gen_specs['in'], range(len(H)), persis_info.get(i))
             else:
-                gen_work(Work, i, [], [], persis_info[i])
+                gen_work(Work, i, [], [], persis_info.get(i))
 
     return Work, persis_info

--- a/libensemble/alloc_funcs/inverse_bayes_allocf.py
+++ b/libensemble/alloc_funcs/inverse_bayes_allocf.py
@@ -37,7 +37,7 @@ def only_persistent_gens_for_inverse_bayes(W, H, sim_specs, gen_specs, alloc_spe
                 H['weight'][(n*(k-1)):(n*k)] = H['weight'][(n*k):(n*(k+1))]
 
             gen_work(Work, i, ['like'], np.atleast_1d(inds_to_send_back),
-                     persis_info[i], persistent=True)
+                     persis_info.get(i), persistent=True)
 
     task_avail = ~H['given']
     for i in avail_worker_ids(W, persistent=False):
@@ -54,7 +54,7 @@ def only_persistent_gens_for_inverse_bayes(W, H, sim_specs, gen_specs, alloc_spe
 
             # Finally, generate points since there is nothing else to do.
             gen_count += 1
-            gen_work(Work, i, gen_specs['in'], [], persis_info[i],
+            gen_work(Work, i, gen_specs['in'], [], persis_info.get(i),
                      persistent=True)
 
     return Work, persis_info

--- a/libensemble/alloc_funcs/only_one_gen_alloc.py
+++ b/libensemble/alloc_funcs/only_one_gen_alloc.py
@@ -29,6 +29,6 @@ def ensure_one_active_gen(W, H, sim_specs, gen_specs, alloc_specs, persis_info):
             # Give gen work
             persis_info['total_gen_calls'] += 1
             gen_flag = False
-            gen_work(Work, i, gen_specs['in'], range(len(H)), persis_info[i])
+            gen_work(Work, i, gen_specs['in'], range(len(H)), persis_info.get(i))
 
     return Work, persis_info

--- a/libensemble/alloc_funcs/persistent_aposmm_alloc.py
+++ b/libensemble/alloc_funcs/persistent_aposmm_alloc.py
@@ -51,22 +51,22 @@ def persistent_aposmm_alloc(W, H, sim_specs, gen_specs, alloc_specs, persis_info
                 inds_to_give = np.where(returned_but_not_given)[0]
 
                 gen_work(Work, i, persis_info['fields_to_give_back'],
-                         np.atleast_1d(inds_to_give), persis_info[i], persistent=True)
+                         np.atleast_1d(inds_to_give), persis_info.get(i), persistent=True)
 
                 H['given_back'][inds_to_give] = True
 
     for i in avail_worker_ids(W, persistent=False):
         if persis_info['next_to_give'] < len(H):
             # perform sim evaluations (if they exist in History).
-            sim_work(Work, i, sim_specs['in'], np.atleast_1d(persis_info['next_to_give']), persis_info[i])
+            sim_work(Work, i, sim_specs['in'], np.atleast_1d(persis_info['next_to_give']), persis_info.get(i))
             persis_info['next_to_give'] += 1
 
         elif persis_info.get('gen_started') is None:
             # Finally, call a persistent generator as there is nothing else to do.
             persis_info['gen_started'] = True
-            persis_info[i]['nworkers'] = len(W)
+            persis_info.get(i)['nworkers'] = len(W)
 
-            gen_work(Work, i, gen_specs['in'], range(len(H)), persis_info[i],
+            gen_work(Work, i, gen_specs['in'], range(len(H)), persis_info.get(i),
                      persistent=True)
 
     return Work, persis_info

--- a/libensemble/alloc_funcs/start_fd_persistent.py
+++ b/libensemble/alloc_funcs/start_fd_persistent.py
@@ -41,7 +41,7 @@ def finite_diff_alloc(W, H, sim_specs, gen_specs, alloc_specs, persis_info):
         if len(inds_to_send):
             gen_work(Work, i,
                      list(set(gen_specs['in'] + sim_specs['in'] + [n[0] for n in sim_specs['out']] + [('sim_id')])),
-                     np.atleast_1d(inds_to_send), persis_info[i], persistent=True)
+                     np.atleast_1d(inds_to_send), persis_info.get(i), persistent=True)
 
             H['given_back'][inds_to_send] = True
 
@@ -50,13 +50,13 @@ def finite_diff_alloc(W, H, sim_specs, gen_specs, alloc_specs, persis_info):
         if np.any(task_avail):
             # perform sim evaluations (if they exist in History).
             sim_ids_to_send = np.nonzero(task_avail)[0][0]  # oldest point
-            sim_work(Work, i, sim_specs['in'], np.atleast_1d(sim_ids_to_send), persis_info[i])
+            sim_work(Work, i, sim_specs['in'], np.atleast_1d(sim_ids_to_send), persis_info.get(i))
             task_avail[sim_ids_to_send] = False
 
         elif gen_count == 0:
             # Finally, call a persistent generator as there is nothing else to do.
             gen_count += 1
-            gen_work(Work, i, gen_specs['in'], [], persis_info[i],
+            gen_work(Work, i, gen_specs['in'], [], persis_info.get(i),
                      persistent=True)
 
     return Work, persis_info, 0

--- a/libensemble/alloc_funcs/start_only_persistent.py
+++ b/libensemble/alloc_funcs/start_only_persistent.py
@@ -32,7 +32,7 @@ def only_persistent_gens(W, H, sim_specs, gen_specs, alloc_specs, persis_info):
                 inds_to_give = np.where(returned_but_not_given)[0]
                 gen_work(Work, i,
                          sim_specs['in'] + [n[0] for n in sim_specs['out']] + [('sim_id')],
-                         np.atleast_1d(inds_to_give), persis_info[i], persistent=True)
+                         np.atleast_1d(inds_to_give), persis_info.get(i), persistent=True)
 
                 H['given_back'][inds_to_give] = True
 
@@ -46,7 +46,7 @@ def only_persistent_gens(W, H, sim_specs, gen_specs, alloc_specs, persis_info):
                 inds_to_give = H['sim_id'][gen_inds][H['gen_time'][gen_inds] == last_time_gen_gave_batch]
                 gen_work(Work, i,
                          sim_specs['in'] + [n[0] for n in sim_specs['out']] + [('sim_id')],
-                         np.atleast_1d(inds_to_give), persis_info[i], persistent=True)
+                         np.atleast_1d(inds_to_give), persis_info.get(i), persistent=True)
 
                 H['given_back'][inds_to_give] = True
 
@@ -55,13 +55,13 @@ def only_persistent_gens(W, H, sim_specs, gen_specs, alloc_specs, persis_info):
         if np.any(task_avail):
             # perform sim evaluations (if they exist in History).
             sim_ids_to_send = np.nonzero(task_avail)[0][0]  # oldest point
-            sim_work(Work, i, sim_specs['in'], np.atleast_1d(sim_ids_to_send), persis_info[i])
+            sim_work(Work, i, sim_specs['in'], np.atleast_1d(sim_ids_to_send), persis_info.get(i))
             task_avail[sim_ids_to_send] = False
 
         elif gen_count == 0:
             # Finally, call a persistent generator as there is nothing else to do.
             gen_count += 1
-            gen_work(Work, i, gen_specs['in'], range(len(H)), persis_info[i],
+            gen_work(Work, i, gen_specs['in'], range(len(H)), persis_info.get(i),
                      persistent=True)
             persis_info['gen_started'] = True
 


### PR DESCRIPTION
Addresses #571 

An approach to many ``alloc_f`` functions like the default failing with a ``KeyError`` if an empty ``persis_info`` dictionary is passed to ``libE()``. 

This occurs since most of the ``alloc_f``s index ``persis_info`` by workerID using square brackets, producing the error if the workerID keys appended by ``add_unique_random_streams()`` don't exist. Using ``persis_info.get(i)`` instead returns None. This should be fine if no user function requires a ``persis_info`` entry.

Alternative approaches may be best. I considered initiating workerIDs within ``persis_info`` in ``libE()``, but then I think we'd require ``nworkers`` information passed in ``libE_specs`` at runtime. Currently, I think passing ``libE_specs`` (and even ``persis_info``) is supposed to be optional.