### PR TITLE
Removing usage of np.float and np.int

### DIFF
--- a/libensemble/gen_funcs/aposmm_localopt_support.py
+++ b/libensemble/gen_funcs/aposmm_localopt_support.py
@@ -197,7 +197,7 @@ def run_local_nlopt(user_specs, comm_queue, x0, f0, child_can_read, parent_can_r
 
     # Care must be taken here because a too-large initial step causes nlopt to move the starting point!
     dist_to_bound = min(min(ub-x0), min(x0-lb))
-    assert dist_to_bound > np.finfo(np.float32).eps, "The distance to the boundary is too small for NLopt to handle"
+    assert dist_to_bound > np.finfo(np.float64).eps, "The distance to the boundary is too small for NLopt to handle"
 
     if 'dist_to_bound_multiple' in user_specs:
         opt.set_initial_step(dist_to_bound*user_specs['dist_to_bound_multiple'])
@@ -353,7 +353,7 @@ def run_local_dfols(user_specs, comm_queue, x0, f0, child_can_read, parent_can_r
 
     # Care must be taken here because a too-large initial step causes DFO-LS to move the starting point!
     dist_to_bound = min(min(ub-x0), min(x0-lb))
-    assert dist_to_bound > np.finfo(np.float32).eps, "The distance to the boundary is too small"
+    assert dist_to_bound > np.finfo(np.float64).eps, "The distance to the boundary is too small"
     assert 'bounds' not in user_specs.get('dfols_kwargs', {}), "APOSMM must set the bounds for DFO-LS"
     assert 'rhobeg' not in user_specs.get('dfols_kwargs', {}), "APOSMM must set rhobeg for DFO-LS"
     assert 'x0' not in user_specs.get('dfols_kwargs', {}), "APOSMM must set x0 for DFO-LS"

--- a/libensemble/gen_funcs/old_aposmm.py
+++ b/libensemble/gen_funcs/old_aposmm.py
@@ -631,7 +631,7 @@ def set_up_and_run_nlopt(Run_H, user_specs):
 
     # Care must be taken here because a too-large initial step causes nlopt to move the starting point!
     dist_to_bound = min(min(ub-x0), min(x0-lb))
-    assert dist_to_bound > np.finfo(np.float32).eps, "The distance to the boundary is too small for NLopt to handle"
+    assert dist_to_bound > np.finfo(np.float64).eps, "The distance to the boundary is too small for NLopt to handle"
 
     if 'dist_to_bound_multiple' in user_specs:
         opt.set_initial_step(dist_to_bound*user_specs['dist_to_bound_multiple'])

--- a/libensemble/gen_funcs/uniform_or_localopt.py
+++ b/libensemble/gen_funcs/uniform_or_localopt.py
@@ -57,7 +57,7 @@ def try_and_run_nlopt(H, gen_specs, libE_info):
         if np.array_equiv(x, H['x']):
             if gen_specs['user']['localopt_method'] in ['LD_MMA']:
                 grad[:] = H['grad']
-            return np.float(H['f'])
+            return float(H['f'])
 
         # Send back x to the manager, then receive info or stop tag
         H_o = add_to_Out(np.zeros(1, dtype=gen_specs['out']), x, 0,


### PR DESCRIPTION
`np.float` and `np.int` are deprecated:

https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

I've opened a PR with DFO-LS, which is also affected by this deprecation, which is causing our regression tests to fail (as we error on warnings).

https://github.com/numericalalgorithmsgroup/dfols/pull/13

