### PR TITLE
Bugfix/fix error handling

### DIFF
--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -160,16 +160,16 @@ def manager(wcomms, sim_specs, gen_specs, exit_criteria, persis_info,
             raise
         except WorkerException as e:
             report_worker_exc(e)
-            raise
-        except Exception:
+            raise LoggedException(e.args[0], e.args[1]) from None
+        except Exception as e:
             logger.error(traceback.format_exc())
-            raise
-    except Exception:
+            raise LoggedException(e.args) from None
+    except Exception as e:
         exit_flag = 1  # Only exits if no abort/raise
         _dump_on_abort(hist, persis_info, save_H=save_H)
         if libE_specs.get('abort_on_exception', True) and on_abort is not None:
             on_abort()
-        raise LoggedException('See specific error above and in ensemble.log') from None
+        raise LoggedException(*e.args, 'See error details above and in ensemble.log') from None
     else:
         logger.debug("Manager exiting")
         logger.debug("Exiting with {} workers.".format(len(wcomms)))

--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -26,7 +26,7 @@ import pickle  # Only used when saving output on error
 from libensemble.utils import launcher
 from libensemble.utils.timer import Timer
 from libensemble.history import History
-from libensemble.manager import manager_main, ManagerException
+from libensemble.manager import manager_main, report_worker_exc, WorkerException, LoggedException
 from libensemble.worker import worker_main
 from libensemble.alloc_funcs import defaults as alloc_defaults
 from libensemble.comms.comms import QCommProcess, Timeout
@@ -150,21 +150,26 @@ def manager(wcomms, sim_specs, gen_specs, exit_criteria, persis_info,
     save_H = libE_specs.get('save_H_and_persis_on_abort', True)
 
     try:
-        persis_info, exit_flag, elapsed_time = \
-            manager_main(hist, libE_specs, alloc_specs, sim_specs, gen_specs,
-                         exit_criteria, persis_info, wcomms)
-        logger.info("manager total time: {}".format(elapsed_time))
-
-    except ManagerException as e:
-        _report_manager_exception(hist, persis_info, e, save_H=save_H)
-        if libE_specs.get('abort_on_exception', True) and on_abort is not None:
-            on_abort()
-        raise
+        try:
+            persis_info, exit_flag, elapsed_time = \
+                manager_main(hist, libE_specs, alloc_specs, sim_specs, gen_specs,
+                             exit_criteria, persis_info, wcomms)
+            logger.info("manager total time: {}".format(elapsed_time))
+        except LoggedException:
+            # Exception already logged in manager
+            raise
+        except WorkerException as e:
+            report_worker_exc(e)
+            raise
+        except Exception:
+            logger.error(traceback.format_exc())
+            raise
     except Exception:
-        _report_manager_exception(hist, persis_info, save_H=save_H)
+        exit_flag = 1  # Only exits if no abort/raise
+        _dump_on_abort(hist, persis_info, save_H=save_H)
         if libE_specs.get('abort_on_exception', True) and on_abort is not None:
             on_abort()
-        raise
+        # raise
     else:
         logger.debug("Manager exiting")
         logger.debug("Exiting with {} workers.".format(len(wcomms)))
@@ -477,15 +482,7 @@ def libE_tcp_worker(sim_specs, gen_specs, libE_specs):
 # ==================== Additional Internal Functions ===========================
 
 
-def _report_manager_exception(hist, persis_info, mgr_exc=None, save_H=True):
-    "Write out exception manager exception to log."
-    if mgr_exc is not None:
-        from_line, msg, exc = mgr_exc.args
-        logger.error("---- {} ----".format(from_line))
-        logger.error("Message: {}".format(msg))
-        logger.error(exc)
-    else:
-        logger.error(traceback.format_exc())
+def _dump_on_abort(hist, persis_info, save_H=True):
     logger.error("Manager exception raised .. aborting ensemble:")
     logger.error("Dumping ensemble history with {} sims evaluated:".
                  format(hist.sim_count))

--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -169,7 +169,7 @@ def manager(wcomms, sim_specs, gen_specs, exit_criteria, persis_info,
         _dump_on_abort(hist, persis_info, save_H=save_H)
         if libE_specs.get('abort_on_exception', True) and on_abort is not None:
             on_abort()
-        # raise
+        raise LoggedException('See specific error above and in ensemble.log') from None
     else:
         logger.debug("Manager exiting")
         logger.debug("Exiting with {} workers.".format(len(wcomms)))

--- a/libensemble/manager.py
+++ b/libensemble/manager.py
@@ -78,8 +78,13 @@ def manager_main(hist, libE_specs, alloc_specs,
         gen_specs['in'] = []
 
     # Send dtypes to workers
-    dtypes = {EVAL_SIM_TAG: hist.H[sim_specs['in']].dtype,
-              EVAL_GEN_TAG: hist.H[gen_specs['in']].dtype}
+    if 'repack_fields' in globals():
+        dtypes = {EVAL_SIM_TAG: repack_fields(hist.H[sim_specs['in']]).dtype,
+                  EVAL_GEN_TAG: repack_fields(hist.H[gen_specs['in']]).dtype}
+    else:
+        dtypes = {EVAL_SIM_TAG: hist.H[sim_specs['in']].dtype,
+                  EVAL_GEN_TAG: hist.H[gen_specs['in']].dtype}
+
     for wcomm in wcomms:
         wcomm.send(0, dtypes)
 

--- a/libensemble/manager.py
+++ b/libensemble/manager.py
@@ -495,10 +495,10 @@ class Manager:
                     "alloc_f did not return any work, although all workers are idle."
         except WorkerException as e:
             report_worker_exc(e)
-            raise LoggedException from None
-        except Exception:
+            raise LoggedException(e.args[0], e.args[1]) from None
+        except Exception as e:
             logger.error(traceback.format_exc())
-            raise LoggedException from None
+            raise LoggedException(e.args) from None
         finally:
             # Return persis_info, exit_flag, elapsed time
             result = self._final_receive_and_kill(persis_info)

--- a/libensemble/manager.py
+++ b/libensemble/manager.py
@@ -8,6 +8,7 @@ import os
 import glob
 import logging
 import socket
+import traceback
 import numpy as np
 
 from libensemble.utils.timer import Timer
@@ -36,7 +37,24 @@ logger = logging.getLogger(__name__)
 
 
 class ManagerException(Exception):
-    "Exception at manager, raised on abort signal from worker"
+    """Exception raised by the Manager"""
+
+
+class WorkerException(Exception):
+    """Exception raised on abort signal from worker"""
+
+
+class LoggedException(Exception):
+    """Raise exception for handling without re-logging"""
+
+
+def report_worker_exc(wrk_exc=None):
+    """Write worker exception to log"""
+    if wrk_exc is not None:
+        from_line, msg, exc = wrk_exc.args
+        logger.error("---- {} ----".format(from_line))
+        logger.error("Message: {}".format(msg))
+        logger.error(exc)
 
 
 def manager_main(hist, libE_specs, alloc_specs,
@@ -378,8 +396,8 @@ class Manager:
             if not self.WorkerExc:
                 self.WorkerExc = True
                 self._kill_workers()
-                raise ManagerException('Received error message from {}'.format(w),
-                                       D_recv.msg, D_recv.exc)
+                raise WorkerException('Received error message from worker {}'.format(w),
+                                      D_recv.msg, D_recv.exc)
         elif isinstance(D_recv, logging.LogRecord):
             logging.getLogger(D_recv.name).handle(D_recv)
         else:
@@ -475,7 +493,12 @@ class Manager:
                         self._update_state_on_alloc(Work[w], w)
                 assert self.term_test() or any(self.W['active'] != 0), \
                     "alloc_f did not return any work, although all workers are idle."
-
+        except WorkerException as e:
+            report_worker_exc(e)
+            raise LoggedException from None
+        except Exception:
+            logger.error(traceback.format_exc())
+            raise LoggedException from None
         finally:
             # Return persis_info, exit_flag, elapsed time
             result = self._final_receive_and_kill(persis_info)

--- a/libensemble/tests/regression_tests/test_calc_exception.py
+++ b/libensemble/tests/regression_tests/test_calc_exception.py
@@ -16,7 +16,7 @@
 import numpy as np
 
 from libensemble.libE import libE
-from libensemble.manager import ManagerException
+from libensemble.manager import LoggedException
 from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
 from libensemble.tools import parse_args, add_unique_random_streams
 
@@ -49,7 +49,7 @@ return_flag = 1
 try:
     H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria,
                                 persis_info, libE_specs=libE_specs)
-except ManagerException as e:
+except LoggedException as e:
     print("Caught deliberate exception: {}".format(e))
     return_flag = 0
 

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_exception.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_exception.py
@@ -80,7 +80,7 @@ try:
                                 alloc_specs, libE_specs)
 except Exception as e:
     if is_manager:
-        if e.args[1] == 'NLopt roundoff-limited':
+        if e.args[1].endswith('NLopt roundoff-limited'):
             assertion(True)
         else:
             assertion(False)

--- a/libensemble/tests/regression_tests/test_sim_dirs_with_exception.py
+++ b/libensemble/tests/regression_tests/test_sim_dirs_with_exception.py
@@ -21,9 +21,10 @@ from libensemble.libE import libE
 from libensemble.tests.regression_tests.support import write_sim_func as sim_f
 from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
 from libensemble.tools import parse_args, add_unique_random_streams
-from libensemble.manager import ManagerException
+from libensemble.manager import LoggedException
 
 nworkers, is_manager, libE_specs, _ = parse_args()
+import pdb;pdb.set_trace()
 
 sim_input_dir = './sim_input_dir'
 dir_to_copy = sim_input_dir + '/copy_this'
@@ -63,7 +64,7 @@ return_flag = 1
 try:
     H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria,
                                 persis_info, libE_specs=libE_specs)
-except ManagerException as e:
+except LoggedException as e:
     print("Caught deliberate exception: {}".format(e))
     return_flag = 0
 

--- a/libensemble/tests/regression_tests/test_sim_dirs_with_exception.py
+++ b/libensemble/tests/regression_tests/test_sim_dirs_with_exception.py
@@ -24,7 +24,6 @@ from libensemble.tools import parse_args, add_unique_random_streams
 from libensemble.manager import LoggedException
 
 nworkers, is_manager, libE_specs, _ = parse_args()
-import pdb;pdb.set_trace()
 
 sim_input_dir = './sim_input_dir'
 dir_to_copy = sim_input_dir + '/copy_this'

--- a/libensemble/tests/regression_tests/test_worker_exceptions.py
+++ b/libensemble/tests/regression_tests/test_worker_exceptions.py
@@ -18,7 +18,7 @@ import numpy as np
 from libensemble.libE import libE
 from libensemble.tests.regression_tests.support import nan_func as sim_f
 from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
-from libensemble.manager import ManagerException
+from libensemble.manager import LoggedException
 from libensemble.tools import parse_args, add_unique_random_streams
 
 nworkers, is_manager, libE_specs, _ = parse_args()
@@ -46,7 +46,7 @@ return_flag = 1
 try:
     H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria,
                                 persis_info, libE_specs=libE_specs)
-except ManagerException as e:
+except LoggedException as e:
     print("Caught deliberate exception: {}".format(e))
     return_flag = 0
 

--- a/libensemble/tests/unit_tests/test_libE_main.py
+++ b/libensemble/tests/unit_tests/test_libE_main.py
@@ -4,6 +4,7 @@ import pytest
 import mock
 
 from libensemble.libE import check_inputs, libE
+from libensemble.manager import LoggedException
 import libensemble.tests.unit_tests.setup as setup
 from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from mpi4py import MPI
@@ -112,7 +113,7 @@ def test_exception_raising_manager_no_abort():
     will be caught by libE and raise MPIAbortException from fakeMPI.Abort"""
     libE_specs['abort_on_exception'] = False
     libE_specs['mpi_comm'] = fake_mpi
-    with pytest.raises(MPISendException):
+    with pytest.raises(LoggedException):
         sim_specs, gen_specs, exit_criteria = setup.make_criteria_and_specs_0()
         libE(sim_specs, gen_specs, exit_criteria, libE_specs=libE_specs)
         pytest.fail('Expected MPISendException exception')

--- a/libensemble/tools/gen_support.py
+++ b/libensemble/tools/gen_support.py
@@ -37,5 +37,9 @@ def get_mgr_worker_msg(comm):
     if tag in [STOP_TAG, PERSIS_STOP]:
         comm.push_to_buffer(tag, Work)
         return tag, Work, None
-    _, calc_in = comm.recv()
+    data_tag, calc_in = comm.recv()
+    # Check for unexpected STOP (e.g. error between sending Work info and rows)
+    if data_tag in [STOP_TAG, PERSIS_STOP]:
+        comm.push_to_buffer(data_tag, calc_in)
+        return data_tag, calc_in, None  # calc_in is signal identifier
     return tag, Work, calc_in

--- a/libensemble/worker.py
+++ b/libensemble/worker.py
@@ -206,11 +206,9 @@ class Worker:
         timer = Timer()
 
         try:
-            logger.debug("Running {}".format(calc_type_strings[calc_type]))
+            logger.debug("Starting {}: {}".format(enum_desc, calc_id))
             calc = self._run_calc[calc_type]
             with timer:
-                logger.debug("Calling calc {}".format(calc_type))
-
                 if self.EnsembleDirectory.use_calc_dirs(calc_type):
                     loc_stack, calc_dir = self.EnsembleDirectory.prep_calc_dir(Work, self.calc_iter,
                                                                                self.workerID, calc_type)
@@ -219,7 +217,7 @@ class Worker:
                 else:
                     out = calc(calc_in, Work['persis_info'], Work['libE_info'])
 
-                logger.debug("Return from calc call")
+                logger.debug("Returned from user function for {} {}".format(enum_desc, calc_id))
 
             assert isinstance(out, tuple), \
                 "Calculation output must be a tuple."
@@ -239,8 +237,8 @@ class Worker:
                         calc_status = MAN_SIGNAL_FINISH
 
             return out[0], out[1], calc_status
-        except Exception:
-            logger.debug("Re-raising exception from calc")
+        except Exception as e:
+            logger.debug("Re-raising exception from calc {}".format(e))
             calc_status = CALC_EXCEPTION
             raise
         finally:

--- a/libensemble/worker.py
+++ b/libensemble/worker.py
@@ -25,9 +25,6 @@ from libensemble.comms.logs import LogConfig
 import cProfile
 import pstats
 
-if tuple(np.__version__.split('.')) >= ('1', '15'):
-    from numpy.lib.recfunctions import repack_fields
-
 logger = logging.getLogger(__name__)
 # To change logging level for just this module
 # logger.setLevel(logging.DEBUG)
@@ -276,10 +273,7 @@ class Worker:
         if len(libE_info['H_rows']) > 0:
             _, calc_in = self.comm.recv()
         else:
-            if 'repack_fields' in globals():
-                calc_in = repack_fields(np.zeros(0, dtype=self.dtypes[calc_type]), recurse=True)
-            else:
-                calc_in = np.zeros(0, dtype=self.dtypes[calc_type])
+            calc_in = np.zeros(0, dtype=self.dtypes[calc_type])
 
         logger.debug("Received calc_in ({}) of len {}".
                      format(calc_type_strings[calc_type], np.size(calc_in)))

--- a/libensemble/worker.py
+++ b/libensemble/worker.py
@@ -8,6 +8,7 @@ import logging
 import logging.handlers
 from itertools import count
 from traceback import format_exc
+from traceback import format_exception_only as format_exc_msg
 
 import numpy as np
 
@@ -326,7 +327,7 @@ class Worker:
                 self.comm.send(0, response)
 
         except Exception as e:
-            self.comm.send(0, WorkerErrMsg(str(e), format_exc()))
+            self.comm.send(0, WorkerErrMsg(' '.join(format_exc_msg(type(e), e)).strip(), format_exc()))
         else:
             self.comm.kill_pending()
         finally:

--- a/libensemble/worker.py
+++ b/libensemble/worker.py
@@ -329,7 +329,6 @@ class Worker:
 
         except Exception as e:
             self.comm.send(0, WorkerErrMsg(str(e), format_exc()))
-            self.EnsembleDirectory.copy_back()  # Copy back current results on Exception
         else:
             self.comm.kill_pending()
         finally:


### PR DESCRIPTION
Make exception handling more robust.

Catch exceptions in manager to ensure they get logged when worker
exceptions occur in the finally block.

Exception handling remains in libE to ensure exceptions in the manager
finally block are handled and abort/dump happens.

Final raise is disabled, this should be reviewed.
