### PR TITLE
Hugely simplify sim_dir exception test

### DIFF
--- a/libensemble/tests/regression_tests/test_sim_dirs_with_exception.py
+++ b/libensemble/tests/regression_tests/test_sim_dirs_with_exception.py
@@ -25,24 +25,13 @@ from libensemble.manager import ManagerException
 
 nworkers, is_manager, libE_specs, _ = parse_args()
 
-sim_input_dir = './sim_input_dir'
-dir_to_copy = sim_input_dir + '/copy_this'
-dir_to_symlink = sim_input_dir + '/symlink_this'
-e_ensemble = './ensemble_calcdirs_w' + str(nworkers) + '_' + libE_specs.get('comms')
-print('attempting to use ensemble dir: ', e_ensemble, flush=True)
-print('previous dir contains ', len(os.listdir(e_ensemble)), ' items.', flush=True)
+e_ensemble = './ensemble_ex_w' + str(nworkers) + '_' + libE_specs.get('comms')
 
-assert os.path.isdir(e_ensemble), \
-    "Previous ensemble directory doesn't exist. Can't test exception."
-assert len(os.listdir(e_ensemble)), \
-    "Previous ensemble directory doesn't have any contents. Can't catch exception."
+if not os.path.isdir(e_ensemble):
+    os.makedirs(os.path.join(e_ensemble, 'sim0_worker0'), exist_ok=True)
 
 libE_specs['sim_dirs_make'] = True
 libE_specs['ensemble_dir_path'] = e_ensemble
-libE_specs['use_worker_dirs'] = False
-libE_specs['sim_dir_copy_files'] = [dir_to_copy]
-libE_specs['sim_dir_symlink_files'] = [dir_to_symlink]
-
 libE_specs['abort_on_exception'] = False
 
 sim_specs = {'sim_f': sim_f, 'in': ['x'], 'out': [('f', float)]}


### PR DESCRIPTION
Fixes my silly design choice of having this test rely on output from a previous calc_dir test