### PR TITLE
Feature/break main loop differently

### DIFF
--- a/libensemble/history.py
+++ b/libensemble/history.py
@@ -31,10 +31,10 @@ class History:
     :ivar int given_count:
         Number of points given to sim fuctions (according to H)
 
-    :ivar int sim_count:
+    :ivar int returned_count:
         Number of points evaluated  (according to H)
 
-    Note that index, given_count and sim_count reflect the total number of points
+    Note that index, given_count and returned_count reflect the total number of points
     in H and therefore include those prepended to H in addition to the current run.
 
     """
@@ -85,7 +85,7 @@ class History:
 
         self.given_count = np.sum(H['given'])
 
-        self.sim_count = np.sum(H['returned'])
+        self.returned_count = np.sum(H['returned'])
 
     def update_history_f(self, D, safe_mode):
         """
@@ -114,7 +114,7 @@ class History:
 
             self.H['returned'][ind] = True
             self.H['returned_time'][ind] = time.time()
-            self.sim_count += 1
+            self.returned_count += 1
 
     def update_history_x_out(self, q_inds, sim_worker):
         """

--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -487,9 +487,9 @@ def libE_tcp_worker(sim_specs, gen_specs, libE_specs):
 def _dump_on_abort(hist, persis_info, save_H=True):
     logger.error("Manager exception raised .. aborting ensemble:")
     logger.error("Dumping ensemble history with {} sims evaluated:".
-                 format(hist.sim_count))
+                 format(hist.returned_count))
 
     if save_H:
-        np.save('libE_history_at_abort_' + str(hist.sim_count) + '.npy', hist.trim_H())
-        with open('libE_persis_info_at_abort_' + str(hist.sim_count) + '.pickle', "wb") as f:
+        np.save('libE_history_at_abort_' + str(hist.returned_count) + '.npy', hist.trim_H())
+        with open('libE_persis_info_at_abort_' + str(hist.returned_count) + '.pickle', "wb") as f:
             pickle.dump(persis_info, f)

--- a/libensemble/manager.py
+++ b/libensemble/manager.py
@@ -206,6 +206,16 @@ class Manager:
         H = self.hist.H
         return np.any(filter_nans(H[key][H['returned']]) <= val)
 
+    def work_giving_term_test(self, logged=True):
+        b = self.term_test()
+        if b:
+            return b
+        elif 'sim_max' in self.exit_criteria and self.hist.given_count >= self.exit_criteria['sim_max']:
+            # To avoid starting more sims if sim_max is an exit criteria
+            return 1
+        else:
+            return 0
+
     def term_test(self, logged=True):
         """Checks termination criteria"""
         for retval, key, testf in self.term_tests:
@@ -521,7 +531,7 @@ class Manager:
                         break
 
                     for w in Work:
-                        if self.term_test():
+                        if self.work_giving_term_test():
                             break
                         self._check_work_order(Work[w], w)
                         self._send_work_order(Work[w], w)

--- a/libensemble/manager.py
+++ b/libensemble/manager.py
@@ -210,7 +210,8 @@ class Manager:
         b = self.term_test()
         if b:
             return b
-        elif 'sim_max' in self.exit_criteria and self.hist.given_count >= self.exit_criteria['sim_max'] + self.hist.offset:
+        elif ('sim_max' in self.exit_criteria
+              and self.hist.given_count >= self.exit_criteria['sim_max'] + self.hist.offset):
             # To avoid starting more sims if sim_max is an exit criteria
             logger.info("Ignoring the alloc_f request for more sims than sim_max.")
             return 1
@@ -537,7 +538,7 @@ class Manager:
                         self._check_work_order(Work[w], w)
                         self._send_work_order(Work[w], w)
                         self._update_state_on_alloc(Work[w], w)
-                assert self.work_giving_term_test() or any(self.W['active'] != 0), \
+                assert self.term_test() or any(self.W['active'] != 0), \
                     "alloc_f did not return any work, although all workers are idle."
         except WorkerException as e:
             report_worker_exc(e)

--- a/libensemble/manager.py
+++ b/libensemble/manager.py
@@ -212,6 +212,7 @@ class Manager:
             return b
         elif 'sim_max' in self.exit_criteria and self.hist.given_count >= self.exit_criteria['sim_max']:
             # To avoid starting more sims if sim_max is an exit criteria
+            logger.info("Ignoring the alloc_f request for more sims than sim_max.")
             return 1
         else:
             return 0

--- a/libensemble/manager.py
+++ b/libensemble/manager.py
@@ -194,7 +194,7 @@ class Manager:
 
     def term_test_sim_max(self, sim_max):
         """Checks against max simulations"""
-        return self.hist.given_count >= sim_max + self.hist.offset
+        return self.hist.returned_count >= sim_max + self.hist.offset
 
     def term_test_gen_max(self, gen_max):
         """Checks against max generator calls"""

--- a/libensemble/manager.py
+++ b/libensemble/manager.py
@@ -210,7 +210,7 @@ class Manager:
         b = self.term_test()
         if b:
             return b
-        elif 'sim_max' in self.exit_criteria and self.hist.given_count >= self.exit_criteria['sim_max']:
+        elif 'sim_max' in self.exit_criteria and self.hist.given_count >= self.exit_criteria['sim_max'] + self.hist.offset:
             # To avoid starting more sims if sim_max is an exit criteria
             logger.info("Ignoring the alloc_f request for more sims than sim_max.")
             return 1
@@ -537,7 +537,7 @@ class Manager:
                         self._check_work_order(Work[w], w)
                         self._send_work_order(Work[w], w)
                         self._update_state_on_alloc(Work[w], w)
-                assert self.term_test() or any(self.W['active'] != 0), \
+                assert self.work_giving_term_test() or any(self.W['active'] != 0), \
                     "alloc_f did not return any work, although all workers are idle."
         except WorkerException as e:
             report_worker_exc(e)

--- a/libensemble/manager.py
+++ b/libensemble/manager.py
@@ -237,7 +237,7 @@ class Manager:
     def _save_every_k_sims(self):
         "Saves history every kth sim step"
         self._save_every_k('libE_history_for_run_starting_{}_after_sim_{}.npy',
-                           self.hist.sim_count,
+                           self.hist.returned_count,
                            self.libE_specs['save_every_k_sims'])
 
     def _save_every_k_gens(self):

--- a/libensemble/sim_funcs/executor_hworld.py
+++ b/libensemble/sim_funcs/executor_hworld.py
@@ -7,7 +7,7 @@ import numpy as np
 __all__ = ['executor_hworld']
 
 # Alt send values through X
-sim_count = 0
+returned_count = 0
 
 
 def polling_loop(exctr, task, timeout_sec=3.0, delay=0.3):
@@ -73,25 +73,25 @@ def executor_hworld(H, persis_info, sim_specs, libE_info):
 
     args_for_sim = 'sleep 1'
     # pref send this in X as a sim_in from calling script
-    global sim_count
-    sim_count += 1
+    global returned_count
+    returned_count += 1
     timeout = 6.0
     wait = False
     launch_shc = False
-    if sim_count == 1:
+    if returned_count == 1:
         args_for_sim = 'sleep 1'  # Should finish
-    elif sim_count == 2:
+    elif returned_count == 2:
         args_for_sim = 'sleep 1 Error'  # Worker kill on error
-    if sim_count == 3:
+    if returned_count == 3:
         wait = True
         args_for_sim = 'sleep 1'  # Should finish
         launch_shc = True
-    elif sim_count == 4:
+    elif returned_count == 4:
         args_for_sim = 'sleep 3'  # Worker kill on timeout
         timeout = 1.0
-    elif sim_count == 5:
+    elif returned_count == 5:
         args_for_sim = 'sleep 1 Fail'  # Manager kill - if signal received else completes
-    elif sim_count == 6:
+    elif returned_count == 6:
         args_for_sim = 'sleep 60'  # Manager kill - if signal received else completes
         timeout = 65.0
 

--- a/libensemble/tests/unit_tests/test_history.py
+++ b/libensemble/tests/unit_tests/test_history.py
@@ -90,7 +90,7 @@ def test_hist_init_1():
     assert np.array_equal(hist.H, wrs), "Array does not match expected"
     assert hist.given_count == 0
     assert hist.index == 0
-    assert hist.sim_count == 0
+    assert hist.returned_count == 0
 
 
 def test_hist_init_1A_H0():
@@ -104,7 +104,7 @@ def test_hist_init_1A_H0():
     # assert np.array_equal(hist.H, exp_H0_H), "Array does not match expected"
     assert hist.given_count == 3
     assert hist.index == 3
-    assert hist.sim_count == 3
+    assert hist.returned_count == 3
     assert len(hist.H) == 5
 
 
@@ -113,7 +113,7 @@ def test_hist_init_2():
     assert np.array_equal(hist.H, wrs2), "Array does not match expected"
     assert hist.given_count == 0
     assert hist.index == 0
-    assert hist.sim_count == 0
+    assert hist.returned_count == 0
 
 
 def test_grow_H():
@@ -123,7 +123,7 @@ def test_grow_H():
     assert np.array_equal(hist.H, wrs), "Array does not match expected"
     assert hist.given_count == 0
     assert hist.index == 0
-    assert hist.sim_count == 0
+    assert hist.returned_count == 0
 
 
 def test_trim_H():
@@ -133,7 +133,7 @@ def test_trim_H():
     assert np.array_equal(H, wrs), "Array does not match expected"
     assert hist.given_count == 0
     assert hist.index == 10
-    assert hist.sim_count == 0
+    assert hist.returned_count == 0
 
 
 def test_update_history_x_in_Oempty():
@@ -144,7 +144,7 @@ def test_update_history_x_in_Oempty():
     assert np.array_equal(hist.H, wrs2), "H Array does not match expected"
     assert hist.given_count == 0
     assert hist.index == 0
-    assert hist.sim_count == 0
+    assert hist.returned_count == 0
 
 
 def test_update_history_x_in():
@@ -165,7 +165,7 @@ def test_update_history_x_in():
     assert isclose(single_rand, hist.H['x'][0])
     assert hist.given_count == 0
     assert hist.index == 1
-    assert hist.sim_count == 0
+    assert hist.returned_count == 0
 
     size = 6
     gen_worker = 3
@@ -180,7 +180,7 @@ def test_update_history_x_in():
 
     assert hist.given_count == 0
     assert hist.index == 7
-    assert hist.sim_count == 0
+    assert hist.returned_count == 0
 
     # Force H to grow when add points
     size = 3
@@ -196,7 +196,7 @@ def test_update_history_x_in():
 
     assert hist.given_count == 0
     assert hist.index == 10
-    assert hist.sim_count == 0
+    assert hist.returned_count == 0
 
     # Test libE errors when a protected field appears in output from a gen_worker
     H_o = np.zeros(size, dtype=gen_specs['out'] + [('given', bool)])
@@ -227,7 +227,7 @@ def test_update_history_x_in_sim_ids():
     assert isclose(single_rand, hist.H['x'][0])
     assert hist.given_count == 0
     assert hist.index == 1
-    assert hist.sim_count == 0
+    assert hist.returned_count == 0
 
     size = 6
     gen_worker = 3
@@ -243,7 +243,7 @@ def test_update_history_x_in_sim_ids():
 
     assert hist.given_count == 0
     assert hist.index == 7
-    assert hist.sim_count == 0
+    assert hist.returned_count == 0
 
     # Force H to grow when add points
     size = 3
@@ -260,7 +260,7 @@ def test_update_history_x_in_sim_ids():
 
     assert hist.given_count == 0
     assert hist.index == 10
-    assert hist.sim_count == 0
+    assert hist.returned_count == 0
 
 
 # Note - Ideally have more setup here (so hist.index reflects generated points)
@@ -277,7 +277,7 @@ def test_update_history_x_out():
 
     # Check some unchanged values for point and counts
     assert hist.index == 0
-    assert hist.sim_count == 0
+    assert hist.returned_count == 0
     hist.H['returned'][0] = False
     hist.H['allocated'][0] = False
     hist.H['f'][0] == 0.0
@@ -307,7 +307,7 @@ def test_update_history_x_out():
     # Check counts
     assert hist.given_count == 6
     assert hist.index == 0  # In real case this would be ahead.....
-    assert hist.sim_count == 0
+    assert hist.returned_count == 0
 
 
 def test_update_history_f():
@@ -331,7 +331,7 @@ def test_update_history_f():
     assert isclose(exp_vals[0], hist.H['g'][0])
     assert np.all(hist.H['returned'][0:1])
     assert np.all(~hist.H['returned'][1:10])  # Check the rest
-    assert hist.sim_count == 1
+    assert hist.returned_count == 1
     assert hist.given_count == 0  # In real case this would be ahead.....
     assert hist.index == 0  # In real case this would be ahead....
 
@@ -355,7 +355,7 @@ def test_update_history_f():
     assert np.allclose(exp_vals, hist.H['g'])
     assert np.all(hist.H['returned'][0:3])
     assert np.all(~hist.H['returned'][3:10])  # Check the rest
-    assert hist.sim_count == 3
+    assert hist.returned_count == 3
     assert hist.given_count == 0  # In real case this would be ahead.....
     assert hist.index == 0  # In real case this would be ahead....
 
@@ -386,7 +386,7 @@ def test_update_history_f_vec():
     assert np.allclose(exp_fvecs[0], hist.H['fvec'][0])
     assert np.all(hist.H['returned'][0:1])
     assert np.all(~hist.H['returned'][1:10])  # Check the rest
-    assert hist.sim_count == 1
+    assert hist.returned_count == 1
     assert hist.given_count == 0  # In real case this would be ahead.....
     assert hist.index == 0  # In real case this would be ahead....
 
@@ -419,7 +419,7 @@ def test_update_history_f_vec():
     assert np.allclose(exp_fvecs, hist.H['fvec'])
     assert np.all(hist.H['returned'][0:3])
     assert np.all(~hist.H['returned'][3:10])  # Check the rest
-    assert hist.sim_count == 3
+    assert hist.returned_count == 3
     assert hist.given_count == 0  # In real case this would be ahead.....
     assert hist.index == 0  # In real case this would be ahead....
 
@@ -454,7 +454,7 @@ def test_update_history_f_vec():
     assert np.allclose(exp_fvecs, hist.H['fvec'])
     assert np.all(hist.H['returned'][0:5])
     assert np.all(~hist.H['returned'][5:10])  # Check the rest
-    assert hist.sim_count == 5
+    assert hist.returned_count == 5
     assert hist.given_count == 0  # In real case this would be ahead.....
     assert hist.index == 0  # In real case this would be ahead....
 


### PR DESCRIPTION
Addresses issue raised in #620. This PR allows for the allocation function to be queried, even when `sim_max` sims have been given. Instead, the main loop is only broken if `sim_max` sims have been returned. 

Renamed `sim_count` to the more accurate `returned_count`

Also adjusted the test when work is given out to avoid overshooting `sim_max` sims being given (only if `sim_max` is an exit criteria.)
Addresses issue with the final communication with a persistent work as raised in #620.