### PR TITLE
added batched construction for Tasmanian

### DIFF
--- a/libensemble/gen_funcs/persistent_tasmanian.py
+++ b/libensemble/gen_funcs/persistent_tasmanian.py
@@ -16,7 +16,7 @@ def sparse_grid_batched(H, persis_info, gen_specs, libE_info):
 
     """
     U = gen_specs['user']
-    grid = U['grid']
+    grid = U['tasmanian_init']()  # initialize the grid
     allowed_refinements = ['setAnisotropicRefinement', 'setSurplusRefinement', 'none']
     assert 'refinement' in U and U['refinement'] in allowed_refinements, \
         "Must provide a gen_specs['user']['refinement'] in: {}".format(allowed_refinements)

--- a/libensemble/gen_funcs/persistent_tasmanian.py
+++ b/libensemble/gen_funcs/persistent_tasmanian.py
@@ -4,9 +4,9 @@ A persistent generator using the uncertainty quantification capabilities in
 """
 
 import numpy as np
-import Tasmanian
 from libensemble.message_numbers import STOP_TAG, PERSIS_STOP, FINISHED_PERSISTENT_GEN_TAG
 from libensemble.tools.gen_support import sendrecv_mgr_worker_msg
+
 
 def sparse_grid_batched(H, persis_info, gen_specs, libE_info):
     """
@@ -17,6 +17,9 @@ def sparse_grid_batched(H, persis_info, gen_specs, libE_info):
     """
     U = gen_specs['user']
     grid = U['grid']
+    allowed_refinements = ['setAnisotropicRefinement', 'setSurplusRefinement', 'none']
+    assert 'refinement' in U and U['refinement'] in allowed_refinements, \
+        "Must provide a gen_specs['user']['refinement'] in: {}".format(allowed_refinements)
 
     while grid.getNumNeeded() > 0:
         aPoints = grid.getNeededPoints()
@@ -52,6 +55,6 @@ def sparse_grid_batched(H, persis_info, gen_specs, libE_info):
                 assert 'sCriteria' in U
                 grid.setSurplusRefinement(U['fTolerance'], U['iOutput'], U['sCriteria'])
             else:
-                pass # called with refinement = none (or some typo)
+                pass  # called with refinement = none (or some typo)
 
     return H0, persis_info, FINISHED_PERSISTENT_GEN_TAG

--- a/libensemble/gen_funcs/persistent_tasmanian.py
+++ b/libensemble/gen_funcs/persistent_tasmanian.py
@@ -43,16 +43,15 @@ def sparse_grid_batched(H, persis_info, gen_specs, libE_info):
             grid.write(U['tasmanian_checkpoint_file'])
 
         # set refinement, using user['refinement'] to pick the refinement strategy
-        if 'refinement' in U:
-            if U['refinement'] == 'setAnisotropicRefinement':
-                assert 'sType' in U
-                assert 'iMinGrowth' in U
-                assert 'iOutput' in U
-                grid.setAnisotropicRefinement(U['sType'], U['iMinGrowth'], U['iOutput'])
-            elif U['refinement'] == 'setSurplusRefinement':
-                assert 'fTolerance' in U
-                assert 'iOutput' in U
-                assert 'sCriteria' in U
-                grid.setSurplusRefinement(U['fTolerance'], U['iOutput'], U['sCriteria'])
+        if U['refinement'] == 'setAnisotropicRefinement':
+            assert 'sType' in U
+            assert 'iMinGrowth' in U
+            assert 'iOutput' in U
+            grid.setAnisotropicRefinement(U['sType'], U['iMinGrowth'], U['iOutput'])
+        elif U['refinement'] == 'setSurplusRefinement':
+            assert 'fTolerance' in U
+            assert 'iOutput' in U
+            assert 'sCriteria' in U
+            grid.setSurplusRefinement(U['fTolerance'], U['iOutput'], U['sCriteria'])
 
     return H0, persis_info, FINISHED_PERSISTENT_GEN_TAG

--- a/libensemble/gen_funcs/persistent_tasmanian.py
+++ b/libensemble/gen_funcs/persistent_tasmanian.py
@@ -54,7 +54,5 @@ def sparse_grid_batched(H, persis_info, gen_specs, libE_info):
                 assert 'iOutput' in U
                 assert 'sCriteria' in U
                 grid.setSurplusRefinement(U['fTolerance'], U['iOutput'], U['sCriteria'])
-            else:
-                pass  # called with refinement = none (or some typo)
 
     return H0, persis_info, FINISHED_PERSISTENT_GEN_TAG

--- a/libensemble/gen_funcs/persistent_tasmanian.py
+++ b/libensemble/gen_funcs/persistent_tasmanian.py
@@ -8,35 +8,19 @@ import Tasmanian
 from libensemble.message_numbers import STOP_TAG, PERSIS_STOP, FINISHED_PERSISTENT_GEN_TAG
 from libensemble.tools.gen_support import sendrecv_mgr_worker_msg
 
-
-def sparse_grid(H, persis_info, gen_specs, libE_info):
+def sparse_grid_batched(H, persis_info, gen_specs, libE_info):
     """
-    This generator,  mirrors the Tasmanian
-    `sparse grid example <https://github.com/ORNL/TASMANIAN/blob/master/InterfacePython/example_sparse_grids_04.py>`_
-    loops over the given precisions, producing a grid of points
-    at which the `sim_f` should be evaluated. The points are communicated to the
-    manager, who coordinates their evaluation. After function values are
-    returned, they are used to update the model; the model is evaluated at a
-    point of interest.
+    Implements batched construction for a Tasmanian sparse grid,
+    using the loop described in Tasmanian Example 09:
+    `sparse grid example <https://github.com/ORNL/TASMANIAN/blob/master/InterfacePython/example_sparse_grids_09.py>`_
+
     """
     U = gen_specs['user']
+    grid = U['grid']
 
-    iNumInputs = U['NumInputs']
-    iNumOutputs = U['NumOutputs']
-    precisions = U['precisions']
-    aPointOfInterest = U['x0']
-
-    tag = None
-
-    persis_info['aResult'] = {}
-
-    for prec in precisions:
-        # Generate Tasmanian grid
-        grid = Tasmanian.makeGlobalGrid(iNumInputs, iNumOutputs, prec,
-                                        "iptotal", "clenshaw-curtis")
+    while grid.getNumNeeded() > 0:
         aPoints = grid.getNeededPoints()
 
-        # Return the points of that need to be evaluated to the manager
         H0 = np.zeros(len(aPoints), dtype=gen_specs['out'])
         H0['x'] = aPoints
 
@@ -47,14 +31,27 @@ def sparse_grid(H, persis_info, gen_specs, libE_info):
         aModelValues = calc_in['f']
 
         # Update surrogate on grid
-        t = aModelValues.reshape((aModelValues.shape[0], iNumOutputs))
+        t = aModelValues.reshape((aModelValues.shape[0], grid.getNumOutputs()))
         t = t.flatten()
         t = np.atleast_2d(t).T
         grid.loadNeededPoints(t)
 
-        # Evaluate grid
-        aResult = grid.evaluate(aPointOfInterest)
+        if 'tasmanian_checkpoint_file' in U:
+            grid.write(U['tasmanian_checkpoint_file'])
 
-        persis_info['aResult'][prec] = aResult
+        # set refinement, using user['refinement'] to pick the refinement strategy
+        if 'refinement' in U:
+            if U['refinement'] == 'setAnisotropicRefinement':
+                assert 'sType' in U
+                assert 'iMinGrowth' in U
+                assert 'iOutput' in U
+                grid.setAnisotropicRefinement(U['sType'], U['iMinGrowth'], U['iOutput'])
+            elif U['refinement'] == 'setSurplusRefinement':
+                assert 'fTolerance' in U
+                assert 'iOutput' in U
+                assert 'sCriteria' in U
+                grid.setSurplusRefinement(U['fTolerance'], U['iOutput'], U['sCriteria'])
+            else:
+                pass # called with refinement = none (or some typo)
 
     return H0, persis_info, FINISHED_PERSISTENT_GEN_TAG

--- a/libensemble/tests/regression_tests/test_persistent_tasmanian.py
+++ b/libensemble/tests/regression_tests/test_persistent_tasmanian.py
@@ -14,7 +14,7 @@ import numpy as np
 
 # Import libEnsemble items for this test
 from libensemble.libE import libE
-from libensemble.sim_funcs.six_hump_camel import six_hump_camel as sim_f, six_hump_camel_func
+from libensemble.sim_funcs.six_hump_camel import six_hump_camel as sim_f
 from libensemble.gen_funcs.persistent_tasmanian import sparse_grid_batched as gen_f_batched
 from libensemble.alloc_funcs.start_only_persistent import only_persistent_gens as alloc_f
 from libensemble.tools import parse_args, save_libE_output, add_unique_random_streams
@@ -67,7 +67,7 @@ for run in range(2):
         gen_specs['user']['refinement'] = 'none'
 
     if run == 1:
-        # refer to the Tasmanian manual: https://ornl.github.io/TASMANIAN/stable/classTasGrid_1_1TasmanianSparseGrid.html
+        # See Tasmanian manual: https://ornl.github.io/TASMANIAN/stable/classTasGrid_1_1TasmanianSparseGrid.html
         gen_specs['user']['refinement'] = 'setAnisotropicRefinement'
         gen_specs['user']['sType'] = 'iptotal'
         gen_specs['user']['iMinGrowth'] = 10

--- a/libensemble/tests/regression_tests/test_persistent_tasmanian.py
+++ b/libensemble/tests/regression_tests/test_persistent_tasmanian.py
@@ -31,11 +31,13 @@ def tasmanian_init_global():
     grid.setDomainTransform(np.array([[-5.0, 5.0], [-2.0, 2.0]]))
     return grid
 
+
 def tasmanian_init_localp():
     import Tasmanian
     grid = Tasmanian.makeLocalPolynomialGrid(num_dimensions, 1, 3)
     grid.setDomainTransform(np.array([[-5.0, 5.0], [-2.0, 2.0]]))
     return grid
+
 
 nworkers, is_manager, libE_specs, _ = parse_args()
 


### PR DESCRIPTION
Adding capabilities for static grid construction and batch refinement algorithms. The main contribution is the modification of the refinement loop, `while grid.getNumNeeded() > 0:` and performing refinement operations after the manager reports back each set of points.
