### PR TITLE
Bugfix/ddmd reference file fix

### DIFF
--- a/libensemble/tests/scaling_tests/ddmd/openmm_md_simf.py
+++ b/libensemble/tests/scaling_tests/ddmd/openmm_md_simf.py
@@ -19,7 +19,7 @@ def update_config_file(H, sim_specs):
         'experiment_directory': os.path.abspath('../' + H['gen_dir_loc'][0]),
         'output_path': here,
         'initial_pdb_dir': here,
-        'reference_pdb_file': os.path.join(here, '1FME-folded.pdb'),
+        'reference_pdb_file': sim_specs['user']['reference_pdb_file'],
         'simulation_length_ns': sim_specs['user']['sim_length_ns'],
         'task_idx': int(H['task_id']),
         'stage_idx': int(H['stage_id'])

--- a/libensemble/tests/scaling_tests/ddmd/run_libe_ddmd.py
+++ b/libensemble/tests/scaling_tests/ddmd/run_libe_ddmd.py
@@ -68,6 +68,7 @@ sim_specs = {'sim_f': run_openmm_sim_f,
              'user': {'sim_kill_minutes': 15,
                       'sim_length_ns': 1.0,
                       'poll_interval': 1,
+                      'reference_pdb_file': os.path.abspath(folded_url.split('/')[-1]),
                       'config_file': 'molecular_dynamics.yaml'}
              }
 
@@ -103,8 +104,7 @@ exit_criteria = {'sim_max': 120}
 # Additional libEnsemble settings to customize our ensemble directory
 libE_specs['sim_dirs_make'] = True
 libE_specs['sim_input_dir'] = './sim'
-libE_specs['sim_dir_symlink_files'] = [os.path.abspath(folded_url.split('/')[-1]),
-                                       os.path.abspath(unfolded_url.split('/')[-1])]
+libE_specs['sim_dir_symlink_files'] = [os.path.abspath(unfolded_url.split('/')[-1])]
 
 libE_specs['gen_dirs_make'] = True
 libE_specs['gen_input_dir'] = './gen'

--- a/libensemble/tests/scaling_tests/ddmd/run_libe_ddmd.py
+++ b/libensemble/tests/scaling_tests/ddmd/run_libe_ddmd.py
@@ -14,14 +14,11 @@ from openmm_md_simf import run_openmm_sim_f
 from keras_cvae_ml_genf import run_keras_cvae_ml_genf
 
 # Import DeepDriveMD components for registering with libEnsemble's executor
-try:
-    from deepdrivemd.sim.openmm import run_openmm
-    from deepdrivemd.aggregation.basic import aggregate
-    from deepdrivemd.models.keras_cvae import train
-    from deepdrivemd.selection.latest import select_model
-    from deepdrivemd.agents.lof import lof
-except ModuleNotFoundError:
-    pass
+from deepdrivemd.sim.openmm import run_openmm
+from deepdrivemd.aggregation.basic import aggregate
+from deepdrivemd.models.keras_cvae import train
+from deepdrivemd.selection.latest import select_model
+from deepdrivemd.agents.lof import lof
 
 logger.set_level('INFO')
 

--- a/libensemble/tests/scaling_tests/ddmd/swing_submit_central_onenode.sh
+++ b/libensemble/tests/scaling_tests/ddmd/swing_submit_central_onenode.sh
@@ -3,6 +3,7 @@
 #SBATCH --account=STARTUP-USERNAME
 #SBATCH --nodes=1
 #SBATCH --gres=gpu:4
+#SBATCH --ntasks=4
 #SBATCH --time=00:45:00
 
 # Make sure conda and environment are loaded and activated before sbatch


### PR DESCRIPTION
Fixes a reference file path issue, additional comments and clarifications in README, specifies ntasks in onenode submission script (multiple MD sims and GPUs on a single node can be used now)