### PR TITLE
Feature - Adds filter label for "extra" regression tests

### DIFF
--- a/.github/workflows/libE-ci.yml
+++ b/.github/workflows/libE-ci.yml
@@ -111,14 +111,14 @@ jobs:
         - name: Run tests, Ubuntu
           if: matrix.os == 'ubuntu-16.04'
           run: |
-           ./libensemble/tests/run-tests.sh -A "-W error" -z -${{ matrix.comms-type }}
+           ./libensemble/tests/run-tests.sh -e -A "-W error" -z -${{ matrix.comms-type }}
 
         - name: Run tests, macOS
           if: matrix.os == 'macos-latest'
           env:
               CONDA_BUILD_SYSROOT: /Users/runner/work/libensemble/sdk/MacOSX10.14.sdk
           run: |
-            ./libensemble/tests/run-tests.sh -A "-W error" -z -${{ matrix.comms-type }}
+            ./libensemble/tests/run-tests.sh -e -A "-W error" -z -${{ matrix.comms-type }}
 
         - name: Merge coverage, run Coveralls
           env:

--- a/.github/workflows/libE-ci.yml
+++ b/.github/workflows/libE-ci.yml
@@ -213,7 +213,7 @@ jobs:
         - name: Run test
           run: |
            source balsamactivate test-balsam
-           ./libensemble/tests/run-tests.sh -r -y 'test_balsam*' -z -l
+           ./libensemble/tests/run-tests.sh -re -y 'test_balsam*' -z -l
 
         - name: Merge coverage, run Coveralls
           env:

--- a/docs/data_structures/libE_specs.rst
+++ b/docs/data_structures/libE_specs.rst
@@ -75,8 +75,8 @@ Specifications for libEnsemble::
             moderate overhead.
             Default: True
         'kill_canceled_sims' [boolean]:
-            Will libE try to kill sims that user functions mark 'cancel_requested' as True. 
-            If False, the manager avoid this moderate overhead. 
+            Will libE try to kill sims that user functions mark 'cancel_requested' as True.
+            If False, the manager avoid this moderate overhead.
             Default: True
         'use_persis_return' [boolean]:
             Adds persistent function H return to managers history array.

--- a/libensemble/tests/regression_tests/scripts_used_by_reg_tests/test_balsam_hworld.py
+++ b/libensemble/tests/regression_tests/scripts_used_by_reg_tests/test_balsam_hworld.py
@@ -6,6 +6,7 @@ from libensemble.tests.regression_tests.common import modify_Balsam_worker, modi
 
 # TESTSUITE_COMMS: local
 # TESTSUITE_NPROCS: 3
+# TESTSUITE_EXTRA: true
 
 # This test is NOT submitted as a job to Balsam. script_test_balsam_hworld.py is
 #   the executable submitted to Balsam as a job. This test executes that job

--- a/libensemble/tests/regression_tests/test_1d_with_profile_sampling.py
+++ b/libensemble/tests/regression_tests/test_1d_with_profile_sampling.py
@@ -12,6 +12,7 @@
 # Do not change these lines - they are parsed by run-tests.sh
 # TESTSUITE_COMMS: mpi local tcp
 # TESTSUITE_NPROCS: 2 4
+# TESTSUITE_EXTRA: true
 
 import numpy as np
 import os

--- a/libensemble/tests/regression_tests/test_deap_nsga2.py
+++ b/libensemble/tests/regression_tests/test_deap_nsga2.py
@@ -6,6 +6,7 @@
 # Do not change these lines - they are parsed by run-tests.sh
 # TESTSUITE_COMMS: mpi local
 # TESTSUITE_NPROCS: 3 4
+# TESTSUITE_EXTRA: true
 
 import numpy as np
 from time import time

--- a/libensemble/tests/regression_tests/test_nan_func_old_aposmm.py
+++ b/libensemble/tests/regression_tests/test_nan_func_old_aposmm.py
@@ -12,6 +12,7 @@
 # Do not change these lines - they are parsed by run-tests.sh
 # TESTSUITE_COMMS: mpi local tcp
 # TESTSUITE_NPROCS: 2 4
+# TESTSUITE_EXTRA: true
 
 import numpy as np
 

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_dfols.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_dfols.py
@@ -12,6 +12,7 @@
 # Do not change these lines - they are parsed by run-tests.sh
 # TESTSUITE_COMMS: local mpi tcp
 # TESTSUITE_NPROCS: 4
+# TESTSUITE_EXTRA: true
 
 import sys
 import numpy as np

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_exception.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_exception.py
@@ -13,6 +13,7 @@
 # Do not change these lines - they are parsed by run-tests.sh
 # TESTSUITE_COMMS: local mpi
 # TESTSUITE_NPROCS: 4
+# TESTSUITE_EXTRA: true
 
 import sys
 import numpy as np

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_external_localopt.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_external_localopt.py
@@ -20,6 +20,7 @@
 # TESTSUITE_COMMS: local mpi tcp
 # TESTSUITE_NPROCS: 4
 # TESTSUITE_OS_SKIP: OSX
+# TESTSUITE_EXTRA: true
 
 import sys
 import numpy as np

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_nlopt.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_nlopt.py
@@ -13,6 +13,7 @@
 # Do not change these lines - they are parsed by run-tests.sh
 # TESTSUITE_COMMS: local mpi tcp
 # TESTSUITE_NPROCS: 3
+# TESTSUITE_EXTRA: true
 
 import sys
 import numpy as np

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_periodic.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_periodic.py
@@ -13,6 +13,7 @@
 # Do not change these lines - they are parsed by run-tests.sh
 # TESTSUITE_COMMS: local mpi
 # TESTSUITE_NPROCS: 4
+# TESTSUITE_EXTRA: true
 
 import sys
 import numpy as np

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_pounders.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_pounders.py
@@ -12,6 +12,7 @@
 # Do not change these lines - they are parsed by run-tests.sh
 # TESTSUITE_COMMS: local mpi tcp
 # TESTSUITE_NPROCS: 4
+# TESTSUITE_EXTRA: true
 
 import sys
 import numpy as np

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_scipy.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_scipy.py
@@ -13,6 +13,7 @@
 # Do not change these lines - they are parsed by run-tests.sh
 # TESTSUITE_COMMS: mpi local
 # TESTSUITE_NPROCS: 4
+# TESTSUITE_EXTRA: true
 
 import sys
 import numpy as np

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_tao_blmvm.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_tao_blmvm.py
@@ -13,6 +13,7 @@
 # Do not change these lines - they are parsed by run-tests.sh
 # TESTSUITE_COMMS: local mpi tcp
 # TESTSUITE_NPROCS: 4
+# TESTSUITE_EXTRA: true
 
 import sys
 import numpy as np

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_tao_nm.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_tao_nm.py
@@ -13,6 +13,7 @@
 # Do not change these lines - they are parsed by run-tests.sh
 # TESTSUITE_COMMS: local mpi tcp
 # TESTSUITE_NPROCS: 4
+# TESTSUITE_EXTRA: true
 
 import sys
 import numpy as np

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_timeout.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_timeout.py
@@ -12,6 +12,7 @@
 # Do not change these lines - they are parsed by run-tests.sh
 # TESTSUITE_COMMS: local mpi tcp
 # TESTSUITE_NPROCS: 4
+# TESTSUITE_EXTRA: true
 
 import sys
 import numpy as np

--- a/libensemble/tests/regression_tests/test_persistent_aposmm_with_grad.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_with_grad.py
@@ -13,6 +13,7 @@
 # Do not change these lines - they are parsed by run-tests.sh
 # TESTSUITE_COMMS: local mpi tcp
 # TESTSUITE_NPROCS: 4
+# TESTSUITE_EXTRA: true
 
 import sys
 import numpy as np

--- a/libensemble/tests/regression_tests/test_persistent_fd_param_finder.py
+++ b/libensemble/tests/regression_tests/test_persistent_fd_param_finder.py
@@ -11,6 +11,7 @@
 # TESTSUITE_COMMS: mpi
 # TESTSUITE_NPROCS: 4
 # TESTSUITE_OS_SKIP: OSX
+# TESTSUITE_EXTRA: true
 
 import sys
 import numpy as np

--- a/libensemble/tests/regression_tests/test_persistent_surmise_calib.py
+++ b/libensemble/tests/regression_tests/test_persistent_surmise_calib.py
@@ -22,6 +22,7 @@
 # Do not change these lines - they are parsed by run-tests.sh
 # TESTSUITE_COMMS: mpi local tcp
 # TESTSUITE_NPROCS: 3 4
+# TESTSUITE_EXTRA: true
 
 # Requires:
 #   Install Surmise package

--- a/libensemble/tests/regression_tests/test_persistent_surmise_killsims.py
+++ b/libensemble/tests/regression_tests/test_persistent_surmise_killsims.py
@@ -22,6 +22,7 @@
 # Do not change these lines - they are parsed by run-tests.sh
 # TESTSUITE_COMMS: mpi local tcp
 # TESTSUITE_NPROCS: 3 4
+# TESTSUITE_EXTRA: true
 
 # Requires:
 #   Install Surmise package

--- a/libensemble/tests/regression_tests/test_persistent_tasmanian.py
+++ b/libensemble/tests/regression_tests/test_persistent_tasmanian.py
@@ -8,6 +8,7 @@
 # TESTSUITE_COMMS: local
 # TESTSUITE_NPROCS: 4
 # TESTSUITE_OS_SKIP: OSX
+# TESTSUITE_EXTRA: true
 
 import sys
 import numpy as np

--- a/libensemble/tests/regression_tests/test_vtmop.py
+++ b/libensemble/tests/regression_tests/test_vtmop.py
@@ -21,6 +21,7 @@
 # Do not change these lines - they are parsed by run-tests.sh
 # TESTSUITE_COMMS:
 # TESTSUITE_NPROCS:
+# TESTSUITE_EXTRA: true
 
 import numpy as np
 import os

--- a/libensemble/tests/run-tests.sh
+++ b/libensemble/tests/run-tests.sh
@@ -18,6 +18,7 @@ export REG_TEST_LIST=test_*.py #unordered # override with -y
 export REG_USE_PYTEST=false
 export REG_TEST_OUTPUT_EXT=std.out #/dev/null
 export REG_STOP_ON_FAILURE=false
+export RUN_EXTRA=false
 #-----------------------------------------------------------------------------------------
 
 # Test Directories - all relative to project root dir
@@ -189,7 +190,7 @@ export RUN_TCP=false
 
 usage() {
   echo -e "\nUsage:"
-  echo "  $0 [-hcsurmltz] [-p <2|3>] [-n <string>] [-a <string>]" 1>&2;
+  echo "  $0 [-hcszurmlte] [-p <2|3>] [-A <string>] [-n <string>] [-a <string>] [-y <string>]" 1>&2;
   echo ""
   echo "Options:"
   echo "  -h              Show this help message and exit"
@@ -201,6 +202,7 @@ usage() {
   echo "  -m              Run the regression tests using MPI comms"
   echo "  -l              Run the regression tests using Local comms"
   echo "  -t              Run the regression tests using TCP comms"
+  echo "  -e              Run extra regression tests that require additional dependencies"
   echo "  -p {version}    Select a version of python. E.g. -p 2 will run with the python2 exe"
   echo "                  Note: This will literally run the python2/python3 exe. Default runs python"
   echo "  -A {-flag arg}  Supply arguments to python"
@@ -213,7 +215,7 @@ usage() {
   exit 1
 }
 
-while getopts ":p:n:a:y:A:hcszurmlt" opt; do
+while getopts ":p:n:a:y:A:hcszurmlte" opt; do
   case $opt in
     p)
       echo "Parameter supplied for Python version: $OPTARG" >&2
@@ -254,6 +256,10 @@ while getopts ":p:n:a:y:A:hcszurmlt" opt; do
     t)
       echo "Running only the TCP regression tests"
       export RUN_TCP=true
+      ;;
+    e)
+      echo "Running extra regression tests with additional dependencies"
+      export RUN_EXTRA=true
       ;;
     m)
       echo "Running only the MPI regression tests"
@@ -452,6 +458,12 @@ if [ "$root_found" = true ]; then
     for TEST_SCRIPT in $REG_TEST_LIST
     do
       COMMS_LIST=$(sed -n '/# TESTSUITE_COMMS/s/# TESTSUITE_COMMS: //p' $TEST_SCRIPT)
+      IS_EXTRA=$(sed -n '/# TESTSUITE_EXTRA/s/# TESTSUITE_EXTRA: //p' $TEST_SCRIPT)
+
+      if [[ "$IS_EXTRA" = "true" ]] && [[ "$RUN_EXTRA" = false ]]; then
+        continue
+      fi
+
       for LAUNCHER in $COMMS_LIST
       do
         #Need proc count here for now - still stop on failure etc.


### PR DESCRIPTION
Addresses #611 

Adds label to certain regression tests that excludes them from normal ``./run-tests.sh`` runs. I tried to pick those that have external dependencies that most users (or new users) don't have following a fresh install of libEnsemble. The idea is, following ``git clone ...libensemble.git`` that users can hopefully verify their installation with a quick ``./run-tests.sh``.

For our CI, and for those who want to run the entire regression test suite, the new ``./run-tests.sh -e`` option is available.

Will changes also be necessary for unit tests? I haven't decided yet, but would appreciate feedback on that or anything else. Thanks!