### PR TITLE
Feature/small 08 changes

### DIFF
--- a/docs/tutorials/aposmm_tutorial.rst
+++ b/docs/tutorials/aposmm_tutorial.rst
@@ -179,8 +179,7 @@ and :doc:`alloc_specs<../data_structures/alloc_specs>`:
                           'ub': np.array([2, 1])}    # Upper bound of search domain
                  }
 
-    alloc_specs = {'alloc_f': persistent_aposmm_alloc,
-                   'out': [('given_back', bool)], 'user': {}}
+    alloc_specs = {'alloc_f': persistent_aposmm_alloc}
 
 ``gen_specs['user']`` fields above that are required for APOSMM are:
 

--- a/docs/tutorials/calib_cancel_tutorial.rst
+++ b/docs/tutorials/calib_cancel_tutorial.rst
@@ -158,7 +158,6 @@ The allocation function used in this example is the *only_persistent_gens* funct
 .. code-block:: python
 
     alloc_specs = {'alloc_f': alloc_f,
-                   'out': [('given_back', bool)],
                    'user': {'init_sample_size': init_sample_size,
                             'async_return': True,
                             'active_recv_gen': True

--- a/libensemble/api.py
+++ b/libensemble/api.py
@@ -127,6 +127,8 @@ class Ensemble:
     def _get_outputs(loaded, type):
         """ Extracts output parameters from loaded yaml dict """
         outputs = loaded[type + '_specs'].get('outputs')
+        if not outputs:
+            return []
         fields = [i for i in outputs]
         field_params = [i for i in outputs.values()]
         results = []

--- a/libensemble/history.py
+++ b/libensemble/history.py
@@ -50,7 +50,7 @@ class History:
         L = exit_criteria.get('sim_max', 100)
 
         # Combine all 'out' fields (if they exist) in sim_specs, gen_specs, or alloc_specs
-        dtype_list = list(set(libE_fields + sum([k['out'] for k in [sim_specs, alloc_specs, gen_specs] if k], [])))
+        dtype_list = list(set(libE_fields + sum([k.get('out', []) for k in [sim_specs, alloc_specs, gen_specs] if k], [])))
         H = np.zeros(L + len(H0), dtype=dtype_list)  # This may be more history than is needed if H0 has un-given points
 
         if len(H0):

--- a/libensemble/history.py
+++ b/libensemble/history.py
@@ -50,7 +50,8 @@ class History:
         L = exit_criteria.get('sim_max', 100)
 
         # Combine all 'out' fields (if they exist) in sim_specs, gen_specs, or alloc_specs
-        dtype_list = list(set(libE_fields + sum([k.get('out', []) for k in [sim_specs, alloc_specs, gen_specs] if k], [])))
+        specs = [sim_specs, alloc_specs, gen_specs]
+        dtype_list = list(set(libE_fields + sum([k.get('out', []) for k in specs if k], [])))
         H = np.zeros(L + len(H0), dtype=dtype_list)  # This may be more history than is needed if H0 has un-given points
 
         if len(H0):

--- a/libensemble/tests/regression_tests/deap_nsga2.yaml
+++ b/libensemble/tests/regression_tests/deap_nsga2.yaml
@@ -36,12 +36,10 @@ gen_specs:
             - 2.0
         pop_size: 100
         indiv_size: 2
-        give_all_with_same_priority: True
         cxpb: 0.8
         eta: 20.0
 
 alloc_specs:
     function: libensemble.alloc_funcs.start_only_persistent.only_persistent_gens
-    outputs:
-        given_back:
-            type: bool
+    user:
+        give_all_with_same_priority: True

--- a/libensemble/tests/regression_tests/test_deap_nsga2.py
+++ b/libensemble/tests/regression_tests/test_deap_nsga2.py
@@ -61,16 +61,13 @@ gen_specs = {'gen_f': gen_f,
                       'weights': w,
                       'pop_size': pop_size,
                       'indiv_size': ind_size,
-                      'give_all_with_same_priority': True,
                       'cxpb': 0.8,  # probability two individuals are crossed
                       'eta': 20.0,  # large eta = low variation in children
                       'indpb': 0.8/ind_size}  # end user
              }  # end gen specs
 
 alloc_specs = {'alloc_f': alloc_f,
-               'user': {'give_all_with_same_priority': False},
-               'out': [],
-               }
+               'user': {'give_all_with_same_priority': True}}
 
 # Tell libEnsemble when to stop
 # 'sim_max' = number of simulation calls

--- a/libensemble/tests/scaling_tests/ddmd/run_libe_ddmd.py
+++ b/libensemble/tests/scaling_tests/ddmd/run_libe_ddmd.py
@@ -92,7 +92,7 @@ for app in ddmd_apps:
     gen_specs['out'].append((app + '_cstat', int))
 
 # Parameterize the provided allocation function
-alloc_specs = {'alloc_f': alloc_f, 'out': [('given_back', bool)],
+alloc_specs = {'alloc_f': alloc_f,
                'user': {'init_sample_size': MD_BATCH_SIZE}}
 
 # Specify when libEnsemble should shut down

--- a/libensemble/tools/check_inputs.py
+++ b/libensemble/tools/check_inputs.py
@@ -117,7 +117,7 @@ def check_H(H0, sim_specs, alloc_specs, gen_specs):
         # Set up dummy history to see if it agrees with H0
 
         # Combines all 'out' fields (if they exist) in sim_specs, gen_specs, or alloc_specs
-        dtype_list = list(set(libE_fields + sum([k['out'] for k in [sim_specs, alloc_specs, gen_specs] if k], [])))
+        dtype_list = list(set(libE_fields + sum([k.get('out', []) for k in [sim_specs, alloc_specs, gen_specs] if k], [])))
         Dummy_H = np.zeros(1 + len(H0), dtype=dtype_list)
 
         fields = H0.dtype.names

--- a/libensemble/tools/check_inputs.py
+++ b/libensemble/tools/check_inputs.py
@@ -117,7 +117,8 @@ def check_H(H0, sim_specs, alloc_specs, gen_specs):
         # Set up dummy history to see if it agrees with H0
 
         # Combines all 'out' fields (if they exist) in sim_specs, gen_specs, or alloc_specs
-        dtype_list = list(set(libE_fields + sum([k.get('out', []) for k in [sim_specs, alloc_specs, gen_specs] if k], [])))
+        specs = [sim_specs, alloc_specs, gen_specs]
+        dtype_list = list(set(libE_fields + sum([k.get('out', []) for k in specs if k], [])))
         Dummy_H = np.zeros(1 + len(H0), dtype=dtype_list)
 
         fields = H0.dtype.names


### PR DESCRIPTION
- No longer enforce presence of alloc_specs['out'], especially as an empty list.
- Remove 'given_back' from alloc_specs in tutorials
- Fixes to yaml files