### PR TITLE
Add persistent sim example.

### DIFF
--- a/docs/data_structures/libE_specs.rst
+++ b/docs/data_structures/libE_specs.rst
@@ -78,8 +78,11 @@ Specifications for libEnsemble::
             Will libE try to kill sims that user functions mark 'cancel_requested' as True.
             If False, the manager avoid this moderate overhead.
             Default: True
-        'use_persis_return' [boolean]:
-            Adds persistent function H return to managers history array.
+        'use_persis_return_gen' [boolean]:
+            Adds persistent generator function H return to managers history array.
+            Default: False
+        'use_persis_return_sim' [boolean]:
+            Adds persistent simulator function H return to managers history array.
             Default: False
         'final_fields' [list]:
             List of fields in H that the manager will return to persistent

--- a/libensemble/alloc_funcs/start_only_persistent.py
+++ b/libensemble/alloc_funcs/start_only_persistent.py
@@ -1,5 +1,5 @@
 import numpy as np
-from libensemble.message_numbers import EVAL_GEN_TAG
+from libensemble.message_numbers import EVAL_SIM_TAG, EVAL_GEN_TAG
 from libensemble.tools.alloc_support import AllocSupport, InsufficientFreeResources
 
 
@@ -104,5 +104,119 @@ def only_persistent_gens(W, H, sim_specs, gen_specs, alloc_specs, persis_info):
                 persis_info['num_gens_started'] = persis_info.get('num_gens_started', 0) + 1
                 gen_count += 1
 
+    del support
+    return Work, persis_info, 0
+
+
+def only_persistent_workers(W, H, sim_specs, gen_specs, alloc_specs, persis_info):
+    """
+    SH: TODO - Need to update docstring...
+    This allocation function will give simulation work if possible, but
+    otherwise start up to ``alloc_specs['user']['num_active_gens']``
+    persistent generators (defaulting to one).
+
+    By default, evaluation results are given back to the generator once
+    all generated points have been returned from the simulation evaluation.
+    If ``alloc_specs['user']['async_return']`` is set to True, then any
+    returned points are given back to the generator.
+
+    If any of the persistent generators has exited, then ensemble shutdown
+    is triggered.
+
+    **User options**:
+
+    To be provided in calling script: E.g., ``alloc_specs['user']['async_return'] = True``
+
+    init_sample_size: int, optional
+        Initial sample size - always return in batch. Default: 0
+
+    num_active_gens: int, optional
+        Maximum number of persistent generators to start. Default: 1
+
+    async_return: boolean, optional
+        Return results to gen as they come in (after sample). Default: False (batch return).
+
+    active_recv_gen: boolean, optional
+        Create gen in active receive mode. If True, the manager does not need to wait
+        for a return from the generator before sending further returned points.
+        Default: False
+
+
+    .. seealso::
+        `test_persistent_gensim_uniform_sampling.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_persistent_gensim_uniform_sampling.py>`_ # noqa
+    """
+
+    # Initialize alloc_specs['user'] as user.
+    user = alloc_specs.get('user', {})
+    sched_opts = user.get('scheduler_opts', {})
+    manage_resources = 'resource_sets' in H.dtype.names
+    active_recv_gen = user.get('active_recv_gen', False)  # Persistent gen can handle irregular communications
+    init_sample_size = user.get('init_sample_size', 0)   # Always batch return until this many evals complete
+    batch_give = user.get('give_all_with_same_priority', False)
+
+    support = AllocSupport(W, manage_resources, persis_info, sched_opts)
+    gen_count = support.count_persis_gens()
+    Work = {}
+
+    # Asynchronous return to generator
+    async_return = user.get('async_return', False) and sum(H['returned']) >= init_sample_size
+
+    if gen_count < persis_info.get('num_gens_started', 0):
+        # When a persistent gen worker is done, trigger a shutdown (returning exit condition of 1)
+        return Work, persis_info, 1
+
+    # Give evaluated results back to a running persistent gen
+    for wid in support.avail_worker_ids(persistent=EVAL_GEN_TAG, active_recv=active_recv_gen):
+        gen_inds = (H['gen_worker'] == wid)
+        returned_but_not_given = np.logical_and.reduce((H['returned'], ~H['given_back'], gen_inds))
+        if np.any(returned_but_not_given):
+            if async_return or support.all_returned(H, gen_inds):
+                point_ids = np.where(returned_but_not_given)[0]
+                Work[wid] = support.gen_work(wid, gen_specs['persis_in'], point_ids, persis_info.get(wid),
+                                             persistent=True, active_recv=active_recv_gen)
+                returned_but_not_given[point_ids] = False
+
+    # SH Make sure once set up persistent sim that it W array is correct.
+
+    # Now the give_sim_work_first part
+    points_to_evaluate = ~H['given'] & ~H['cancel_requested']
+    avail_workers = list(set(support.avail_worker_ids(persistent=False, zero_resource_workers=False)) |
+                         set(support.avail_worker_ids(persistent=EVAL_SIM_TAG, zero_resource_workers=False)))
+    for wid in avail_workers:
+
+        if not np.any(points_to_evaluate):
+            break
+
+        sim_ids_to_send = support.points_by_priority(H, points_avail=points_to_evaluate, batch=batch_give)
+
+        # Stop all persistent sims periodically.
+        if np.sum(H['returned']) >= persis_info.get('last_stop', 0) + user.get('stop_frequency', np.inf):
+            persis_info['last_stop'] = np.sum(H['returned'])
+            Work[wid] = support.stop_persis_worker(wid, sim_specs['in'], sim_ids_to_send,
+                                                   persis_info.get(wid), persistent=True)
+        else:
+            try:
+                # Note that resources will not change if worker is already persistent.
+                Work[wid] = support.sim_work(wid, H, sim_specs['in'], sim_ids_to_send,
+                                             persis_info.get(wid), persistent=True)
+            except InsufficientFreeResources:
+                break
+
+        points_to_evaluate[sim_ids_to_send] = False
+
+    # Start persistent gens if no worker to give out. Uses zero_resource_workers if defined.
+    if not np.any(points_to_evaluate):
+        avail_workers = support.avail_worker_ids(persistent=False, zero_resource_workers=True)
+
+        for wid in avail_workers:
+            if gen_count < user.get('num_active_gens', 1):
+                # Finally, start a persistent generator as there is nothing else to do.
+                try:
+                    Work[wid] = support.gen_work(wid, gen_specs.get('in', []), range(len(H)), persis_info.get(wid),
+                                                 persistent=True, active_recv=active_recv_gen)
+                except InsufficientFreeResources:
+                    break
+                persis_info['num_gens_started'] = persis_info.get('num_gens_started', 0) + 1
+                gen_count += 1
     del support
     return Work, persis_info, 0

--- a/libensemble/comms/comms.py
+++ b/libensemble/comms/comms.py
@@ -115,6 +115,7 @@ class QComm(Comm):
         self._outbox = outbox
         self._copy = copy_msg
         self.recv_buffer = None
+        self.last_work_dict = None
 
     def get_num_workers(self):
         """Return global _ncomms"""
@@ -146,6 +147,15 @@ class QComm(Comm):
     def mail_flag(self):
         "Check whether we know a message is ready for receipt."
         return not self._inbox.empty()
+
+    def reset_last_work_dict(self):
+        self.last_work_dict = None
+
+    def set_last_work_dict(self, work):
+        self.last_work_dict = work
+
+    def get_last_work_dict(self):
+        return self.last_work_dict
 
 
 class QCommThread(Comm):

--- a/libensemble/comms/mpi.py
+++ b/libensemble/comms/mpi.py
@@ -31,6 +31,7 @@ class MPIComm(Comm):
         self.status = MPI.Status()
         self._outbox = []
         self.recv_buffer = None
+        self.last_work_dict = None
 
     def __del__(self):
         "Wait on anything pending if comm is killed."
@@ -96,6 +97,15 @@ class MPIComm(Comm):
 
     def get_num_workers(self):
         return self.mpi_comm.Get_size() - 1
+
+    def reset_last_work_dict(self):
+        self.last_work_dict = None
+
+    def set_last_work_dict(self, work):
+        self.last_work_dict = work
+
+    def get_last_work_dict(self):
+        return self.last_work_dict
 
 
 class MainMPIComm(MPIComm):

--- a/libensemble/gen_funcs/persistent_aposmm.py
+++ b/libensemble/gen_funcs/persistent_aposmm.py
@@ -142,7 +142,7 @@ def aposmm(H, persis_info, gen_specs, libE_info):
 
     try:
         user_specs = gen_specs['user']
-        ps = PersistentSupport(libE_info['comm'], EVAL_GEN_TAG)
+        ps = PersistentSupport(libE_info, EVAL_GEN_TAG)
         n, n_s, rk_const, ld, mu, nu, comm, local_H = initialize_APOSMM(H, user_specs, libE_info)
         local_opters, sim_id_to_child_inds, run_order, run_pts, total_runs, fields_to_pass = initialize_children(user_specs)
         if user_specs['initial_sample_size'] != 0:

--- a/libensemble/gen_funcs/persistent_deap_nsga2.py
+++ b/libensemble/gen_funcs/persistent_deap_nsga2.py
@@ -90,7 +90,7 @@ def deap_nsga2(H, persis_info, gen_specs, libE_info):
 
     # Initialize NSGA2 DEAP toolbox
     toolbox = nsga2_toolbox(gen_specs)
-    ps = PersistentSupport(libE_info['comm'], EVAL_GEN_TAG)
+    ps = PersistentSupport(libE_info, EVAL_GEN_TAG)
 
     pop_size = gen_specs['user']['pop_size']
     # CXPB  is the probability with which two individuals are crossed

--- a/libensemble/gen_funcs/persistent_fd_param_finder.py
+++ b/libensemble/gen_funcs/persistent_fd_param_finder.py
@@ -49,7 +49,7 @@ def fd_param_finder(H, persis_info, gen_specs, libE_info):
     inform = np.zeros_like(noise_h_mat)
     Fnoise = np.zeros_like(noise_h_mat)
     maxnoiseits = U['maxnoiseits']
-    ps = PersistentSupport(libE_info['comm'], EVAL_GEN_TAG)
+    ps = PersistentSupport(libE_info, EVAL_GEN_TAG)
 
     n = len(x0)
     Fhist0 = np.zeros((n, p, nf+1))

--- a/libensemble/gen_funcs/persistent_gp.py
+++ b/libensemble/gen_funcs/persistent_gp.py
@@ -32,7 +32,7 @@ def persistent_gp_gen_f(H, persis_info, gen_specs, libE_info):
     # Extract bounds of the parameter space, and batch size
     ub_list = gen_specs['user']['ub']
     lb_list = gen_specs['user']['lb']
-    ps = PersistentSupport(libE_info['comm'], EVAL_GEN_TAG)
+    ps = PersistentSupport(libE_info, EVAL_GEN_TAG)
 
     # Number of points to generate initially
     number_of_gen_points = gen_specs['user']['gen_batch_size']
@@ -100,7 +100,7 @@ def persistent_gp_mf_gen_f(H, persis_info, gen_specs, libE_info):
     # Extract bounds of the parameter space, and batch size
     ub_list = gen_specs['user']['ub']
     lb_list = gen_specs['user']['lb']
-    ps = PersistentSupport(libE_info['comm'], EVAL_GEN_TAG)
+    ps = PersistentSupport(libE_info, EVAL_GEN_TAG)
 
     # Fidelity range.
     fidel_range = gen_specs['user']['range']
@@ -184,7 +184,7 @@ def persistent_gp_mf_disc_gen_f(H, persis_info, gen_specs, libE_info):
     # Extract bounds of the parameter space, and batch size
     ub_list = gen_specs['user']['ub']
     lb_list = gen_specs['user']['lb']
-    ps = PersistentSupport(libE_info['comm'], EVAL_GEN_TAG)
+    ps = PersistentSupport(libE_info, EVAL_GEN_TAG)
 
     # Multifidelity settings.
     cost_func = gen_specs['user']['cost_func']

--- a/libensemble/gen_funcs/persistent_inverse_bayes.py
+++ b/libensemble/gen_funcs/persistent_inverse_bayes.py
@@ -12,7 +12,7 @@ def persistent_updater_after_likelihood(H, persis_info, gen_specs, libE_info):
     n = len(lb)
     subbatch_size = gen_specs['user']['subbatch_size']
     num_subbatches = gen_specs['user']['num_subbatches']
-    ps = PersistentSupport(libE_info['comm'], EVAL_GEN_TAG)
+    ps = PersistentSupport(libE_info, EVAL_GEN_TAG)
 
     # Receive information from the manager (or a STOP_TAG)
     batch = -1

--- a/libensemble/gen_funcs/persistent_surmise_calib.py
+++ b/libensemble/gen_funcs/persistent_surmise_calib.py
@@ -137,7 +137,7 @@ def surmise_calib(H, persis_info, gen_specs, libE_info):
     obsvar_const = gen_specs['user']['obsvar']  # Constant for generator
     priorloc = gen_specs['user']['priorloc']
     priorscale = gen_specs['user']['priorscale']
-    ps = PersistentSupport(libE_info['comm'], EVAL_GEN_TAG)
+    ps = PersistentSupport(libE_info, EVAL_GEN_TAG)
 
     prior = thetaprior(priorloc, priorscale)
 

--- a/libensemble/gen_funcs/persistent_tasmanian.py
+++ b/libensemble/gen_funcs/persistent_tasmanian.py
@@ -16,7 +16,7 @@ def sparse_grid_batched(H, persis_info, gen_specs, libE_info):
 
     """
     U = gen_specs['user']
-    ps = PersistentSupport(libE_info['comm'], EVAL_GEN_TAG)
+    ps = PersistentSupport(libE_info, EVAL_GEN_TAG)
     grid = U['tasmanian_init']()  # initialize the grid
     allowed_refinements = ['setAnisotropicRefinement', 'setSurplusRefinement', 'none']
     assert 'refinement' in U and U['refinement'] in allowed_refinements, \

--- a/libensemble/gen_funcs/persistent_uniform_sampling.py
+++ b/libensemble/gen_funcs/persistent_uniform_sampling.py
@@ -24,7 +24,7 @@ def persistent_uniform(H, persis_info, gen_specs, libE_info):
     lb = gen_specs['user']['lb']
     n = len(lb)
     b = gen_specs['user']['initial_batch_size']
-    ps = PersistentSupport(libE_info['comm'], EVAL_GEN_TAG)
+    ps = PersistentSupport(libE_info, EVAL_GEN_TAG)
 
     # Send batches until manager sends stop tag
     tag = None

--- a/libensemble/gen_funcs/persistent_uniform_sampling.py
+++ b/libensemble/gen_funcs/persistent_uniform_sampling.py
@@ -57,7 +57,7 @@ def uniform_random_sample_with_variable_resources(H, persis_info, gen_specs, lib
     lb = gen_specs['user']['lb']
     n = len(lb)
     b = gen_specs['user']['initial_batch_size']
-    ps = PersistentSupport(libE_info['comm'], EVAL_GEN_TAG)
+    ps = PersistentSupport(libE_info, EVAL_GEN_TAG)
 
     H_o = np.zeros(b, dtype=gen_specs['out'])
     for i in range(0, b):
@@ -100,7 +100,7 @@ def persistent_request_shutdown(H, persis_info, gen_specs, libE_info):
     b = gen_specs['user']['initial_batch_size']
     shutdown_limit = gen_specs['user']['shutdown_limit']
     f_count = 0
-    ps = PersistentSupport(libE_info['comm'], EVAL_GEN_TAG)
+    ps = PersistentSupport(libE_info, EVAL_GEN_TAG)
 
     # Send batches until manager sends stop tag
     tag = None

--- a/libensemble/gen_funcs/uniform_or_localopt.py
+++ b/libensemble/gen_funcs/uniform_or_localopt.py
@@ -49,7 +49,7 @@ def try_and_run_nlopt(H, gen_specs, libE_info):
     order receive function values for points of interest.
     """
 
-    ps = PersistentSupport(libE_info['comm'], EVAL_GEN_TAG)
+    ps = PersistentSupport(libE_info, EVAL_GEN_TAG)
 
     def nlopt_obj_fun(x, grad):
 

--- a/libensemble/manager.py
+++ b/libensemble/manager.py
@@ -419,11 +419,11 @@ class Manager:
                            FINISHED_PERSISTENT_GEN_TAG]:
             final_data = D_recv.get('calc_out', None)
             if isinstance(final_data, np.ndarray):
-                if self.libE_specs.get('use_persis_return', False):
-                    if calc_status is FINISHED_PERSISTENT_GEN_TAG:
-                        self.hist.update_history_x_in(w, final_data, self.safe_mode)
-                    else:
-                        self.hist.update_history_f(D_recv, self.safe_mode)
+                # SH TODO update other examples
+                if calc_status is FINISHED_PERSISTENT_GEN_TAG and self.libE_specs.get('use_persis_return_gen', False):
+                    self.hist.update_history_x_in(w, final_data, self.safe_mode)
+                elif calc_status is FINISHED_PERSISTENT_SIM_TAG and self.libE_specs.get('use_persis_return_sim', False):
+                    self.hist.update_history_f(D_recv, self.safe_mode)
                 else:
                     logger.info(_PERSIS_RETURN_WARNING)
             self.W[w-1]['persis_state'] = 0

--- a/libensemble/manager.py
+++ b/libensemble/manager.py
@@ -419,7 +419,6 @@ class Manager:
                            FINISHED_PERSISTENT_GEN_TAG]:
             final_data = D_recv.get('calc_out', None)
             if isinstance(final_data, np.ndarray):
-                # SH TODO update other examples
                 if calc_status is FINISHED_PERSISTENT_GEN_TAG and self.libE_specs.get('use_persis_return_gen', False):
                     self.hist.update_history_x_in(w, final_data, self.safe_mode)
                 elif calc_status is FINISHED_PERSISTENT_SIM_TAG and self.libE_specs.get('use_persis_return_sim', False):

--- a/libensemble/message_numbers.py
+++ b/libensemble/message_numbers.py
@@ -18,6 +18,7 @@ PERSIS_STOP = 4          # Manager tells persistent calculation to stop
 calc_type_strings = {
     EVAL_SIM_TAG: 'sim',
     EVAL_GEN_TAG: 'gen',
+    PERSIS_STOP: 'STOP with work',
     None: 'No type set'
 }
 

--- a/libensemble/sim_funcs/six_hump_camel.py
+++ b/libensemble/sim_funcs/six_hump_camel.py
@@ -174,9 +174,9 @@ def persistent_six_hump_camel(H, persis_info, sim_specs, libE_info):
     Similar to ``six_hump_camel``, but runs in persistent mode.
     """
 
-    ps = PersistentSupport(libE_info['comm'], EVAL_SIM_TAG)
+    ps = PersistentSupport(libE_info, EVAL_SIM_TAG)
 
-    # Could start with a work item to process - or just start and wait for data
+    # Either start with a work item to process - or just start and wait for data
     if H.size > 0:
         tag = None
         Work = None
@@ -186,6 +186,7 @@ def persistent_six_hump_camel(H, persis_info, sim_specs, libE_info):
 
     while tag not in [STOP_TAG, PERSIS_STOP]:
 
+        # calc_in: This should either be a function (unpack_work ?) or included/unpacked in ps.recv/ps.send_recv.
         if Work is not None:
             persis_info = Work.get('persis_info', persis_info)
             libE_info = Work.get('libE_info', libE_info)
@@ -193,18 +194,9 @@ def persistent_six_hump_camel(H, persis_info, sim_specs, libE_info):
         # Call standard six_hump_camel sim
         H_o, persis_info = six_hump_camel(calc_in, persis_info, sim_specs, libE_info)
 
-        # SH Must return correct libE_info as this contains H_rows for H on manager.
-        # SH Or can libE_info received be stored in support function?
-        tag, Work, calc_in = ps.send_recv(H_o, libE_info=libE_info)
+        tag, Work, calc_in = ps.send_recv(H_o)
 
-    if calc_in is not None:
-        # If PERSIS_STOP signal came with data, run calculation now.
-        H_o, persis_info = six_hump_camel(calc_in, persis_info, sim_specs, libE_info)
-        final_return = H_o
-    else:
-        final_return = None
-
-    return final_return, persis_info, FINISHED_PERSISTENT_SIM_TAG
+    return None, persis_info, FINISHED_PERSISTENT_SIM_TAG
 
 
 def six_hump_camel_func(x):

--- a/libensemble/sim_funcs/six_hump_camel.py
+++ b/libensemble/sim_funcs/six_hump_camel.py
@@ -196,7 +196,14 @@ def persistent_six_hump_camel(H, persis_info, sim_specs, libE_info):
 
         tag, Work, calc_in = ps.send_recv(H_o)
 
-    return None, persis_info, FINISHED_PERSISTENT_SIM_TAG
+    final_return = None
+
+    # Overwrite final point - for testing only
+    calc_in = np.ones(1, dtype=[('x', float, (2,))])
+    H_o, persis_info = six_hump_camel(calc_in, persis_info, sim_specs, libE_info)
+    final_return = H_o
+
+    return final_return, persis_info, FINISHED_PERSISTENT_SIM_TAG
 
 
 def six_hump_camel_func(x):

--- a/libensemble/tests/regression_tests/test_deap_nsga2.py
+++ b/libensemble/tests/regression_tests/test_deap_nsga2.py
@@ -111,8 +111,8 @@ for run in range(3):
     elif run == 1:
         H0[['given', 'returned', 'given_back']] = False
 
-        # Testing use_persis_return capabilities
-        libE_specs['use_persis_return'] = True
+        # Testing use_persis_return_gen capabilities
+        libE_specs['use_persis_return_gen'] = True
 
     else:
         H0 = None
@@ -123,10 +123,10 @@ for run in range(3):
     if is_manager:
         if run == 0:
             assert np.sum(H['last_points']) == 0, ("The last_points shouldn't be marked (even though "
-                                                   "they were marked in the gen) as 'use_persis_return' was false.")
+                                                   "they were marked in the gen) as 'use_persis_return_gen' was false.")
         elif run == 1:
-            assert np.sum(H['last_points']) == pop_size, ("The last_points should be marked as true because they "
-                                                          "were marked in the manager and 'use_persis_return' is true.")
+            assert np.sum(H['last_points']) == pop_size, ("The last_points should be marked as true because they were "
+                                                          "marked in the manager and 'use_persis_return_gen' is true.")
 
         script_name = os.path.splitext(os.path.basename(__file__))[0]
         assert flag == 0, script_name + " didn't exit correctly"

--- a/libensemble/tests/regression_tests/test_deap_nsga2_from_yaml.py
+++ b/libensemble/tests/regression_tests/test_deap_nsga2_from_yaml.py
@@ -75,8 +75,8 @@ if __name__ == "__main__":
                 objs = deap_six_hump(H_dummy, {}, deap_test.sim_specs, {})
                 H0['fitness_values'][i] = objs[0]
 
-            # Testing use_persis_return capabilities
-            deap_test.libE_specs['use_persis_return'] = True
+            # Testing use_persis_return_gen capabilities
+            deap_test.libE_specs['use_persis_return_gen'] = True
             deap_test.H0 = H0
         else:
             deap_test.H0 = None
@@ -88,11 +88,11 @@ if __name__ == "__main__":
             if run == 0:
                 assert np.sum(deap_test.H['last_points']) == 0, \
                     ("The last_points shouldn't be marked (even though "
-                     "they were marked in the gen) as 'use_persis_return' was false.")
+                     "they were marked in the gen) as 'use_persis_return_gen' was false.")
             elif run == 1:
                 assert np.sum(deap_test.H['last_points']) == 100, \
                     ("The last_points should be marked as true because they "
-                     "were marked in the manager and 'use_persis_return' is true.")
+                     "were marked in the manager and 'use_persis_return_gen' is true.")
 
             script_name = os.path.splitext(os.path.basename(__file__))[0]
             assert deap_test.flag == 0, script_name + " didn't exit correctly"

--- a/libensemble/tests/regression_tests/test_persistent_sim_uniform_sampling.py
+++ b/libensemble/tests/regression_tests/test_persistent_sim_uniform_sampling.py
@@ -1,0 +1,78 @@
+# """
+# Runs libEnsemble on the 6-hump camel problem. Documented here:
+#    https://www.sfu.ca/~ssurjano/camel6.html
+#
+# Execute via one of the following commands (e.g. 3 workers):
+#    mpiexec -np 4 python3 test_persistent_sim_uniform_sampling.py
+#    python3 test_persistent_sim_uniform_sampling.py --nworkers 3 --comms local
+#    python3 test_persistent_sim_uniform_sampling.py --nworkers 3 --comms tcp
+#
+# The number of concurrent evaluations of the objective function will be 4-1=3.
+# """
+
+# Do not change these lines - they are parsed by run-tests.sh
+# TESTSUITE_COMMS: mpi local tcp
+# TESTSUITE_NPROCS: 3 4
+
+# SH TODO: Regarding a persistent sim test
+# Should it insist on sending sims to particular workers (why is it persistent....)
+# - Or use active_recv mode to send back intermediate data.
+
+# Need to test final H data return (as with gens).
+# Should alloc setup all persistent workers at start
+#  - Whether need to specify in alloc: eg. give me a list of persistent sims
+#    - (then all persis allocs need updating to ask for persis gen only)
+# Determine test pass condition
+
+import sys
+import numpy as np
+
+# Import libEnsemble items for this test
+from libensemble.libE import libE
+from libensemble.sim_funcs.six_hump_camel import persistent_six_hump_camel as sim_f
+from libensemble.gen_funcs.persistent_uniform_sampling import persistent_uniform as gen_f
+from libensemble.alloc_funcs.start_only_persistent import only_persistent_workers as alloc_f
+from libensemble.tools import parse_args, save_libE_output, add_unique_random_streams
+
+from libensemble import logger
+logger.set_level('DEBUG')
+
+
+nworkers, is_manager, libE_specs, _ = parse_args()
+
+# libE_specs['use_persis_return_sim'] = True
+
+if nworkers < 2:
+    sys.exit("Cannot run with a persistent worker if only one worker -- aborting...")
+
+n = 2
+sim_specs = {'sim_f': sim_f,
+             'in': ['x'],
+             'out': [('f', float), ('grad', float, n)]}
+
+gen_specs = {'gen_f': gen_f,
+             'in': [],
+             'persis_in': ['sim_id', 'f', 'grad'],
+             'out': [('x', float, (n,))],
+             'user': {'initial_batch_size': 5,
+                      'lb': np.array([-3, -2]),
+                      'ub': np.array([3, 2]),
+                      # 'give_all_with_same_priority': True
+                      }
+             }
+
+alloc_specs = {'alloc_f': alloc_f, 'out': [('given_back', bool)]}
+alloc_specs['user'] = {'stop_frequency': 10}
+
+persis_info = add_unique_random_streams({}, nworkers + 1)
+
+exit_criteria = {'sim_max': 40, 'elapsed_wallclock_time': 300}
+
+# Perform the run
+H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
+                            alloc_specs, libE_specs)
+
+if is_manager:
+    assert len(np.unique(H['gen_time'])) == 8
+    assert not any((H['f'] == 0))
+    save_libE_output(H, persis_info, __file__, nworkers)

--- a/libensemble/tests/regression_tests/test_persistent_sim_uniform_sampling.py
+++ b/libensemble/tests/regression_tests/test_persistent_sim_uniform_sampling.py
@@ -14,16 +14,6 @@
 # TESTSUITE_COMMS: mpi local tcp
 # TESTSUITE_NPROCS: 3 4
 
-# SH TODO: Regarding a persistent sim test
-# Should it insist on sending sims to particular workers (why is it persistent....)
-# - Or use active_recv mode to send back intermediate data.
-
-# Need to test final H data return (as with gens).
-# Should alloc setup all persistent workers at start
-#  - Whether need to specify in alloc: eg. give me a list of persistent sims
-#    - (then all persis allocs need updating to ask for persis gen only)
-# Determine test pass condition
-
 import sys
 import numpy as np
 
@@ -34,13 +24,12 @@ from libensemble.gen_funcs.persistent_uniform_sampling import persistent_uniform
 from libensemble.alloc_funcs.start_only_persistent import only_persistent_workers as alloc_f
 from libensemble.tools import parse_args, save_libE_output, add_unique_random_streams
 
-from libensemble import logger
-logger.set_level('DEBUG')
-
+# from libensemble import logger
+# logger.set_level('DEBUG')
 
 nworkers, is_manager, libE_specs, _ = parse_args()
 
-# libE_specs['use_persis_return_sim'] = True
+libE_specs['zero_resource_workers'] = [1]  # Only necessary if sims use resources.
 
 if nworkers < 2:
     sys.exit("Cannot run with a persistent worker if only one worker -- aborting...")
@@ -61,8 +50,8 @@ gen_specs = {'gen_f': gen_f,
                       }
              }
 
-alloc_specs = {'alloc_f': alloc_f, 'out': [('given_back', bool)]}
-alloc_specs['user'] = {'stop_frequency': 10}
+alloc_specs = {'alloc_f': alloc_f}
+# alloc_specs['user'] = {'stop_frequency': 10}
 
 persis_info = add_unique_random_streams({}, nworkers + 1)
 

--- a/libensemble/tests/regression_tests/test_persistent_sim_uniform_sampling.py
+++ b/libensemble/tests/regression_tests/test_persistent_sim_uniform_sampling.py
@@ -31,6 +31,9 @@ nworkers, is_manager, libE_specs, _ = parse_args()
 
 libE_specs['zero_resource_workers'] = [1]  # Only necessary if sims use resources.
 
+libE_specs['use_persis_return_sim'] = True  # Only necessary if sims use resources.
+
+
 if nworkers < 2:
     sys.exit("Cannot run with a persistent worker if only one worker -- aborting...")
 
@@ -64,4 +67,7 @@ H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
 if is_manager:
     assert len(np.unique(H['gen_time'])) == 8
     assert not any((H['f'] == 0))
+    # Should overwrite the last value (in fact last (nworker-1) values) with f(1,1) = 3.23333333
+    assert not np.isclose(H['f'][0], 3.23333333)
+    assert np.isclose(H['f'][-1], 3.23333333)
     save_libE_output(H, persis_info, __file__, nworkers)

--- a/libensemble/tests/regression_tests/test_persistent_uniform_sampling_adv.py
+++ b/libensemble/tests/regression_tests/test_persistent_uniform_sampling_adv.py
@@ -26,7 +26,7 @@ from libensemble.tools import parse_args, save_libE_output, add_unique_random_st
 
 nworkers, is_manager, libE_specs, _ = parse_args()
 
-libE_specs['use_persis_return'] = True
+libE_specs['use_persis_return_gen'] = True
 
 if nworkers < 2:
     sys.exit("Cannot run with a persistent worker if only one worker -- aborting...")

--- a/libensemble/tools/alloc_support.py
+++ b/libensemble/tools/alloc_support.py
@@ -1,5 +1,5 @@
 import numpy as np
-from libensemble.message_numbers import EVAL_SIM_TAG, EVAL_GEN_TAG, PERSIS_STOP
+from libensemble.message_numbers import EVAL_SIM_TAG, EVAL_GEN_TAG
 from libensemble.resources.resources import Resources
 from libensemble.resources.scheduler import ResourceScheduler, InsufficientFreeResources  # noqa: F401
 

--- a/libensemble/tools/alloc_support.py
+++ b/libensemble/tools/alloc_support.py
@@ -199,20 +199,6 @@ class AllocSupport:
                 'tag': EVAL_GEN_TAG,
                 'libE_info': libE_info}
 
-    def stop_persis_worker(Work, i, H_fields, H_rows, persis_info, **libE_info):
-        """Create a work record for a persistent worker along with a request to leave persistent mode.
-
-        Parameters match the ``gen_work`` function.
-        A resource check is not required as the worker is already persistent.
-        """
-
-        H_fields = AllocSupport._check_H_fields(H_fields)
-        libE_info['H_rows'] = np.atleast_1d(H_rows)
-        return {'H_fields': H_fields,
-                'persis_info': persis_info,
-                'tag': PERSIS_STOP,
-                'libE_info': libE_info}
-
     def _filter_points(self, H_in, pt_filter, low_bound):
         """Returns H and pt_filter filted by lower bound
 

--- a/libensemble/tools/alloc_support.py
+++ b/libensemble/tools/alloc_support.py
@@ -1,5 +1,5 @@
 import numpy as np
-from libensemble.message_numbers import EVAL_SIM_TAG, EVAL_GEN_TAG
+from libensemble.message_numbers import EVAL_SIM_TAG, EVAL_GEN_TAG, PERSIS_STOP
 from libensemble.resources.resources import Resources
 from libensemble.resources.scheduler import ResourceScheduler, InsufficientFreeResources  # noqa: F401
 
@@ -197,6 +197,20 @@ class AllocSupport:
         return {'H_fields': H_fields,
                 'persis_info': persis_info,
                 'tag': EVAL_GEN_TAG,
+                'libE_info': libE_info}
+
+    def stop_persis_worker(Work, i, H_fields, H_rows, persis_info, **libE_info):
+        """Create a work record for a persistent worker along with a request to leave persistent mode.
+
+        Parameters match the ``gen_work`` function.
+        A resource check is not required as the worker is already persistent.
+        """
+
+        H_fields = AllocSupport._check_H_fields(H_fields)
+        libE_info['H_rows'] = np.atleast_1d(H_rows)
+        return {'H_fields': H_fields,
+                'persis_info': persis_info,
+                'tag': PERSIS_STOP,
                 'libE_info': libE_info}
 
     def _filter_points(self, H_in, pt_filter, low_bound):

--- a/libensemble/tools/alloc_support.py
+++ b/libensemble/tools/alloc_support.py
@@ -1,7 +1,13 @@
 import numpy as np
+import logging
 from libensemble.message_numbers import EVAL_SIM_TAG, EVAL_GEN_TAG
 from libensemble.resources.resources import Resources
 from libensemble.resources.scheduler import ResourceScheduler, InsufficientFreeResources  # noqa: F401
+from libensemble.output_directory import EnsembleDirectory
+
+logger = logging.getLogger(__name__)
+# For debug messages - uncomment
+# logger.setLevel(logging.DEBUG)
 
 
 class AllocException(Exception):
@@ -157,12 +163,16 @@ class AllocSupport:
         libE_info['rset_team'] = self._update_rset_team(libE_info, wid,
                                                         H=H, H_rows=H_rows)  # to parse out resource_sets
         H_fields = AllocSupport._check_H_fields(H_fields)
-        libE_info['H_rows'] = np.atleast_1d(H_rows)
+        libE_info['H_rows'] = AllocSupport._check_H_rows(H_rows)
 
-        return {'H_fields': H_fields,
+        work = {'H_fields': H_fields,
                 'persis_info': persis_info,
                 'tag': EVAL_SIM_TAG,
                 'libE_info': libE_info}
+
+        logger.debug("Alloc func packing SIM work for worker {}. Packing sim_ids: {}".
+                     format(wid, EnsembleDirectory.extract_H_ranges(work) or None))
+        return work
 
     def gen_work(self, wid, H_fields, H_rows, persis_info, **libE_info):
         """Add gen work record to given ``Work`` dictionary.
@@ -192,12 +202,16 @@ class AllocSupport:
             libE_info['gen_count'] = AllocSupport.gen_counter
 
         H_fields = AllocSupport._check_H_fields(H_fields)
-        libE_info['H_rows'] = np.atleast_1d(H_rows)
+        libE_info['H_rows'] = AllocSupport._check_H_rows(H_rows)
 
-        return {'H_fields': H_fields,
+        work = {'H_fields': H_fields,
                 'persis_info': persis_info,
                 'tag': EVAL_GEN_TAG,
                 'libE_info': libE_info}
+
+        logger.debug("Alloc func packing GEN work for worker {}. Packing sim_ids: {}".
+                     format(wid, EnsembleDirectory.extract_H_ranges(work) or None))
+        return work
 
     def _filter_points(self, H_in, pt_filter, low_bound):
         """Returns H and pt_filter filted by lower bound
@@ -277,10 +291,28 @@ class AllocSupport:
         return np.nonzero(points_avail)[0][q_inds]
 
     @staticmethod
+    def _check_H_rows(H_rows):
+        """Ensure H_rows is a numpy array.  If it is not, then convert if possible,
+        else raise an error.
+
+        :returns: ndarray. H_rows
+        """
+        H_rows = np.atleast_1d(H_rows)  # Makes sure a numpy scalar is an ndarray
+
+        if isinstance(H_rows, np.ndarray):
+            return H_rows
+        try:
+            H_rows = np.fromiter(H_rows, int)
+        except Exception:
+            raise AllocException("H_rows could not be converted to a numpy array. Type {}".
+                                 format(type(H_rows)))
+        return H_rows
+
+    @staticmethod
     def _check_H_fields(H_fields):
         """Ensure no duplicates in H_fields"""
         if len(H_fields) != len(set(H_fields)):
-            # logger.debug("Removing duplicate field when packing work request".format(H_fields))
+            logger.debug("Removing duplicate field(s) when packing work request. {}".format(H_fields))
             H_fields = list(set(H_fields))
             # H_fields = list(OrderedDict.fromkeys(H_fields))  # Maintain order
         return H_fields

--- a/libensemble/tools/consensus_subroutines.py
+++ b/libensemble/tools/consensus_subroutines.py
@@ -25,7 +25,7 @@ def print_final_score(x, f_i_idxs, gen_specs, libE_info):
     - gen_specs, libE_info :
         Used to communicate
     """
-    ps = PersistentSupport(libE_info['comm'], EVAL_GEN_TAG)
+    ps = PersistentSupport(libE_info, EVAL_GEN_TAG)
 
     # evaluate { f_i(x) } first
     H_o = np.zeros(len(f_i_idxs), dtype=gen_specs['out'])
@@ -68,7 +68,7 @@ def get_func_or_grad(x, f_i_idxs, gen_specs, libE_info, get_grad):
     - get_grad : bool
         True if we want gradient, otherwise returns function eval
     """
-    ps = PersistentSupport(libE_info['comm'], EVAL_GEN_TAG)
+    ps = PersistentSupport(libE_info, EVAL_GEN_TAG)
 
     H_o = np.zeros(len(f_i_idxs), dtype=gen_specs['out'])
     H_o['x'][:] = x
@@ -148,7 +148,7 @@ def get_neighbor_vals(x, local_gen_id, A_gen_ids_no_local, gen_specs, libE_info)
     H_o = np.zeros(1, dtype=gen_specs['out'])
     H_o['x'][0] = x
     H_o['consensus_pt'][0] = True
-    ps = PersistentSupport(libE_info['comm'], EVAL_GEN_TAG)
+    ps = PersistentSupport(libE_info, EVAL_GEN_TAG)
 
     tag, Work, calc_in = ps.send_recv(H_o)
     if tag in [STOP_TAG, PERSIS_STOP]:
@@ -194,7 +194,7 @@ def get_consensus_gradient(x, gen_specs, libE_info):
     H_o = np.zeros(1, dtype=gen_specs['out'])
     H_o['x'][0] = x
     H_o['consensus_pt'][0] = True
-    ps = PersistentSupport(libE_info['comm'], EVAL_GEN_TAG)
+    ps = PersistentSupport(libE_info, EVAL_GEN_TAG)
 
     tag, Work, calc_in = ps.send_recv(H_o)
 

--- a/libensemble/tools/fields_keys.py
+++ b/libensemble/tools/fields_keys.py
@@ -82,7 +82,8 @@ allowed_libE_spec_keys = ['abort_on_exception',             #
                           'save_every_k_gens',              #
                           'save_every_k_sims',              #
                           'save_H_and_persis_on_abort',     #
-                          'use_persis_return',              #
+                          'use_persis_return_gen',          #
+                          'use_persis_return_sim',          #
                           'workerID',                       #
                           'worker_timeout',                 #
                           'zero_resource_workers',          #

--- a/libensemble/tools/persistent_support.py
+++ b/libensemble/tools/persistent_support.py
@@ -2,6 +2,8 @@ from libensemble.message_numbers import STOP_TAG, PERSIS_STOP, UNSET_TAG, EVAL_G
 import logging
 logger = logging.getLogger(__name__)
 
+info_default = {'persistent': True}
+
 
 class PersistentSupport:
 
@@ -13,30 +15,37 @@ class PersistentSupport:
 
         self.calc_str = calc_type_strings[self.calc_type]
 
-    def send(self, output):
+    def send(self, output, libE_info=info_default, calc_status=UNSET_TAG):
         """Send message from worker to manager.
 
         :param output: Output array to be sent to manager
         :returns: None
         """
+
+        if 'comm' in libE_info:
+            # Cannot pickle a comm and should not need for return
+            libE_info = dict(libE_info)
+            libE_info.pop('comm')
+
         D = {'calc_out': output,
-             'libE_info': {'persistent': True},
-             'calc_status': UNSET_TAG,
+             'libE_info': libE_info,
+             'calc_status': calc_status,
              'calc_type': self.calc_type
              }
         logger.debug('Persistent {} function sending data message to manager'.format(self.calc_str))
         self.comm.send(self.calc_type, D)
 
     def recv(self):
-        """Get message to worker from manager.
+        """Receive message to worker from manager.
 
         :returns: message tag, Work dictionary, calc_in array
         """
         tag, Work = self.comm.recv()
         if tag in [STOP_TAG, PERSIS_STOP]:
             logger.debug('Persistent {} received signal {} from manager'.format(self.calc_str, tag))
-            self.comm.push_to_buffer(tag, Work)
-            return tag, Work, None
+            if not isinstance(Work, dict):
+                self.comm.push_to_buffer(tag, Work)
+                return tag, Work, None
 
         logger.debug('Persistent {} received work request from manager'.format(self.calc_str))
         data_tag, calc_in = self.comm.recv()
@@ -46,14 +55,17 @@ class PersistentSupport:
                          'from manager while expecting work rows')
             self.comm.push_to_buffer(data_tag, calc_in)
             return data_tag, calc_in, None  # calc_in is signal identifier
+
         logger.debug('Persistent {} received work rows from manager'.format(self.calc_str))
+        if tag in [STOP_TAG, PERSIS_STOP]:
+            self.comm.push_to_buffer(tag, Work)
         return tag, Work, calc_in
 
-    def send_recv(self, output):
+    def send_recv(self, output, libE_info=info_default, calc_status=UNSET_TAG):
         """Send message from worker to manager and receive response.
 
         :param output: Output array to be sent to manager
         :returns: message tag, Work dictionary, calc_in array
         """
-        self.send(output)
+        self.send(output, libE_info, calc_status)
         return self.recv()

--- a/libensemble/tools/persistent_support.py
+++ b/libensemble/tools/persistent_support.py
@@ -2,33 +2,35 @@ from libensemble.message_numbers import STOP_TAG, PERSIS_STOP, UNSET_TAG, EVAL_G
 import logging
 logger = logging.getLogger(__name__)
 
-info_default = {'persistent': True}
-
 
 class PersistentSupport:
+    """A helper class to assist with writing allocation functions."""
 
-    def __init__(self, comm, calc_type):
-        self.comm = comm
+    def __init__(self, libE_info, calc_type):
+        """Instantiate a new PersistentSupport instance
+
+        :param libE_info: A dictionary containing information about this work request
+        :param calc_type: Named integer giving calculation type - EVAL_GEN_TAG or EVAL_SIM_TAG
+        """
+        self.libE_info = libE_info
+        self.comm = self.libE_info['comm']
         self.calc_type = calc_type
         assert self.calc_type in [EVAL_GEN_TAG, EVAL_SIM_TAG], \
             "User function value {} specifies neither a simulator nor generator.".format(self.calc_type)
-
         self.calc_str = calc_type_strings[self.calc_type]
 
-    def send(self, output, libE_info=info_default, calc_status=UNSET_TAG):
+    def send(self, output, calc_status=UNSET_TAG):
         """Send message from worker to manager.
 
         :param output: Output array to be sent to manager
+        :param calc_status::Optional, Provides a task status
         :returns: None
         """
-
-        if 'comm' in libE_info:
-            # Cannot pickle a comm and should not need for return
-            libE_info = dict(libE_info)
-            libE_info.pop('comm')
+        if 'comm' in self.libE_info:
+            del self.libE_info['comm']
 
         D = {'calc_out': output,
-             'libE_info': libE_info,
+             'libE_info': self.libE_info,
              'calc_status': calc_status,
              'calc_type': self.calc_type
              }
@@ -40,15 +42,19 @@ class PersistentSupport:
 
         :returns: message tag, Work dictionary, calc_in array
         """
-        tag, Work = self.comm.recv()
+        tag, Work = self.comm.recv()  # Receive meta-data or signal
         if tag in [STOP_TAG, PERSIS_STOP]:
             logger.debug('Persistent {} received signal {} from manager'.format(self.calc_str, tag))
-            if not isinstance(Work, dict):
-                self.comm.push_to_buffer(tag, Work)
-                return tag, Work, None
+            self.comm.push_to_buffer(tag, Work)
+            return tag, Work, None
+        else:
+            logger.debug('Persistent {} received work request from manager'.format(self.calc_str))
 
-        logger.debug('Persistent {} received work request from manager'.format(self.calc_str))
-        data_tag, calc_in = self.comm.recv()
+        # Update libE_info
+        self.libE_info = Work['libE_info']
+
+        data_tag, calc_in = self.comm.recv()  # Receive work rows
+
         # Check for unexpected STOP (e.g. error between sending Work info and rows)
         if data_tag in [STOP_TAG, PERSIS_STOP]:
             logger.debug('Persistent {} received signal {} '.format(self.calc_str, tag) +
@@ -57,15 +63,14 @@ class PersistentSupport:
             return data_tag, calc_in, None  # calc_in is signal identifier
 
         logger.debug('Persistent {} received work rows from manager'.format(self.calc_str))
-        if tag in [STOP_TAG, PERSIS_STOP]:
-            self.comm.push_to_buffer(tag, Work)
         return tag, Work, calc_in
 
-    def send_recv(self, output, libE_info=info_default, calc_status=UNSET_TAG):
+    def send_recv(self, output, calc_status=UNSET_TAG):
         """Send message from worker to manager and receive response.
 
         :param output: Output array to be sent to manager
+        :param calc_status::Optional, Provides a task status
         :returns: message tag, Work dictionary, calc_in array
         """
-        self.send(output, libE_info, calc_status)
+        self.send(output, calc_status)
         return self.recv()

--- a/libensemble/tools/persistent_support.py
+++ b/libensemble/tools/persistent_support.py
@@ -14,6 +14,7 @@ class PersistentSupport:
         """
         self.libE_info = libE_info
         self.comm = self.libE_info['comm']
+        self.comm.reset_last_work_dict()
         self.calc_type = calc_type
         assert self.calc_type in [EVAL_GEN_TAG, EVAL_SIM_TAG], \
             "User function value {} specifies neither a simulator nor generator.".format(self.calc_type)
@@ -56,6 +57,7 @@ class PersistentSupport:
 
         # Update libE_info
         self.libE_info = Work['libE_info']
+        self.comm.set_last_work_dict(Work)
 
         data_tag, calc_in = self.comm.recv()  # Receive work rows
 

--- a/libensemble/tools/persistent_support.py
+++ b/libensemble/tools/persistent_support.py
@@ -27,10 +27,14 @@ class PersistentSupport:
         :returns: None
         """
         if 'comm' in self.libE_info:
-            del self.libE_info['comm']
+            # Need to make copy before remove comm as original could be reused
+            libE_info = dict(self.libE_info)
+            libE_info.pop('comm')
+        else:
+            libE_info = self.libE_info
 
         D = {'calc_out': output,
-             'libE_info': self.libE_info,
+             'libE_info': libE_info,
              'calc_status': calc_status,
              'calc_type': self.calc_type
              }

--- a/libensemble/tools/tools.py
+++ b/libensemble/tools/tools.py
@@ -55,7 +55,8 @@ _PERSIS_RETURN_WARNING = \
      "A persistent worker has returned history data on shutdown. This data is\n" +
      "not currently added to the manager's history to avoid possibly overwriting, but\n" +
      "will be added to the manager's history in a future release. If you want to\n" +
-     "overwrite/append, you can set the libE_specs option ``use_persis_return``" +
+     "overwrite/append, you can set the libE_specs option ``use_persis_return_gen``" +
+     "or ``use_persis_return_sim``"
      '\n' + 79*'*' + '\n\n')
 
 # =================== save libE output to pickle and np ========================

--- a/libensemble/worker.py
+++ b/libensemble/worker.py
@@ -316,7 +316,9 @@ class Worker:
         Worker._set_rset_team(libE_info['rset_team'])
 
         calc_out, persis_info, calc_status = self._handle_calc(Work, calc_in)
-        del libE_info['comm']
+
+        if 'comm' in libE_info:
+            del libE_info['comm']
 
         # If there was a finish signal, bail
         if calc_status == MAN_SIGNAL_FINISH:

--- a/libensemble/worker.py
+++ b/libensemble/worker.py
@@ -317,6 +317,12 @@ class Worker:
 
         calc_out, persis_info, calc_status = self._handle_calc(Work, calc_in)
 
+        if self.comm.get_last_work_dict() is not None:
+            Work = self.comm.get_last_work_dict()
+
+        if 'libE_info' in Work:
+            libE_info = Work['libE_info']
+
         if 'comm' in libE_info:
             del libE_info['comm']
 


### PR DESCRIPTION
Ensures libE_info used (including H_rows) updated for each sim in loop (and returned libE_info updated in PersistentSupport)
Split use_persis_return to use_persis_return_sim and use_persis_return_gen

Does not:
  include ability to send work request with persistent stop.
  fix up returns with correct libE_info on persistent stop/return from persistent sim function
  