### PR TITLE
Feature/cancel in alloc

### DIFF
--- a/libensemble/alloc_funcs/give_sim_work_first.py
+++ b/libensemble/alloc_funcs/give_sim_work_first.py
@@ -1,4 +1,5 @@
 import numpy as np
+import time
 from libensemble.tools.alloc_support import AllocSupport, InsufficientFreeResources
 
 
@@ -64,6 +65,13 @@ def give_sim_work_first(W, H, sim_specs, gen_specs, alloc_specs, persis_info):
             except InsufficientFreeResources:
                 break
             gen_count += 1
+
+    if 'cancel_sims_time' in user:
+        rows = np.where(np.logical_and.reduce((H['given'], ~H['returned'], ~H['cancel_requested'])))[0]
+        inds = time.time() - H['last_given_time'][rows] > user['cancel_sims_time']
+        to_request_cancel = rows[inds]
+        H[to_request_cancel]['cancel_requested'] = True
+        print("Marked to cancel:", to_request_cancel)
 
     del support
     return Work, persis_info

--- a/libensemble/alloc_funcs/give_sim_work_first.py
+++ b/libensemble/alloc_funcs/give_sim_work_first.py
@@ -70,8 +70,8 @@ def give_sim_work_first(W, H, sim_specs, gen_specs, alloc_specs, persis_info):
         rows = np.where(np.logical_and.reduce((H['given'], ~H['returned'], ~H['cancel_requested'])))[0]
         inds = time.time() - H['last_given_time'][rows] > user['cancel_sims_time']
         to_request_cancel = rows[inds]
-        H[to_request_cancel]['cancel_requested'] = True
-        print("Marked to cancel:", to_request_cancel)
+        for row in to_request_cancel:
+            H[row]['cancel_requested'] = True
 
     del support
     return Work, persis_info

--- a/libensemble/tests/regression_tests/test_cancel_in_alloc.py
+++ b/libensemble/tests/regression_tests/test_cancel_in_alloc.py
@@ -3,7 +3,7 @@
 # cancel long-running simulations. In this case, the simulation has a run-time
 # in seconds that is drawn uniformly from [0,10] and any time the allocation
 # function is called and a sim_id has been evaluated for more than 5 seconds,
-# it is cancelled. 
+# it is cancelled.
 #
 # Execute via one of the following commands (e.g. 3 workers):
 #    mpiexec -np 4 python3 test_cancel_in_alloc.py
@@ -28,34 +28,33 @@ from libensemble.tools import parse_args, save_libE_output, add_unique_random_st
 
 nworkers, is_manager, libE_specs, _ = parse_args()
 
-sim_specs = {'sim_f': sim_f,
-             'in': ['x'],
-             'out': [('f', float)],
-             'user': {'uniform_random_pause_ub': 10}
-             }
+sim_specs = {
+    "sim_f": sim_f,
+    "in": ["x"],
+    "out": [("f", float)],
+    "user": {"uniform_random_pause_ub": 10},
+}
 
-gen_specs = {'gen_f': gen_f,
-             'in': ['sim_id'],
-             'out': [('x', float, (2,))],
-             'user': {'gen_batch_size': 5,
-                      'lb': np.array([-3, -2]),
-                      'ub': np.array([3, 2])}
-             }
+gen_specs = {
+    "gen_f": gen_f,
+    "in": ["sim_id"],
+    "out": [("x", float, (2,))],
+    "user": {"gen_batch_size": 5, "lb": np.array([-3, -2]), "ub": np.array([3, 2])},
+}
 
-alloc_specs = {'alloc_f': give_sim_work_first,
-               'out': [],
-               'user': {'cancel_sims_time': 5,
-                        'batch_mode': False,
-                        'num_active_gens': 1}}
+alloc_specs = {
+    "alloc_f": give_sim_work_first,
+    "out": [],
+    "user": {"cancel_sims_time": 5, "batch_mode": False, "num_active_gens": 1},
+}
 
 persis_info = add_unique_random_streams({}, nworkers + 1)
 
-exit_criteria = {'sim_max': 10, 'elapsed_wallclock_time': 300}
+exit_criteria = {"sim_max": 10, "elapsed_wallclock_time": 300}
 
 # Perform the run
-H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
-                            libE_specs=libE_specs, alloc_specs=alloc_specs)
+H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs, alloc_specs=alloc_specs)
 
 if is_manager:
-    assert np.any(H['cancel_requested']) and np.any(H['kill_sent']), "This test should have requested a cancellation and had a kill sent"
+    assert np.any(H["cancel_requested"]) and np.any(H["kill_sent"]), "This test should have requested a cancellation and had a kill sent"
     save_libE_output(H, persis_info, __file__, nworkers)

--- a/libensemble/tests/regression_tests/test_cancel_in_alloc.py
+++ b/libensemble/tests/regression_tests/test_cancel_in_alloc.py
@@ -1,6 +1,9 @@
 # """
-# Runs libEnsemble on the 6-hump camel problem. Documented here:
-#    https://www.sfu.ca/~ssurjano/camel6.html
+# Runs libEnsemble in order to test the ability of an allocation function to
+# cancel long-running simulations. In this case, the simulation has a run-time
+# in seconds that is drawn uniformly from [0,10] and any time the allocation
+# function is called and a sim_id has been evaluated for more than 5 seconds,
+# it is cancelled. 
 #
 # Execute via one of the following commands (e.g. 3 workers):
 #    mpiexec -np 4 python3 test_cancel_in_alloc.py
@@ -54,7 +57,5 @@ H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
                             libE_specs=libE_specs, alloc_specs=alloc_specs)
 
 if is_manager:
-    eprint(flag)
-    eprint(H['cancel_requested'])
-    assert flag == 2
+    assert np.any(H['cancel_requested']) and np.any(H['kill_sent']), "This test should have requested a cancellation and had a kill sent"
     save_libE_output(H, persis_info, __file__, nworkers)

--- a/libensemble/tests/regression_tests/test_cancel_in_alloc.py
+++ b/libensemble/tests/regression_tests/test_cancel_in_alloc.py
@@ -1,0 +1,60 @@
+# """
+# Runs libEnsemble on the 6-hump camel problem. Documented here:
+#    https://www.sfu.ca/~ssurjano/camel6.html
+#
+# Execute via one of the following commands (e.g. 3 workers):
+#    mpiexec -np 4 python3 test_cancel_in_alloc.py
+#    python3 test_cancel_in_alloc.py --nworkers 3 --comms local
+#    python3 test_cancel_in_alloc.py --nworkers 3 --comms tcp
+#
+# The number of concurrent evaluations of the objective function will be 4-1=3.
+# """
+
+# Do not change these lines - they are parsed by run-tests.sh
+# TESTSUITE_COMMS: mpi local tcp
+# TESTSUITE_NPROCS: 2 4
+
+import numpy as np
+
+# Import libEnsemble items for this test
+from libensemble.libE import libE
+from libensemble.sim_funcs.branin.branin_obj import call_branin as sim_f
+from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
+from libensemble.tools import parse_args, save_libE_output, add_unique_random_streams, eprint
+
+nworkers, is_manager, libE_specs, _ = parse_args()
+
+sim_specs = {'sim_f': sim_f,
+             'in': ['x'],
+             'out': [('f', float)],
+             'user': {'uniform_random_pause_ub': 10}
+             }
+
+gen_specs = {'gen_f': gen_f,
+             'in': ['sim_id'],
+             'out': [('x', float, (2,))],
+             'user': {'gen_batch_size': 5,
+                      'lb': np.array([-3, -2]),
+                      'ub': np.array([3, 2])}
+             }
+
+alloc_specs = {'alloc_f': give_sim_work_first,
+               'out': [],
+               'user': {'cancel_sims_time': 5,
+                        'batch_mode': False,
+                        'num_active_gens': 1}}
+
+persis_info = add_unique_random_streams({}, nworkers + 1)
+
+exit_criteria = {'sim_max': 10, 'elapsed_wallclock_time': 300}
+
+# Perform the run
+H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
+                            libE_specs=libE_specs, alloc_specs=alloc_specs)
+
+if is_manager:
+    eprint(flag)
+    eprint(H['cancel_requested'])
+    assert flag == 2
+    save_libE_output(H, persis_info, __file__, nworkers)

--- a/libensemble/tests/regression_tests/test_cancel_in_alloc.py
+++ b/libensemble/tests/regression_tests/test_cancel_in_alloc.py
@@ -24,7 +24,7 @@ from libensemble.libE import libE
 from libensemble.sim_funcs.branin.branin_obj import call_branin as sim_f
 from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
 from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
-from libensemble.tools import parse_args, save_libE_output, add_unique_random_streams, eprint
+from libensemble.tools import parse_args, save_libE_output, add_unique_random_streams
 
 nworkers, is_manager, libE_specs, _ = parse_args()
 
@@ -53,8 +53,10 @@ persis_info = add_unique_random_streams({}, nworkers + 1)
 exit_criteria = {"sim_max": 10, "elapsed_wallclock_time": 300}
 
 # Perform the run
-H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs, alloc_specs=alloc_specs)
+H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
+                            libE_specs=libE_specs, alloc_specs=alloc_specs)
 
 if is_manager:
-    assert np.any(H["cancel_requested"]) and np.any(H["kill_sent"]), "This test should have requested a cancellation and had a kill sent"
+    assert np.any(H["cancel_requested"]) and np.any(H["kill_sent"]), \
+        "This test should have requested a cancellation and had a kill sent"
     save_libE_output(H, persis_info, __file__, nworkers)


### PR DESCRIPTION
Adding a regression test that shows how an allocation function can cancel work. 

Perhaps there are helper-routines that can simplify the logic in the lines 69-74 of the new `give_sim_work_first` routine?