### PR TITLE
Fix up for persis sim return

### DIFF
--- a/libensemble/comms/comms.py
+++ b/libensemble/comms/comms.py
@@ -115,6 +115,7 @@ class QComm(Comm):
         self._outbox = outbox
         self._copy = copy_msg
         self.recv_buffer = None
+        self.last_work_dict = None
 
     def get_num_workers(self):
         """Return global _ncomms"""
@@ -146,6 +147,15 @@ class QComm(Comm):
     def mail_flag(self):
         "Check whether we know a message is ready for receipt."
         return not self._inbox.empty()
+
+    def reset_last_work_dict(self):
+        self.last_work_dict = None
+
+    def set_last_work_dict(self, work):
+        self.last_work_dict = work
+
+    def get_last_work_dict(self):
+        return self.last_work_dict
 
 
 class QCommThread(Comm):

--- a/libensemble/comms/mpi.py
+++ b/libensemble/comms/mpi.py
@@ -31,6 +31,7 @@ class MPIComm(Comm):
         self.status = MPI.Status()
         self._outbox = []
         self.recv_buffer = None
+        self.last_work_dict = None
 
     def __del__(self):
         "Wait on anything pending if comm is killed."
@@ -102,10 +103,8 @@ class MPIComm(Comm):
 
     def set_last_work_dict(self, work):
         self.last_work_dict = work
-        #print('setting', self.last_work_dict)
 
     def get_last_work_dict(self):
-        print('getting', self.last_work_dict)
         return self.last_work_dict
 
 class MainMPIComm(MPIComm):

--- a/libensemble/comms/mpi.py
+++ b/libensemble/comms/mpi.py
@@ -97,6 +97,16 @@ class MPIComm(Comm):
     def get_num_workers(self):
         return self.mpi_comm.Get_size() - 1
 
+    def reset_last_work_dict(self):
+        self.last_work_dict = None
+
+    def set_last_work_dict(self, work):
+        self.last_work_dict = work
+        #print('setting', self.last_work_dict)
+
+    def get_last_work_dict(self):
+        print('getting', self.last_work_dict)
+        return self.last_work_dict
 
 class MainMPIComm(MPIComm):
     """MPI communicator used by the workers and managers for the moment."""

--- a/libensemble/comms/mpi.py
+++ b/libensemble/comms/mpi.py
@@ -107,6 +107,7 @@ class MPIComm(Comm):
     def get_last_work_dict(self):
         return self.last_work_dict
 
+
 class MainMPIComm(MPIComm):
     """MPI communicator used by the workers and managers for the moment."""
 

--- a/libensemble/sim_funcs/six_hump_camel.py
+++ b/libensemble/sim_funcs/six_hump_camel.py
@@ -196,7 +196,14 @@ def persistent_six_hump_camel(H, persis_info, sim_specs, libE_info):
 
         tag, Work, calc_in = ps.send_recv(H_o)
 
-    return None, persis_info, FINISHED_PERSISTENT_SIM_TAG
+    final_return = None
+
+    # Overwrite final point - for testing only
+    calc_in = np.ones(1, dtype=[('x', float, (2,))])
+    H_o, persis_info = six_hump_camel(calc_in, persis_info, sim_specs, libE_info)
+    final_return = H_o
+
+    return final_return, persis_info, FINISHED_PERSISTENT_SIM_TAG
 
 
 def six_hump_camel_func(x):

--- a/libensemble/tests/regression_tests/test_persistent_sim_uniform_sampling.py
+++ b/libensemble/tests/regression_tests/test_persistent_sim_uniform_sampling.py
@@ -31,6 +31,9 @@ nworkers, is_manager, libE_specs, _ = parse_args()
 
 libE_specs['zero_resource_workers'] = [1]  # Only necessary if sims use resources.
 
+libE_specs['use_persis_return_sim'] = True  # Only necessary if sims use resources.
+
+
 if nworkers < 2:
     sys.exit("Cannot run with a persistent worker if only one worker -- aborting...")
 
@@ -64,4 +67,7 @@ H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info,
 if is_manager:
     assert len(np.unique(H['gen_time'])) == 8
     assert not any((H['f'] == 0))
+    # Should overwrite the last value (in fact last (nworker-1) values) with f(1,1) = 3.23333333
+    assert not np.isclose(H['f'][0], 3.23333333)
+    assert np.isclose(H['f'][-1], 3.23333333)
     save_libE_output(H, persis_info, __file__, nworkers)

--- a/libensemble/tools/persistent_support.py
+++ b/libensemble/tools/persistent_support.py
@@ -14,6 +14,7 @@ class PersistentSupport:
         """
         self.libE_info = libE_info
         self.comm = self.libE_info['comm']
+        self.comm.reset_last_work_dict()
         self.calc_type = calc_type
         assert self.calc_type in [EVAL_GEN_TAG, EVAL_SIM_TAG], \
             "User function value {} specifies neither a simulator nor generator.".format(self.calc_type)
@@ -56,6 +57,7 @@ class PersistentSupport:
 
         # Update libE_info
         self.libE_info = Work['libE_info']
+        self.comm.set_last_work_dict(Work)
 
         data_tag, calc_in = self.comm.recv()  # Receive work rows
 

--- a/libensemble/worker.py
+++ b/libensemble/worker.py
@@ -317,6 +317,12 @@ class Worker:
 
         calc_out, persis_info, calc_status = self._handle_calc(Work, calc_in)
 
+        if self.comm.get_last_work_dict() is not None:
+            Work = self.comm.get_last_work_dict()
+
+        if 'libE_info' in Work:
+            libE_info = Work['libE_info']
+
         if 'comm' in libE_info:
             del libE_info['comm']
 


### PR DESCRIPTION
Allows a return from persistent sim to be included in the correct H_row.

This uses storing in the comm which worker already has access to. We already do the same thing with the push_to_buffer().

It seems to me this is a possible solution. Unless we subprocess the user functions and add a worker/user function communicatoin layer, then the comms object is a point of communication. 