### PR TITLE
Testing/fixbalsamtest

### DIFF
--- a/.github/workflows/libE-ci.yml
+++ b/.github/workflows/libE-ci.yml
@@ -44,6 +44,12 @@ jobs:
     #         channel-priority: flexible
     #         auto-update-conda: true
     #
+    #     - name: Reinstall ca-certificates
+    #       run: |
+    #         python --version
+    #         conda remove --force ca-certificates
+    #         conda install ca-certificates=2021.5.30
+    #
     #     - name: Install Ubuntu compilers
     #       if: matrix.os == 'ubuntu-latest'
     #       run: conda install gcc_linux-64
@@ -65,9 +71,6 @@ jobs:
     #
     #     - name: Install nlopt, scipy, mpich, mpi4py, blas, psutil, pyyaml
     #       run: |
-    #         python --version
-    #         conda remove ca-certificates
-    #         conda install ca-certificates=2021.5.30
     #         conda install nlopt
     #         conda install scipy
     #         conda install mpich
@@ -171,9 +174,14 @@ jobs:
             channel-priority: flexible
             auto-update-conda: true
 
-        - name: Install Ubuntu compilers, postgresql
+        - name: Reinstall ca-certificates
           run: |
             python --version
+            conda remove --force ca-certificates
+            conda install ca-certificates=2021.5.30
+
+        - name: Install Ubuntu compilers, postgresql
+          run: |
             conda install gcc_linux-64
             conda install libpq postgresql postgresql-plpython
             pg_ctl --version
@@ -185,8 +193,6 @@ jobs:
 
         - name: Install scipy, mpich, mpi4py, blas, psutil, pyyaml
           run: |
-            conda remove ca-certificates
-            conda install ca-certificates=2021.5.30
             conda install scipy
             conda install mpich
             conda install mpi4py

--- a/.github/workflows/libE-ci.yml
+++ b/.github/workflows/libE-ci.yml
@@ -47,9 +47,7 @@ jobs:
         - name: Reinstall ca-certificates
           run: |
             python --version
-            conda remove --force ca-certificates
-            conda install ca-certificates=2021.5.30
-            pip install --upgrade certifi
+            pip install -I --upgrade certifi
 
         - name: Install Ubuntu compilers
           if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/libE-ci.yml
+++ b/.github/workflows/libE-ci.yml
@@ -173,11 +173,10 @@ jobs:
             channel-priority: flexible
             auto-update-conda: true
 
-        - name: Reinstall ca-certificates
+        - name: Force-update certifi
           run: |
             python --version
-            conda remove --force ca-certificates
-            conda install ca-certificates=2021.5.30
+            pip install -I --upgrade certifi
 
         - name: Install Ubuntu compilers, postgresql
           run: |
@@ -201,12 +200,12 @@ jobs:
           run: |
             python -m pip install --upgrade pip
             pip install flake8
-            pip install coverage==4.5.4
-            pip install pytest
+            pip install coverage==5.5
+            pip install pytest==6.2.5
             pip install pytest-cov==2.12.1
-            pip install pytest-timeout
-            pip install mock
-            pip install coveralls
+            pip install pytest-timeout==1.4.2
+            pip install mock==4.0.3
+            pip install coveralls==3.2.0
 
         - name: Find MPI, Install libEnsemble, flake8, ulimit adjust
           run: |

--- a/.github/workflows/libE-ci.yml
+++ b/.github/workflows/libE-ci.yml
@@ -65,6 +65,7 @@ jobs:
     #
     #     - name: Install nlopt, scipy, mpich, mpi4py, blas, psutil, pyyaml
     #       run: |
+    #         python --version
     #         conda remove ca-certificates
     #         conda install ca-certificates=2021.5.30
     #         conda install nlopt
@@ -172,6 +173,7 @@ jobs:
 
         - name: Install Ubuntu compilers, postgresql
           run: |
+            python --version
             conda install gcc_linux-64
             conda install libpq postgresql postgresql-plpython
             pg_ctl --version
@@ -217,6 +219,7 @@ jobs:
 
         - name: Modify Balsam for testing, create DB
           run: |
+            pg_ctl --version
             balsam init $HOME/test-balsam
             sudo chmod -R 700 $HOME/test-balsam/balsamdb
             source balsamactivate test-balsam

--- a/.github/workflows/libE-ci.yml
+++ b/.github/workflows/libE-ci.yml
@@ -104,7 +104,7 @@ jobs:
             pip install flake8
             pip install coverage==4.5.4
             pip install pytest
-            pip install pytest-cov
+            pip install pytest-cov==2.12.1
             pip install pytest-timeout
             pip install mock
             pip install coveralls
@@ -204,7 +204,7 @@ jobs:
             pip install flake8
             pip install coverage==4.5.4
             pip install pytest
-            pip install pytest-cov
+            pip install pytest-cov==2.12.1
             pip install pytest-timeout
             pip install mock
             pip install coveralls

--- a/.github/workflows/libE-ci.yml
+++ b/.github/workflows/libE-ci.yml
@@ -235,16 +235,16 @@ jobs:
             mv libensemble/tests/.cov* .
             coveralls --service=github
 
-    coveralls:
-        name: Notify coveralls of all jobs completing
-        needs: [test-libE, test-libE-with-Balsam]
-        if: always()
-        runs-on: ubuntu-latest
-        container: python:3-slim
-        steps:
-        - name: Finished
-          run: |
-            pip3 install --upgrade coveralls
-            coveralls --finish
-          env:
-              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # coveralls:
+    #     name: Notify coveralls of all jobs completing
+    #     needs: [test-libE, test-libE-with-Balsam]
+    #     if: always()
+    #     runs-on: ubuntu-latest
+    #     container: python:3-slim
+    #     steps:
+    #     - name: Finished
+    #       run: |
+    #         pip3 install --upgrade coveralls
+    #         coveralls --finish
+    #       env:
+    #           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/libE-ci.yml
+++ b/.github/workflows/libE-ci.yml
@@ -1,141 +1,141 @@
 name: libEnsemble-CI
 on: [push, pull_request]
 jobs:
-    test-libE:
-
-        runs-on: ${{ matrix.os }}
-        strategy:
-            fail-fast: false
-            matrix:
-                os: [ubuntu-latest, macos-latest]
-                python-version: [3.6, 3.7, 3.8, 3.9]
-                comms-type: [m, l, t]
-                exclude:
-                    - os: macos-latest
-                      python-version: 3.6
-                    - os: macos-latest
-                      python-version: 3.7
-                    - os: macos-latest
-                      python-version: 3.9
-                    - python-version: 3.6
-                      comms-type: t
-                    - python-version: 3.7
-                      comms-type: t
-                    - python-version: 3.9
-                      comms-type: t
-        env:
-            HYDRA_LAUNCHER: 'fork'
-            TERM: xterm-256color
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-        defaults:
-            run:
-                shell: bash -l {0}
-
-        steps:
-        - uses: actions/checkout@v2
-        - name: Setup conda - Python ${{ matrix.python-version }}
-          uses: conda-incubator/setup-miniconda@v2
-          with:
-            activate-environment: condaenv
-            miniconda-version: "latest"
-            python-version: ${{ matrix.python-version }}
-            channels: conda-forge
-            channel-priority: flexible
-            auto-update-conda: true
-
-        - name: Install Ubuntu compilers
-          if: matrix.os == 'ubuntu-latest'
-          run: conda install gcc_linux-64
-
-        # Roundabout solution on macos for proper linking with mpicc
-        - name: Install macOS compilers and older SDK
-          if: matrix.os == 'macos-latest'
-          run: |
-            wget https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.14.sdk.tar.xz
-            mkdir ../sdk; tar xf MacOSX10.14.sdk.tar.xz -C ../sdk
-            conda install clang_osx-64=9.0.1
-
-        - name: Install Octave and bc on Ubuntu
-          if: matrix.os == 'ubuntu-latest'
-          run: |
-            sudo apt-get update
-            sudo apt-get install octave
-            sudo apt-get install bc
-
-        - name: Install nlopt, scipy, mpich, mpi4py, blas, psutil, pyyaml
-          run: |
-            conda remove ca-certificates
-            conda install ca-certificates=2021.5.30
-            conda install nlopt
-            conda install scipy
-            conda install mpich
-            conda install mpi4py
-            conda install libblas libopenblas psutil pyyaml
-
-        - name: Install with-batch PETSc and petsc4py
-          if: matrix.python-version == 3.8
-          env:
-            PETSC_CONFIGURE_OPTIONS: '--with-batch'
-          run: |
-              conda install hypre=2.22.0
-              conda install petsc4py
-
-        - name: Install mumps-mpi, PETSc, petsc4py
-          if: matrix.python-version != 3.8
-          run: |
-            conda install hypre=2.22.0
-            conda install mumps-mpi
-            conda install petsc
-            conda install petsc4py
-
-        - name: Install DFO-LS, mpmath, deap, other test dependencies
-          run: |
-            python -m pip install --upgrade pip
-            pip install DFO-LS
-            pip install dragonfly-opt
-            pip install mpmath
-            pip install deap
-            python -m pip install --upgrade git+https://github.com/mosesyhc/surmise.git@development/PCGPwM
-            pip install flake8
-            pip install coverage==4.5.4
-            pip install pytest
-            pip install pytest-cov
-            pip install pytest-timeout
-            pip install mock
-            pip install coveralls
-
-        - name: Install Tasmanian on Ubuntu
-          if: matrix.os == 'ubuntu-latest'
-          run: |
-            pip install scikit-build packaging Tasmanian --user
-
-        - name: Find MPI, Install libEnsemble, flake8, ulimit adjust
-          run: |
-            python install/find_mpi.py
-            mpiexec --version
-            pip install -e .
-            flake8 libensemble
-            ulimit -Sn 10000
-
-        - name: Run tests, Ubuntu
-          if: matrix.os == 'ubuntu-latest'
-          run: |
-           ./libensemble/tests/run-tests.sh -e -A "-W error" -z -${{ matrix.comms-type }}
-
-        - name: Run tests, macOS
-          if: matrix.os == 'macos-latest'
-          env:
-              CONDA_BUILD_SYSROOT: /Users/runner/work/libensemble/sdk/MacOSX10.14.sdk
-          run: |
-            ./libensemble/tests/run-tests.sh -e -A "-W error" -z -${{ matrix.comms-type }}
-
-        - name: Merge coverage, run Coveralls
-          env:
-              COVERALLS_PARALLEL: true
-          run: |
-            mv libensemble/tests/.cov* .
-            coveralls --service=github
+    # test-libE:
+    #
+    #     runs-on: ${{ matrix.os }}
+    #     strategy:
+    #         fail-fast: false
+    #         matrix:
+    #             os: [ubuntu-latest, macos-latest]
+    #             python-version: [3.6, 3.7, 3.8, 3.9]
+    #             comms-type: [m, l, t]
+    #             exclude:
+    #                 - os: macos-latest
+    #                   python-version: 3.6
+    #                 - os: macos-latest
+    #                   python-version: 3.7
+    #                 - os: macos-latest
+    #                   python-version: 3.9
+    #                 - python-version: 3.6
+    #                   comms-type: t
+    #                 - python-version: 3.7
+    #                   comms-type: t
+    #                 - python-version: 3.9
+    #                   comms-type: t
+    #     env:
+    #         HYDRA_LAUNCHER: 'fork'
+    #         TERM: xterm-256color
+    #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #
+    #     defaults:
+    #         run:
+    #             shell: bash -l {0}
+    #
+    #     steps:
+    #     - uses: actions/checkout@v2
+    #     - name: Setup conda - Python ${{ matrix.python-version }}
+    #       uses: conda-incubator/setup-miniconda@v2
+    #       with:
+    #         activate-environment: condaenv
+    #         miniconda-version: "latest"
+    #         python-version: ${{ matrix.python-version }}
+    #         channels: conda-forge
+    #         channel-priority: flexible
+    #         auto-update-conda: true
+    #
+    #     - name: Install Ubuntu compilers
+    #       if: matrix.os == 'ubuntu-latest'
+    #       run: conda install gcc_linux-64
+    #
+    #     # Roundabout solution on macos for proper linking with mpicc
+    #     - name: Install macOS compilers and older SDK
+    #       if: matrix.os == 'macos-latest'
+    #       run: |
+    #         wget https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.14.sdk.tar.xz
+    #         mkdir ../sdk; tar xf MacOSX10.14.sdk.tar.xz -C ../sdk
+    #         conda install clang_osx-64=9.0.1
+    #
+    #     - name: Install Octave and bc on Ubuntu
+    #       if: matrix.os == 'ubuntu-latest'
+    #       run: |
+    #         sudo apt-get update
+    #         sudo apt-get install octave
+    #         sudo apt-get install bc
+    #
+    #     - name: Install nlopt, scipy, mpich, mpi4py, blas, psutil, pyyaml
+    #       run: |
+    #         conda remove ca-certificates
+    #         conda install ca-certificates=2021.5.30
+    #         conda install nlopt
+    #         conda install scipy
+    #         conda install mpich
+    #         conda install mpi4py
+    #         conda install libblas libopenblas psutil pyyaml
+    #
+    #     - name: Install with-batch PETSc and petsc4py
+    #       if: matrix.python-version == 3.8
+    #       env:
+    #         PETSC_CONFIGURE_OPTIONS: '--with-batch'
+    #       run: |
+    #           conda install hypre=2.22.0
+    #           conda install petsc4py
+    #
+    #     - name: Install mumps-mpi, PETSc, petsc4py
+    #       if: matrix.python-version != 3.8
+    #       run: |
+    #         conda install hypre=2.22.0
+    #         conda install mumps-mpi
+    #         conda install petsc
+    #         conda install petsc4py
+    #
+    #     - name: Install DFO-LS, mpmath, deap, other test dependencies
+    #       run: |
+    #         python -m pip install --upgrade pip
+    #         pip install DFO-LS
+    #         pip install dragonfly-opt
+    #         pip install mpmath
+    #         pip install deap
+    #         python -m pip install --upgrade git+https://github.com/mosesyhc/surmise.git@development/PCGPwM
+    #         pip install flake8
+    #         pip install coverage==4.5.4
+    #         pip install pytest
+    #         pip install pytest-cov
+    #         pip install pytest-timeout
+    #         pip install mock
+    #         pip install coveralls
+    #
+    #     - name: Install Tasmanian on Ubuntu
+    #       if: matrix.os == 'ubuntu-latest'
+    #       run: |
+    #         pip install scikit-build packaging Tasmanian --user
+    #
+    #     - name: Find MPI, Install libEnsemble, flake8, ulimit adjust
+    #       run: |
+    #         python install/find_mpi.py
+    #         mpiexec --version
+    #         pip install -e .
+    #         flake8 libensemble
+    #         ulimit -Sn 10000
+    #
+    #     - name: Run tests, Ubuntu
+    #       if: matrix.os == 'ubuntu-latest'
+    #       run: |
+    #        ./libensemble/tests/run-tests.sh -e -A "-W error" -z -${{ matrix.comms-type }}
+    #
+    #     - name: Run tests, macOS
+    #       if: matrix.os == 'macos-latest'
+    #       env:
+    #           CONDA_BUILD_SYSROOT: /Users/runner/work/libensemble/sdk/MacOSX10.14.sdk
+    #       run: |
+    #         ./libensemble/tests/run-tests.sh -e -A "-W error" -z -${{ matrix.comms-type }}
+    #
+    #     - name: Merge coverage, run Coveralls
+    #       env:
+    #           COVERALLS_PARALLEL: true
+    #       run: |
+    #         mv libensemble/tests/.cov* .
+    #         coveralls --service=github
 
     test-libE-with-Balsam:
         name: Test Balsam with libEnsemble
@@ -174,6 +174,7 @@ jobs:
           run: |
             conda install gcc_linux-64
             conda install libpq postgresql postgresql-plpython
+            pg_ctl --version
 
         - name: Install bc
           run: |

--- a/.github/workflows/libE-ci.yml
+++ b/.github/workflows/libE-ci.yml
@@ -1,145 +1,145 @@
 name: libEnsemble-CI
 on: [push, pull_request]
 jobs:
-    # test-libE:
-    #
-    #     runs-on: ${{ matrix.os }}
-    #     strategy:
-    #         fail-fast: false
-    #         matrix:
-    #             os: [ubuntu-latest, macos-latest]
-    #             python-version: [3.6, 3.7, 3.8, 3.9]
-    #             comms-type: [m, l, t]
-    #             exclude:
-    #                 - os: macos-latest
-    #                   python-version: 3.6
-    #                 - os: macos-latest
-    #                   python-version: 3.7
-    #                 - os: macos-latest
-    #                   python-version: 3.9
-    #                 - python-version: 3.6
-    #                   comms-type: t
-    #                 - python-version: 3.7
-    #                   comms-type: t
-    #                 - python-version: 3.9
-    #                   comms-type: t
-    #     env:
-    #         HYDRA_LAUNCHER: 'fork'
-    #         TERM: xterm-256color
-    #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #
-    #     defaults:
-    #         run:
-    #             shell: bash -l {0}
-    #
-    #     steps:
-    #     - uses: actions/checkout@v2
-    #     - name: Setup conda - Python ${{ matrix.python-version }}
-    #       uses: conda-incubator/setup-miniconda@v2
-    #       with:
-    #         activate-environment: condaenv
-    #         miniconda-version: "latest"
-    #         python-version: ${{ matrix.python-version }}
-    #         channels: conda-forge
-    #         channel-priority: flexible
-    #         auto-update-conda: true
-    #
-    #     - name: Reinstall ca-certificates
-    #       run: |
-    #         python --version
-    #         conda remove --force ca-certificates
-    #         conda install ca-certificates=2021.5.30
-    #
-    #     - name: Install Ubuntu compilers
-    #       if: matrix.os == 'ubuntu-latest'
-    #       run: conda install gcc_linux-64
-    #
-    #     # Roundabout solution on macos for proper linking with mpicc
-    #     - name: Install macOS compilers and older SDK
-    #       if: matrix.os == 'macos-latest'
-    #       run: |
-    #         wget https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.14.sdk.tar.xz
-    #         mkdir ../sdk; tar xf MacOSX10.14.sdk.tar.xz -C ../sdk
-    #         conda install clang_osx-64=9.0.1
-    #
-    #     - name: Install Octave and bc on Ubuntu
-    #       if: matrix.os == 'ubuntu-latest'
-    #       run: |
-    #         sudo apt-get update
-    #         sudo apt-get install octave
-    #         sudo apt-get install bc
-    #
-    #     - name: Install nlopt, scipy, mpich, mpi4py, blas, psutil, pyyaml
-    #       run: |
-    #         conda install nlopt
-    #         conda install scipy
-    #         conda install mpich
-    #         conda install mpi4py
-    #         conda install libblas libopenblas psutil pyyaml
-    #
-    #     - name: Install with-batch PETSc and petsc4py
-    #       if: matrix.python-version == 3.8
-    #       env:
-    #         PETSC_CONFIGURE_OPTIONS: '--with-batch'
-    #       run: |
-    #           conda install hypre=2.22.0
-    #           conda install petsc4py
-    #
-    #     - name: Install mumps-mpi, PETSc, petsc4py
-    #       if: matrix.python-version != 3.8
-    #       run: |
-    #         conda install hypre=2.22.0
-    #         conda install mumps-mpi
-    #         conda install petsc
-    #         conda install petsc4py
-    #
-    #     - name: Install DFO-LS, mpmath, deap, other test dependencies
-    #       run: |
-    #         python -m pip install --upgrade pip
-    #         pip install DFO-LS
-    #         pip install dragonfly-opt
-    #         pip install mpmath
-    #         pip install deap
-    #         python -m pip install --upgrade git+https://github.com/mosesyhc/surmise.git@development/PCGPwM
-    #         pip install flake8
-    #         pip install coverage==4.5.4
-    #         pip install pytest
-    #         pip install pytest-cov
-    #         pip install pytest-timeout
-    #         pip install mock
-    #         pip install coveralls
-    #
-    #     - name: Install Tasmanian on Ubuntu
-    #       if: matrix.os == 'ubuntu-latest'
-    #       run: |
-    #         pip install scikit-build packaging Tasmanian --user
-    #
-    #     - name: Find MPI, Install libEnsemble, flake8, ulimit adjust
-    #       run: |
-    #         python install/find_mpi.py
-    #         mpiexec --version
-    #         pip install -e .
-    #         flake8 libensemble
-    #         ulimit -Sn 10000
-    #
-    #     - name: Run tests, Ubuntu
-    #       if: matrix.os == 'ubuntu-latest'
-    #       run: |
-    #        ./libensemble/tests/run-tests.sh -e -A "-W error" -z -${{ matrix.comms-type }}
-    #
-    #     - name: Run tests, macOS
-    #       if: matrix.os == 'macos-latest'
-    #       env:
-    #           CONDA_BUILD_SYSROOT: /Users/runner/work/libensemble/sdk/MacOSX10.14.sdk
-    #       run: |
-    #         ./libensemble/tests/run-tests.sh -e -A "-W error" -z -${{ matrix.comms-type }}
-    #
-    #     - name: Merge coverage, run Coveralls
-    #       env:
-    #           COVERALLS_PARALLEL: true
-    #       run: |
-    #         mv libensemble/tests/.cov* .
-    #         coveralls --service=github
+    test-libE:
+
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: false
+            matrix:
+                os: [ubuntu-latest, macos-latest]
+                python-version: [3.6, 3.7, 3.8, 3.9]
+                comms-type: [m, l, t]
+                exclude:
+                    - os: macos-latest
+                      python-version: 3.6
+                    - os: macos-latest
+                      python-version: 3.7
+                    - os: macos-latest
+                      python-version: 3.9
+                    - python-version: 3.6
+                      comms-type: t
+                    - python-version: 3.7
+                      comms-type: t
+                    - python-version: 3.9
+                      comms-type: t
+        env:
+            HYDRA_LAUNCHER: 'fork'
+            TERM: xterm-256color
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+        defaults:
+            run:
+                shell: bash -l {0}
+
+        steps:
+        - uses: actions/checkout@v2
+        - name: Setup conda - Python ${{ matrix.python-version }}
+          uses: conda-incubator/setup-miniconda@v2
+          with:
+            activate-environment: condaenv
+            miniconda-version: "latest"
+            python-version: ${{ matrix.python-version }}
+            channels: conda-forge
+            channel-priority: flexible
+            auto-update-conda: true
+
+        - name: Reinstall ca-certificates
+          run: |
+            python --version
+            conda remove --force ca-certificates
+            conda install ca-certificates=2021.5.30
+
+        - name: Install Ubuntu compilers
+          if: matrix.os == 'ubuntu-latest'
+          run: conda install gcc_linux-64
+
+        # Roundabout solution on macos for proper linking with mpicc
+        - name: Install macOS compilers and older SDK
+          if: matrix.os == 'macos-latest'
+          run: |
+            wget https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.14.sdk.tar.xz
+            mkdir ../sdk; tar xf MacOSX10.14.sdk.tar.xz -C ../sdk
+            conda install clang_osx-64=9.0.1
+
+        - name: Install Octave and bc on Ubuntu
+          if: matrix.os == 'ubuntu-latest'
+          run: |
+            sudo apt-get update
+            sudo apt-get install octave
+            sudo apt-get install bc
+
+        - name: Install nlopt, scipy, mpich, mpi4py, blas, psutil, pyyaml
+          run: |
+            conda install nlopt
+            conda install scipy
+            conda install mpich
+            conda install mpi4py
+            conda install libblas libopenblas psutil pyyaml
+
+        - name: Install with-batch PETSc and petsc4py
+          if: matrix.python-version == 3.8
+          env:
+            PETSC_CONFIGURE_OPTIONS: '--with-batch'
+          run: |
+              conda install hypre=2.22.0
+              conda install petsc4py
+
+        - name: Install mumps-mpi, PETSc, petsc4py
+          if: matrix.python-version != 3.8
+          run: |
+            conda install hypre=2.22.0
+            conda install mumps-mpi
+            conda install petsc
+            conda install petsc4py
+
+        - name: Install DFO-LS, mpmath, deap, other test dependencies
+          run: |
+            python -m pip install --upgrade pip
+            pip install DFO-LS
+            pip install dragonfly-opt
+            pip install mpmath
+            pip install deap
+            python -m pip install --upgrade git+https://github.com/mosesyhc/surmise.git@development/PCGPwM
+            pip install flake8
+            pip install coverage==4.5.4
+            pip install pytest
+            pip install pytest-cov
+            pip install pytest-timeout
+            pip install mock
+            pip install coveralls
+
+        - name: Install Tasmanian on Ubuntu
+          if: matrix.os == 'ubuntu-latest'
+          run: |
+            pip install scikit-build packaging Tasmanian --user
+
+        - name: Find MPI, Install libEnsemble, flake8, ulimit adjust
+          run: |
+            python install/find_mpi.py
+            mpiexec --version
+            pip install -e .
+            flake8 libensemble
+            ulimit -Sn 10000
+
+        - name: Run tests, Ubuntu
+          if: matrix.os == 'ubuntu-latest'
+          run: |
+           ./libensemble/tests/run-tests.sh -e -A "-W error" -z -${{ matrix.comms-type }}
+
+        - name: Run tests, macOS
+          if: matrix.os == 'macos-latest'
+          env:
+              CONDA_BUILD_SYSROOT: /Users/runner/work/libensemble/sdk/MacOSX10.14.sdk
+          run: |
+            ./libensemble/tests/run-tests.sh -e -A "-W error" -z -${{ matrix.comms-type }}
+
+        - name: Merge coverage, run Coveralls
+          env:
+              COVERALLS_PARALLEL: true
+          run: |
+            mv libensemble/tests/.cov* .
+            coveralls --service=github
 
     test-libE-with-Balsam:
         name: Test Balsam with libEnsemble
@@ -244,16 +244,16 @@ jobs:
             mv libensemble/tests/.cov* .
             coveralls --service=github
 
-    # coveralls:
-    #     name: Notify coveralls of all jobs completing
-    #     needs: [test-libE, test-libE-with-Balsam]
-    #     if: always()
-    #     runs-on: ubuntu-latest
-    #     container: python:3-slim
-    #     steps:
-    #     - name: Finished
-    #       run: |
-    #         pip3 install --upgrade coveralls
-    #         coveralls --finish
-    #       env:
-    #           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    coveralls:
+        name: Notify coveralls of all jobs completing
+        needs: [test-libE, test-libE-with-Balsam]
+        if: always()
+        runs-on: ubuntu-latest
+        container: python:3-slim
+        steps:
+        - name: Finished
+          run: |
+            pip3 install --upgrade coveralls
+            coveralls --finish
+          env:
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/libE-ci.yml
+++ b/.github/workflows/libE-ci.yml
@@ -102,10 +102,10 @@ jobs:
             pip install deap
             python -m pip install --upgrade git+https://github.com/mosesyhc/surmise.git@development/PCGPwM
             pip install flake8
-            pip install coverage==4.5.4
+            pip install coverage==5.5
             pip install pytest
             pip install pytest-cov==2.12.1
-            pip install pytest-timeout
+            pip install pytest-timeout==1.4.2
             pip install mock
             pip install coveralls
 

--- a/.github/workflows/libE-ci.yml
+++ b/.github/workflows/libE-ci.yml
@@ -44,7 +44,7 @@ jobs:
             channel-priority: flexible
             auto-update-conda: true
 
-        - name: Reinstall ca-certificates
+        - name: Force-update certifi
           run: |
             python --version
             pip install -I --upgrade certifi
@@ -102,11 +102,11 @@ jobs:
             python -m pip install --upgrade git+https://github.com/mosesyhc/surmise.git@development/PCGPwM
             pip install flake8
             pip install coverage==5.5
-            pip install pytest
+            pip install pytest==6.2.5
             pip install pytest-cov==2.12.1
             pip install pytest-timeout==1.4.2
-            pip install mock
-            pip install -I coveralls
+            pip install mock==4.0.3
+            pip install coveralls==3.2.0
 
         - name: Install Tasmanian on Ubuntu
           if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/libE-ci.yml
+++ b/.github/workflows/libE-ci.yml
@@ -49,6 +49,7 @@ jobs:
             python --version
             conda remove --force ca-certificates
             conda install ca-certificates=2021.5.30
+            pip install --upgrade certifi
 
         - name: Install Ubuntu compilers
           if: matrix.os == 'ubuntu-latest'
@@ -107,7 +108,7 @@ jobs:
             pip install pytest-cov==2.12.1
             pip install pytest-timeout==1.4.2
             pip install mock
-            pip install coveralls
+            pip install -I coveralls
 
         - name: Install Tasmanian on Ubuntu
           if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
force-upgrade certifi, since for some reason a really old version started being downloaded for python 3.6. Also locks-in some testing dependency version confirmed to work, so this routine _hopefully_ doesn't break again in the short-term