### PR TITLE
try bumping wallclock again

### DIFF
--- a/libensemble/tests/regression_tests/test_executor_hworld.py
+++ b/libensemble/tests/regression_tests/test_executor_hworld.py
@@ -93,7 +93,7 @@ gen_specs = {
 
 persis_info = add_unique_random_streams({}, nworkers + 1)
 
-exit_criteria = {'elapsed_wallclock_time': 30}
+exit_criteria = {'elapsed_wallclock_time': 35}
 
 # Perform the run
 H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)


### PR DESCRIPTION
this is probably too late - but shouldn't make a difference for users installing and verifying releases from pypi/conda. primarily for slowness of CI.

also opening pr just to be _absolutely sure this time_