### PR TITLE
Docs / Examples Refactor

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -256,7 +256,7 @@ Resources
     doi     = {10.1109/tpds.2021.3082815}
   }
 
-**Capabilities:**
+**Example Compatible Packages**
 
 libEnsemble and the `Community Examples repository`_ include example generator
 functions for the following libraries:
@@ -341,7 +341,7 @@ See a complete list of `example user scripts`_.
 .. _Tasmanian: https://tasmanian.ornl.gov/
 .. _Theta: https://www.alcf.anl.gov/alcf-resources/theta
 .. _user guide: https://libensemble.readthedocs.io/en/latest/programming_libE.html
-.. _VTMOP: https://informs-sim.org/wsc20papers/311.pdf
+.. _VTMOP: https://github.com/Libensemble/libe-community-examples#vtmop
 .. _WarpX: https://warpx.readthedocs.io/en/latest/
 .. _WarpX + libE scripts: https://warpx.readthedocs.io/en/latest/usage/workflows/libensemble.html
 .. _xSDK Extreme-scale Scientific Software Development Kit: https://xsdk.info

--- a/docs/FAQ.rst
+++ b/docs/FAQ.rst
@@ -65,11 +65,8 @@ which will attempt to use all hyperthreads/SMT threads available if set to ``Tru
 **FileExistsError: [Errno 17] File exists: './ensemble'**
 
 This can happen when libEnsemble tries to create ensemble or simulation directories
-that already exist.
-
-To create uniquely-named ensemble directories, set the ``ensemble_dir_suffix``
-option in :doc:`libE_specs<history_output_logging>` to some unique value.
-Alternatively, append some unique value to ``libE_specs['ensemble_dir']``
+that already exist from previous runs. To avoid this, ensure the ensemble directory
+paths are unique by appending some unique value to ``libE_specs['ensemble_dir_path']``
 
 **PETSc and MPI errors with "[unset]: write_line error; fd=-1 buf=:cmd=abort exitcode=59"**
 
@@ -136,7 +133,7 @@ For more information see https://bitbucket.org/mpi4py/mpi4py/issues/102/unpickli
 This error has been encountered on Cori when running with an incorrect installation of ``mpi4py``.
 Make sure platform specific instructions are followed (e.g.~ :doc:`Cori<platforms/cori>`)
 
-**srun: Job ****** step creation temporarily disabled, retrying (Requested nodes are busy)**
+**srun: Job \*\*\*\*\*\* step creation temporarily disabled, retrying (Requested nodes are busy)**
 
 You may also see: ``srun: Job ****** step creation still disabled, retrying (Requested nodes are busy)``
 
@@ -205,6 +202,19 @@ dictionaries will be dumped. This can be suppressed by
 setting ``libE_specs['save_H_and_persis_on_abort']`` to ``False``.
 
 See :doc:`here<history_output_logging>` for more information about these files.
+
+**How can I silence libEnsemble or prevent printed warnings?**
+
+Some logger messages at or above the ``MANAGER_WARNING`` level are mirrored
+to stderr automatically. To disable this, set the minimum stderr displaying level
+to ``CRITICAL`` via the following::
+
+    from libensemble import logger
+    logger.set_stderr_level('CRITICAL')
+
+This effectively puts libEnsemble in silent mode.
+
+See the :ref:`Logger Configuration<logger_config>` docs for more information.
 
 macOS-Specific Errors
 ---------------------

--- a/docs/_static/my_theme.css
+++ b/docs/_static/my_theme.css
@@ -2,8 +2,14 @@
 max-width: 850px !important;
 }
 
+h2 {
+  /*Increases the spacing above methods in modules in html*/
+  margin-top: 10px; # 
+}
+
 .toggle .header {
-  overflow:auto;
+  cursor: pointer;
+  overflow: auto;
   padding-top: 20px;
   background-color: lightblue;
   border: 5px solid black;

--- a/docs/_static/my_theme.css
+++ b/docs/_static/my_theme.css
@@ -4,6 +4,8 @@ max-width: 850px !important;
 
 .toggle {
   margin-bottom: 40px;
+}
+
 
 .toggle .header {
   cursor: pointer;

--- a/docs/_static/my_theme.css
+++ b/docs/_static/my_theme.css
@@ -14,3 +14,7 @@ max-width: 850px !important;
 .toggle .header.open:after {
     content: " ▼";
 }
+
+.underline {
+  text-decoration: underline;
+}

--- a/docs/_static/my_theme.css
+++ b/docs/_static/my_theme.css
@@ -4,7 +4,7 @@ max-width: 850px !important;
 
 h1 {
   /*Increases the spacing above methods in modules in html*/
-  margin-top: 200px; 
+  margin-top: 10px; 
 }
 
 .toggle .header {

--- a/docs/_static/my_theme.css
+++ b/docs/_static/my_theme.css
@@ -3,21 +3,24 @@ max-width: 850px !important;
 }
 
 .toggle .header {
+  width:500px;
   padding-top: 20px;
-  padding-bottom: 20px;
-  width:300px;
   background-color: lightblue;
   border: 5px solid black;
   text-align: center;
-  align-items: center; 
+  display: flex;
 }
 
-.toggle .header:after {
-    content: " ▶";
+.toggle .header:before {
+  padding-left: 10px;
+  padding-right: 10px;
+  content: " ▶ ";
 }
 
-.toggle .header.open:after {
-    content: " ▼";
+.toggle .header.open:before {
+  padding-right: 10px;
+  padding-left: 10px;
+  content: " ▼ ";
 }
 
 .underline {

--- a/docs/_static/my_theme.css
+++ b/docs/_static/my_theme.css
@@ -2,17 +2,15 @@
 max-width: 850px !important;
 }
 
-h1 {
-  /*Increases the spacing above methods in modules in html*/
-  margin-top: 10px; 
-}
+.toggle {
+  margin-bottom: 40px;
 
 .toggle .header {
   cursor: pointer;
   overflow: auto;
   padding-top: 20px;
-  background-color: lightblue;
-  border: 2px solid black;
+  background-color: rgb(86,189,119);
+  border: 2px solid;
   text-align: center;
   display: flex;
 }
@@ -20,6 +18,7 @@ h1 {
 .toggle .header:before {
   padding-left: 10px;
   padding-right: 10px;
+
   content: " ▶ ";
 }
 

--- a/docs/_static/my_theme.css
+++ b/docs/_static/my_theme.css
@@ -12,7 +12,7 @@ h2 {
   overflow: auto;
   padding-top: 20px;
   background-color: lightblue;
-  border: 5px solid black;
+  border: 2px solid black;
   text-align: center;
   display: flex;
 }

--- a/docs/_static/my_theme.css
+++ b/docs/_static/my_theme.css
@@ -2,7 +2,7 @@
 max-width: 850px !important;
 }
 
-h2 {
+h1 {
   /*Increases the spacing above methods in modules in html*/
   margin-top: 200px; 
 }

--- a/docs/_static/my_theme.css
+++ b/docs/_static/my_theme.css
@@ -3,7 +3,7 @@ max-width: 850px !important;
 }
 
 .toggle .header {
-  width:500px;
+  overflow:auto;
   padding-top: 20px;
   background-color: lightblue;
   border: 5px solid black;

--- a/docs/_static/my_theme.css
+++ b/docs/_static/my_theme.css
@@ -1,3 +1,16 @@
 .wy-nav-content {
 max-width: 850px !important;
 }
+
+.toggle .header {
+    display: block;
+    clear: both;
+}
+
+.toggle .header:after {
+    content: " ▶";
+}
+
+.toggle .header.open:after {
+    content: " ▼";
+}

--- a/docs/_static/my_theme.css
+++ b/docs/_static/my_theme.css
@@ -21,13 +21,13 @@ max-width: 850px !important;
   padding-left: 10px;
   padding-right: 10px;
 
-  content: " ▶ ";
+  content: " ▶ Show ";
 }
 
 .toggle .header.open:before {
   padding-right: 10px;
   padding-left: 10px;
-  content: " ▼ ";
+  content: " ▼ Hide ";
 }
 
 .underline {

--- a/docs/_static/my_theme.css
+++ b/docs/_static/my_theme.css
@@ -4,7 +4,7 @@ max-width: 850px !important;
 
 h2 {
   /*Increases the spacing above methods in modules in html*/
-  margin-top: 10px; # 
+  margin-top: 200px; 
 }
 
 .toggle .header {

--- a/docs/_static/my_theme.css
+++ b/docs/_static/my_theme.css
@@ -3,8 +3,13 @@ max-width: 850px !important;
 }
 
 .toggle .header {
-    display: block;
-    clear: both;
+  padding-top: 20px;
+  padding-bottom: 20px;
+  width:300px;
+  background-color: lightblue;
+  border: 5px solid black;
+  text-align: center;
+  align-items: center; 
 }
 
 .toggle .header:after {
@@ -16,5 +21,5 @@ max-width: 850px !important;
 }
 
 .underline {
-  text-decoration: underline;
+  font-weight: bold;
 }

--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -1,0 +1,14 @@
+{% extends "!page.html" %}
+
+{% block footer %}
+ <script type="text/javascript">
+    $(document).ready(function() {
+        $(".toggle > *").hide();
+        $(".toggle .header").show();
+        $(".toggle .header").click(function() {
+            $(this).parent().children().not(".header").toggle(400);
+            $(this).parent().children(".header").toggleClass("open");
+        })
+    });
+</script>
+{% endblock %}

--- a/docs/examples/alloc_funcs.rst
+++ b/docs/examples/alloc_funcs.rst
@@ -8,6 +8,9 @@ Below are example allocation functions available in libEnsemble.
 
 .. note:: The default alloc_func is give_sim_work_first.
 
+.. role:: underline
+    :class: underline
+
 .. _gswf_label:
 
 give_sim_work_first
@@ -16,11 +19,31 @@ give_sim_work_first
   :members:
   :undoc-members:
 
+.. container:: toggle
+
+   .. container:: header
+
+      :underline:`Click Here to Show/Hide give_sim_work_first.py`
+
+   .. literalinclude:: ../../libensemble/alloc_funcs/give_sim_work_first.py
+      :language: python
+      :linenos:
+
 fast_alloc
 ----------
 .. automodule:: fast_alloc
   :members:
   :undoc-members:
+
+.. container:: toggle
+
+   .. container:: header
+
+      :underline:`Click Here to Show/Hide fast_alloc.py`
+
+   .. literalinclude:: ../../libensemble/alloc_funcs/fast_alloc.py
+      :language: python
+      :linenos:
 
 fast_alloc_to_aposmm
 --------------------
@@ -35,6 +58,16 @@ start_only_persistent
 .. automodule:: start_only_persistent
   :members:
   :undoc-members:
+
+.. container:: toggle
+
+   .. container:: header
+
+      :underline:`Click Here to Show/Hide start_only_persistent.py`
+
+   .. literalinclude:: ../../libensemble/alloc_funcs/start_only_persistent.py
+      :language: python
+      :linenos:
 
 start_persistent_local_opt_gens
 -------------------------------

--- a/docs/examples/alloc_funcs.rst
+++ b/docs/examples/alloc_funcs.rst
@@ -1,5 +1,5 @@
-Allocator Functions
-===================
+Allocation Functions
+====================
 
 Below are example allocation functions available in libEnsemble.
 

--- a/docs/examples/alloc_funcs.rst
+++ b/docs/examples/alloc_funcs.rst
@@ -23,7 +23,7 @@ give_sim_work_first
 
    .. container:: header
 
-      :underline:`Show/Hide give_sim_work_first.py`
+      :underline:`give_sim_work_first.py`
 
    .. literalinclude:: ../../libensemble/alloc_funcs/give_sim_work_first.py
       :language: python
@@ -39,7 +39,7 @@ fast_alloc
 
    .. container:: header
 
-      :underline:`Show/Hide fast_alloc.py`
+      :underline:`fast_alloc.py`
 
    .. literalinclude:: ../../libensemble/alloc_funcs/fast_alloc.py
       :language: python
@@ -63,7 +63,7 @@ start_only_persistent
 
    .. container:: header
 
-      :underline:`Show/Hide start_only_persistent.py`
+      :underline:`start_only_persistent.py`
 
    .. literalinclude:: ../../libensemble/alloc_funcs/start_only_persistent.py
       :language: python

--- a/docs/examples/alloc_funcs.rst
+++ b/docs/examples/alloc_funcs.rst
@@ -1,5 +1,5 @@
-Allocation Functions
-====================
+Allocator Functions
+===================
 
 Below are example allocation functions available in libEnsemble.
 

--- a/docs/examples/alloc_funcs.rst
+++ b/docs/examples/alloc_funcs.rst
@@ -23,7 +23,7 @@ give_sim_work_first
 
    .. container:: header
 
-      :underline:`Click Here to Show/Hide give_sim_work_first.py`
+      :underline:`Show/Hide give_sim_work_first.py`
 
    .. literalinclude:: ../../libensemble/alloc_funcs/give_sim_work_first.py
       :language: python
@@ -39,7 +39,7 @@ fast_alloc
 
    .. container:: header
 
-      :underline:`Click Here to Show/Hide fast_alloc.py`
+      :underline:`Show/Hide fast_alloc.py`
 
    .. literalinclude:: ../../libensemble/alloc_funcs/fast_alloc.py
       :language: python
@@ -63,7 +63,7 @@ start_only_persistent
 
    .. container:: header
 
-      :underline:`Click Here to Show/Hide start_only_persistent.py`
+      :underline:`Show/Hide start_only_persistent.py`
 
    .. literalinclude:: ../../libensemble/alloc_funcs/start_only_persistent.py
       :language: python

--- a/docs/examples/gen_funcs.rst
+++ b/docs/examples/gen_funcs.rst
@@ -1,5 +1,5 @@
-Generation Functions
-====================
+Generator Functions
+===================
 
 Below are example generation functions available in libEnsemble.
 

--- a/docs/examples/gen_funcs.rst
+++ b/docs/examples/gen_funcs.rst
@@ -1,5 +1,5 @@
-Generator Functions
-===================
+Generation Functions
+====================
 
 Below are example generation functions available in libEnsemble.
 

--- a/docs/examples/sampling.rst
+++ b/docs/examples/sampling.rst
@@ -12,7 +12,7 @@ sampling
 
    .. container:: header
 
-      :underline:`Click Here to Show/Hide sampling.py`
+      :underline:`Show/Hide sampling.py`
 
    .. literalinclude:: ../../libensemble/gen_funcs/sampling.py
       :language: python
@@ -28,7 +28,7 @@ persistent_uniform_sampling
 
    .. container:: header
 
-      :underline:`Click Here to Show/Hide persistent_uniform_sampling.py`
+      :underline:`Show/Hide persistent_uniform_sampling.py`
 
    .. literalinclude:: ../../libensemble/gen_funcs/persistent_uniform_sampling.py
       :language: python

--- a/docs/examples/sampling.rst
+++ b/docs/examples/sampling.rst
@@ -12,7 +12,7 @@ sampling
 
    .. container:: header
 
-      :underline:`Show/Hide sampling.py`
+      :underline:`sampling.py`
 
    .. literalinclude:: ../../libensemble/gen_funcs/sampling.py
       :language: python
@@ -28,7 +28,7 @@ persistent_uniform_sampling
 
    .. container:: header
 
-      :underline:`Show/Hide persistent_uniform_sampling.py`
+      :underline:`persistent_uniform_sampling.py`
 
    .. literalinclude:: ../../libensemble/gen_funcs/persistent_uniform_sampling.py
       :language: python

--- a/docs/examples/sampling.rst
+++ b/docs/examples/sampling.rst
@@ -1,11 +1,35 @@
 sampling
 --------
+
+.. role:: underline
+    :class: underline
+
 .. automodule:: sampling
   :members:
   :undoc-members:
+
+.. container:: toggle
+
+   .. container:: header
+
+      :underline:`Click Here to Show/Hide sampling.py`
+
+   .. literalinclude:: ../../libensemble/gen_funcs/sampling.py
+      :language: python
+      :linenos:
 
 persistent_uniform_sampling
 ---------------------------
 .. automodule:: persistent_uniform_sampling
   :members:
   :undoc-members:
+
+.. container:: toggle
+
+   .. container:: header
+
+      :underline:`Click Here to Show/Hide persistent_uniform_sampling.py`
+
+   .. literalinclude:: ../../libensemble/gen_funcs/persistent_uniform_sampling.py
+      :language: python
+      :linenos:

--- a/docs/examples/sim_funcs.rst
+++ b/docs/examples/sim_funcs.rst
@@ -1,5 +1,5 @@
-Simulator Functions
-===================
+Simulation Functions
+====================
 
 Below are example simulation functions available in libEnsemble.
 Most of these demonstrate an inexpensive algorithm and do not

--- a/docs/examples/sim_funcs.rst
+++ b/docs/examples/sim_funcs.rst
@@ -1,5 +1,5 @@
-Simulation Functions
-====================
+Simulator Functions
+===================
 
 Below are example simulation functions available in libEnsemble.
 Most of these demonstrate an inexpensive algorithm and do not

--- a/docs/examples/sim_funcs.rst
+++ b/docs/examples/sim_funcs.rst
@@ -10,11 +10,24 @@ function launching tasks, see the
 .. IMPORTANT::
   See the API for simulation functions :ref:`here<api_sim_f>`.
 
+.. role:: underline
+    :class: underline
+
 six_hump_camel
 --------------
 .. automodule:: six_hump_camel
   :members:
   :undoc-members:
+
+.. container:: toggle
+
+   .. container:: header
+
+      :underline:`Click Here to Show/Hide six_hump_camel.py`
+
+   .. literalinclude:: ../../libensemble/sim_funcs/six_hump_camel.py
+      :language: python
+      :linenos:
 
 chwirut
 -------
@@ -27,6 +40,16 @@ noisy_vector_mapping
 .. automodule:: noisy_vector_mapping
   :members:
   :undoc-members:
+
+.. container:: toggle
+
+   .. container:: header
+
+      :underline:`Click Here to Show/Hide noisy_vector_mapping.py`
+
+   .. literalinclude:: ../../libensemble/sim_funcs/noisy_vector_mapping.py
+      :language: python
+      :linenos:
 
 periodic_func
 -------------
@@ -44,3 +67,13 @@ executor_hworld
 ---------------
 .. automodule:: executor_hworld
   :members:
+
+.. container:: toggle
+
+   .. container:: header
+
+      :underline:`Click Here to Show/Hide executor_hworld.py`
+
+   .. literalinclude:: ../../libensemble/sim_funcs/executor_hworld.py
+      :language: python
+      :linenos:

--- a/docs/examples/sim_funcs.rst
+++ b/docs/examples/sim_funcs.rst
@@ -23,7 +23,7 @@ six_hump_camel
 
    .. container:: header
 
-      :underline:`Show/Hide six_hump_camel.py`
+      :underline:`six_hump_camel.py`
 
    .. literalinclude:: ../../libensemble/sim_funcs/six_hump_camel.py
       :language: python
@@ -45,7 +45,7 @@ noisy_vector_mapping
 
    .. container:: header
 
-      :underline:`Show/Hide noisy_vector_mapping.py`
+      :underline:`noisy_vector_mapping.py`
 
    .. literalinclude:: ../../libensemble/sim_funcs/noisy_vector_mapping.py
       :language: python
@@ -72,7 +72,7 @@ executor_hworld
 
    .. container:: header
 
-      :underline:`Show/Hide executor_hworld.py`
+      :underline:`executor_hworld.py`
 
    .. literalinclude:: ../../libensemble/sim_funcs/executor_hworld.py
       :language: python

--- a/docs/examples/sim_funcs.rst
+++ b/docs/examples/sim_funcs.rst
@@ -23,7 +23,7 @@ six_hump_camel
 
    .. container:: header
 
-      :underline:`Click Here to Show/Hide six_hump_camel.py`
+      :underline:`Show/Hide six_hump_camel.py`
 
    .. literalinclude:: ../../libensemble/sim_funcs/six_hump_camel.py
       :language: python
@@ -45,7 +45,7 @@ noisy_vector_mapping
 
    .. container:: header
 
-      :underline:`Click Here to Show/Hide noisy_vector_mapping.py`
+      :underline:`Show/Hide noisy_vector_mapping.py`
 
    .. literalinclude:: ../../libensemble/sim_funcs/noisy_vector_mapping.py
       :language: python
@@ -72,7 +72,7 @@ executor_hworld
 
    .. container:: header
 
-      :underline:`Click Here to Show/Hide executor_hworld.py`
+      :underline:`Show/Hide executor_hworld.py`
 
    .. literalinclude:: ../../libensemble/sim_funcs/executor_hworld.py
       :language: python

--- a/docs/examples/tasmanian.rst
+++ b/docs/examples/tasmanian.rst
@@ -19,7 +19,7 @@ use either *venv* or *--user* install.
 
    .. container:: header
 
-      :underline:`Click Here to Show/Hide persistent_tasmanian.py`
+      :underline:`Show/Hide persistent_tasmanian.py`
 
    .. literalinclude:: ../../libensemble/gen_funcs/persistent_tasmanian.py
       :language: python

--- a/docs/examples/tasmanian.rst
+++ b/docs/examples/tasmanian.rst
@@ -19,7 +19,7 @@ use either *venv* or *--user* install.
 
    .. container:: header
 
-      :underline:`Show/Hide persistent_tasmanian.py`
+      :underline:`persistent_tasmanian.py`
 
    .. literalinclude:: ../../libensemble/gen_funcs/persistent_tasmanian.py
       :language: python

--- a/docs/examples/tasmanian.rst
+++ b/docs/examples/tasmanian.rst
@@ -12,6 +12,19 @@ use either *venv* or *--user* install.
   :members:
   :undoc-members:
 
-.. .. _Tasmanian: https://tasmanian.ornl.gov/
+.. role:: underline
+    :class: underline
+
+.. container:: toggle
+
+   .. container:: header
+
+      :underline:`Click Here to Show/Hide persistent_tasmanian.py`
+
+   .. literalinclude:: ../../libensemble/gen_funcs/persistent_tasmanian.py
+      :language: python
+      :linenos:
+
+.. _Tasmanian: https://tasmanian.ornl.gov/
 .. _pypackaging: https://pypi.org/project/pypackaging/
 .. _scikit-build: https://scikit-build.readthedocs.io/en/latest/index.html

--- a/docs/history_output_logging.rst
+++ b/docs/history_output_logging.rst
@@ -28,6 +28,8 @@ Two other libEnsemble files produced by default:
 
 To suppress libEnsemble from producing these two files, set ``libE_specs['disable_log_files']`` to ``True``.
 
+.. _logger_config:
+
 Logger Configuration
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,7 +24,15 @@
    tutorials/executor_forces_tutorial
    tutorials/aposmm_tutorial
    tutorials/calib_cancel_tutorial
-   examples/examples_index
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Examples:
+
+   examples/gen_funcs
+   examples/sim_funcs
+   examples/alloc_funcs
+   examples/calling_scripts
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Probably still a work-in-progress. Makes Examples a top-level Section in the docs. Adds drop-down boxes for selected examples (users can optionally browse the source-code of example without having to navigate through the repository, and the boxes don't take up space if not maximized).