### PR TITLE
Add support for spawn

### DIFF
--- a/libensemble/comms/comms.py
+++ b/libensemble/comms/comms.py
@@ -25,7 +25,7 @@ access and monitoring (for persistent gens):
 from abc import ABC, abstractmethod
 from time import time
 from threading import Thread
-from multiprocessing import Process, Queue, Value, Lock
+from multiprocessing import Process, Queue
 from traceback import format_exc
 import queue
 import copy

--- a/libensemble/comms/comms.py
+++ b/libensemble/comms/comms.py
@@ -104,20 +104,23 @@ class QComm(Comm):
     These can be used with threads or multiprocessing.
     """
 
-    # Integer count - shared amongst processes
-    lock = Lock()
-    _ncomms = Value("i", 0)
+    # Integer count  - shared amongst processes
+    # Supports adding/removing workers - only works with 'fork'
+    # lock = Lock()
+    # _ncomms = Value("i", 0)
 
-    def __init__(self, inbox, outbox, copy_msg=False):
+    def __init__(self, inbox, outbox, nworkers, copy_msg=False):
         """Set the inbox and outbox queues."""
         self._inbox = inbox
         self._outbox = outbox
         self._copy = copy_msg
         self.recv_buffer = None
+        self.nworkers = nworkers
 
     def get_num_workers(self):
         """Return global _ncomms"""
-        return QComm._ncomms.value
+        return self.nworkers
+        # return QComm._ncomms.value
 
     def send(self, *args):
         """Place a message on the outbox queue."""
@@ -210,15 +213,17 @@ class QCommThread(Comm):
 class QCommProcess(Comm):
     """Launch a user function in a process with an attached QComm."""
 
-    def __init__(self, main, *args, **kwargs):
+    def __init__(self, main, nworkers, *args, **kwargs):
         self.inbox = Queue()
         self.outbox = Queue()
         self._result = None
         self._exception = None
         self._done = False
-        comm = QComm(self.inbox, self.outbox)
-        with QComm.lock:
-            QComm._ncomms.value += 1
+        comm = QComm(self.inbox, self.outbox, nworkers)
+
+        # with QComm.lock:
+        #     QComm._ncomms.value += 1
+
         self.process = Process(target=QCommProcess._qcomm_main, args=(comm, main) + args, kwargs=kwargs)
 
     def _is_result_msg(self, msg):
@@ -277,8 +282,8 @@ class QCommProcess(Comm):
             raise Timeout()
         if self._exception is not None:
             raise RemoteException(self._exception.msg, self._exception.exc)
-        with QComm.lock:
-            QComm._ncomms.value -= 1
+        # with QComm.lock:
+        #     QComm._ncomms.value -= 1
         return self._result
 
     def terminate(self, timeout=None):
@@ -288,8 +293,8 @@ class QCommProcess(Comm):
         self.process.join(timeout=timeout)
         if self.running:
             raise Timeout()
-        with QComm.lock:
-            QComm._ncomms.value -= 1
+        # with QComm.lock:
+        #     QComm._ncomms.value -= 1
 
     @property
     def running(self):

--- a/libensemble/comms/comms.py
+++ b/libensemble/comms/comms.py
@@ -111,7 +111,7 @@ class QComm(Comm):
     # lock = Lock()
     # _ncomms = Value("i", 0)
 
-    def __init__(self, inbox, outbox, nworkers, copy_msg=False):
+    def __init__(self, inbox, outbox, nworkers=None, copy_msg=False):
         """Set the inbox and outbox queues."""
         self._inbox = inbox
         self._outbox = outbox

--- a/libensemble/comms/comms.py
+++ b/libensemble/comms/comms.py
@@ -25,6 +25,8 @@ access and monitoring (for persistent gens):
 from abc import ABC, abstractmethod
 from time import time
 from threading import Thread
+
+# from multiprocessing import Process, Queue, Value, Lock
 from multiprocessing import Process, Queue
 from traceback import format_exc
 import queue
@@ -153,13 +155,13 @@ class QComm(Comm):
 class QCommThread(Comm):
     """Launch a user function in a thread with an attached QComm."""
 
-    def __init__(self, main, *args, **kwargs):
+    def __init__(self, main, nworkers, *args, **kwargs):
         self.inbox = queue.Queue()
         self.outbox = queue.Queue()
         self.main = main
         self._result = None
         self._exception = None
-        kwargs["comm"] = QComm(self.inbox, self.outbox, True)
+        kwargs["comm"] = QComm(self.inbox, self.outbox, nworkers, True)
         self.thread = Thread(target=self._qcomm_main, args=args, kwargs=kwargs)
 
     def send(self, *args):

--- a/libensemble/gen_funcs/sampling.py
+++ b/libensemble/gen_funcs/sampling.py
@@ -8,6 +8,7 @@ import numpy as np
 __all__ = [
     "uniform_random_sample",
     "uniform_random_sample_with_variable_resources",
+    "uniform_random_sample_with_var_priorities_and_resources",
     "uniform_random_sample_obj_components",
     "latin_hypercube_sample",
     "uniform_random_sample_cancel",
@@ -37,15 +38,47 @@ def uniform_random_sample(H, persis_info, gen_specs, _):
 
 def uniform_random_sample_with_variable_resources(H, persis_info, gen_specs, _):
     """
-    Generates points uniformly over the domain defined by ``gen_specs['user']['ub']`` and
-    ``gen_specs['user']['lb']``. Also randomly requests a different number of resource
-    sets to be used in the evaluation of the generated points after the initial batch.
+    Generates ``gen_specs['user']['gen_batch_size']`` points uniformly over the domain
+    defined by ``gen_specs['user']['ub']`` and ``gen_specs['user']['lb']``.
 
-    .. seealso::
-        `test_uniform_sampling_with_variable_resources.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_uniform_sampling_with_variable_resources.py>`_ # noqa
+    Also randomly requests a different number of resource sets to be used in each evaluation.
+
+    This generator is used to test/demonstrate setting of resource sets.
+
+    #.. seealso::
+        #`test_uniform_sampling_with_variable_resources.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_uniform_sampling_with_variable_resources.py>`_ # noqa
+    """
+
+    ub = gen_specs["user"]["ub"]
+    lb = gen_specs["user"]["lb"]
+    max_rsets = gen_specs["user"]["max_resource_sets"]
+
+    n = len(lb)
+    b = gen_specs["user"]["gen_batch_size"]
+
+    H_o = np.zeros(b, dtype=gen_specs["out"])
+
+    H_o["x"] = persis_info["rand_stream"].uniform(lb, ub, (b, n))
+    H_o["resource_sets"] = persis_info["rand_stream"].integers(1, max_rsets + 1, b)
+
+    # print(f'GEN: H rsets requested: {H_o["resource_sets"]}')
+
+    return H_o, persis_info
+
+
+def uniform_random_sample_with_var_priorities_and_resources(H, persis_info, gen_specs, _):
+    """
+    Generates points uniformly over the domain defined by ``gen_specs['user']['ub']`` and
+    ``gen_specs['user']['lb']``. Also, randomly requests a different priority and number of
+    resource sets to be used in the evaluation of the generated points, after the initial batch.
+
+    This generator is used to test/demonstrate setting of priorities and resource sets.
+
     """
     ub = gen_specs["user"]["ub"]
     lb = gen_specs["user"]["lb"]
+    max_rsets = gen_specs["user"]["max_resource_sets"]
+
     n = len(lb)
 
     if len(H) == 0:
@@ -63,9 +96,9 @@ def uniform_random_sample_with_variable_resources(H, persis_info, gen_specs, _):
         H_o = np.zeros(1, dtype=gen_specs["out"])
         # H_o['x'] = len(H)*np.ones(n)  # Can use a simple count for testing.
         H_o["x"] = persis_info["rand_stream"].uniform(lb, ub)
-        H_o["resource_sets"] = persis_info["rand_stream"].integers(1, gen_specs["user"]["max_resource_sets"] + 1)
+        H_o["resource_sets"] = persis_info["rand_stream"].integers(1, max_rsets + 1)
         H_o["priority"] = 10 * H_o["resource_sets"]
-        # print('Created sim for {} workers'.format(H_o['resource_sets']), flush=True)
+        # print('Created sim for {} resource sets'.format(H_o['resource_sets']), flush=True)
 
     return H_o, persis_info
 

--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -403,9 +403,10 @@ def start_proc_team(nworkers, sim_specs, gen_specs, libE_specs, log_comm=True):
     resources = Resources.resources
     executor = Executor.executor
 
-    wcomms = [QCommProcess(worker_main, nworkers, sim_specs, gen_specs, libE_specs,
-                           w, log_comm, resources, executor)
-              for w in range(1, nworkers+1)]
+    wcomms = [
+        QCommProcess(worker_main, nworkers, sim_specs, gen_specs, libE_specs, w, log_comm, resources, executor)
+        for w in range(1, nworkers + 1)
+    ]
 
     for wcomm in wcomms:
         wcomm.run()

--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -399,7 +399,14 @@ def libE_mpi_worker(libE_comm, sim_specs, gen_specs, libE_specs):
 
 def start_proc_team(nworkers, sim_specs, gen_specs, libE_specs, log_comm=True):
     """Launch a process worker team."""
-    wcomms = [QCommProcess(worker_main, sim_specs, gen_specs, libE_specs, w, log_comm) for w in range(1, nworkers + 1)]
+
+    resources = Resources.resources
+    executor = Executor.executor
+
+    wcomms = [QCommProcess(worker_main, nworkers, sim_specs, gen_specs, libE_specs,
+                           w, log_comm, resources, executor)
+              for w in range(1, nworkers+1)]
+
     for wcomm in wcomms:
         wcomm.run()
     return wcomms

--- a/libensemble/tests/regression_tests/test_runlines_adaptive_workers.py
+++ b/libensemble/tests/regression_tests/test_runlines_adaptive_workers.py
@@ -20,7 +20,7 @@ import numpy as np
 from libensemble.libE import libE
 from libensemble.sim_funcs import helloworld
 from libensemble.sim_funcs.six_hump_camel import six_hump_camel_with_variable_resources as sim_f
-from libensemble.gen_funcs.sampling import uniform_random_sample_with_variable_resources as gen_f
+from libensemble.gen_funcs.sampling import uniform_random_sample_with_var_priorities_and_resources as gen_f
 from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.tools import parse_args, save_libE_output, add_unique_random_streams
 from libensemble.executors.mpi_executor import MPIExecutor

--- a/libensemble/tests/regression_tests/test_uniform_sampling_with_variable_resources.py
+++ b/libensemble/tests/regression_tests/test_uniform_sampling_with_variable_resources.py
@@ -27,7 +27,7 @@ from libensemble.executors.mpi_executor import MPIExecutor
 
 from multiprocessing import set_start_method
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     nworkers, is_manager, libE_specs, _ = parse_args()
 
@@ -95,10 +95,10 @@ if __name__ == '__main__':
             sim_specs["user"]["app"] = "helloworld"
             if prob_id == 1:
                 libE_specs["ensemble_dir_path"] = "ensemble_hw_fork"
-                set_start_method('fork', force=True)
+                set_start_method("fork", force=True)
             else:
                 libE_specs["ensemble_dir_path"] = "ensemble_hw_spawn"
-                set_start_method('spawn', force=True)
+                set_start_method("spawn", force=True)
 
         persis_info = add_unique_random_streams({}, nworkers + 1)
 

--- a/libensemble/tests/regression_tests/test_uniform_sampling_with_variable_resources.py
+++ b/libensemble/tests/regression_tests/test_uniform_sampling_with_variable_resources.py
@@ -7,6 +7,8 @@ Execute via one of the following commands (e.g. 3 workers):
    python test_uniform_sampling_with_variable_resources.py --nworkers 3 --comms local
 
 The number of concurrent evaluations of the objective function will be 4-1=3.
+
+Note: This test contains multiple iterations to test different configurations.
 """
 
 # Do not change these lines - they are parsed by run-tests.sh
@@ -64,7 +66,7 @@ if __name__ == "__main__":
             ("x_on_cube", float, n),
         ],
         "user": {
-            "initial_batch_size": 5,
+            "gen_batch_size": 5,
             "max_resource_sets": nworkers,
             "lb": np.array([-3, -2]),
             "ub": np.array([3, 2]),

--- a/libensemble/tests/regression_tests/test_uniform_sampling_with_variable_resources.py
+++ b/libensemble/tests/regression_tests/test_uniform_sampling_with_variable_resources.py
@@ -87,7 +87,12 @@ if __name__ == "__main__":
 
     exit_criteria = {"sim_max": 40, "wallclock_max": 300}
 
-    for prob_id in range(3):
+    if libE_specs["comms"] == "local":
+        iterations = 3
+    else:
+        iterations = 2
+
+    for prob_id in range(iterations):
         if prob_id == 0:
             sim_specs["user"]["app"] = "six_hump_camel"
 

--- a/libensemble/tests/regression_tests/test_uniform_sampling_with_variable_resources.py
+++ b/libensemble/tests/regression_tests/test_uniform_sampling_with_variable_resources.py
@@ -88,22 +88,24 @@ if __name__ == "__main__":
     exit_criteria = {"sim_max": 40, "wallclock_max": 300}
 
     if libE_specs["comms"] == "local":
-        iterations = 3
+        iterations = 4
     else:
         iterations = 2
 
     for prob_id in range(iterations):
         if prob_id == 0:
             sim_specs["user"]["app"] = "six_hump_camel"
-
         else:
             sim_specs["user"]["app"] = "helloworld"
             if prob_id == 1:
                 libE_specs["ensemble_dir_path"] = "ensemble_hw_fork"
                 set_start_method("fork", force=True)
-            else:
+            elif prob_id == 2:
                 libE_specs["ensemble_dir_path"] = "ensemble_hw_spawn"
                 set_start_method("spawn", force=True)
+            else:
+                libE_specs["ensemble_dir_path"] = "ensemble_hw_forkserver"
+                set_start_method("forkserver", force=True)
 
         persis_info = add_unique_random_streams({}, nworkers + 1)
 

--- a/libensemble/tests/regression_tests/test_uniform_sampling_with_variable_resources.py
+++ b/libensemble/tests/regression_tests/test_uniform_sampling_with_variable_resources.py
@@ -25,79 +25,88 @@ from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.tools import parse_args, save_libE_output, add_unique_random_streams
 from libensemble.executors.mpi_executor import MPIExecutor
 
-nworkers, is_manager, libE_specs, _ = parse_args()
+from multiprocessing import set_start_method
 
-libE_specs["sim_dirs_make"] = True
-libE_specs["ensemble_dir_path"] = "./ensemble_diff_nodes_w" + str(nworkers) + "_" + libE_specs.get("comms")
+if __name__ == '__main__':
 
-if libE_specs["comms"] == "tcp":
-    sys.exit("This test only runs with MPI or local -- aborting...")
+    nworkers, is_manager, libE_specs, _ = parse_args()
 
-# Get paths for applications to run
-hello_world_app = helloworld.__file__
-six_hump_camel_app = six_hump_camel.__file__
+    libE_specs["sim_dirs_make"] = True
+    libE_specs["ensemble_dir_path"] = "./ensemble_diff_nodes_w" + str(nworkers) + "_" + libE_specs.get("comms")
 
-# Sim can run either helloworld or six_hump_camel
-exctr = MPIExecutor()
-exctr.register_app(full_path=hello_world_app, app_name="helloworld")
-exctr.register_app(full_path=six_hump_camel_app, app_name="six_hump_camel")
+    if libE_specs["comms"] == "tcp":
+        sys.exit("This test only runs with MPI or local -- aborting...")
 
+    # Get paths for applications to run
+    hello_world_app = helloworld.__file__
+    six_hump_camel_app = six_hump_camel.__file__
 
-n = 2
-sim_specs = {
-    "sim_f": sim_f,
-    "in": ["x"],
-    "out": [("f", float)],
-    "user": {"app": "helloworld"},  # helloworld or six_hump_camel
-}
+    # Sim can run either helloworld or six_hump_camel
+    exctr = MPIExecutor()
+    exctr.register_app(full_path=hello_world_app, app_name="helloworld")
+    exctr.register_app(full_path=six_hump_camel_app, app_name="six_hump_camel")
 
-gen_specs = {
-    "gen_f": gen_f,
-    "in": ["sim_id"],
-    "out": [
-        ("priority", float),
-        ("resource_sets", int),  # Set in gen func, resourced by alloc func.
-        ("x", float, n),
-        ("x_on_cube", float, n),
-    ],
-    "user": {
-        "initial_batch_size": 5,
-        "max_resource_sets": nworkers,
-        "lb": np.array([-3, -2]),
-        "ub": np.array([3, 2]),
-    },
-}
+    n = 2
+    sim_specs = {
+        "sim_f": sim_f,
+        "in": ["x"],
+        "out": [("f", float)],
+        "user": {"app": "helloworld"},  # helloworld or six_hump_camel
+    }
 
-alloc_specs = {
-    "alloc_f": give_sim_work_first,
-    "out": [],
-    "user": {
-        "batch_mode": False,
-        "give_all_with_same_priority": True,
-        "num_active_gens": 1,
-        "async_return": True,
-    },
-}
+    gen_specs = {
+        "gen_f": gen_f,
+        "in": ["sim_id"],
+        "out": [
+            ("priority", float),
+            ("resource_sets", int),  # Set in gen func, resourced by alloc func.
+            ("x", float, n),
+            ("x_on_cube", float, n),
+        ],
+        "user": {
+            "initial_batch_size": 5,
+            "max_resource_sets": nworkers,
+            "lb": np.array([-3, -2]),
+            "ub": np.array([3, 2]),
+        },
+    }
 
-# This can improve scheduling when tasks may run across multiple nodes
-libE_specs["scheduler_opts"] = {"match_slots": False}
+    alloc_specs = {
+        "alloc_f": give_sim_work_first,
+        "out": [],
+        "user": {
+            "batch_mode": False,
+            "give_all_with_same_priority": True,
+            "num_active_gens": 1,
+            "async_return": True,
+        },
+    }
 
-exit_criteria = {"sim_max": 40, "wallclock_max": 300}
+    # This can improve scheduling when tasks may run across multiple nodes
+    libE_specs["scheduler_opts"] = {"match_slots": False}
 
-for prob_id in range(2):
-    if prob_id == 0:
-        sim_specs["user"]["app"] = "six_hump_camel"
-    else:
-        sim_specs["user"]["app"] = "helloworld"
-        libE_specs["ensemble_dir_path"] = "ensemble_dummy"
+    exit_criteria = {"sim_max": 40, "wallclock_max": 300}
 
-    persis_info = add_unique_random_streams({}, nworkers + 1)
+    for prob_id in range(3):
+        if prob_id == 0:
+            sim_specs["user"]["app"] = "six_hump_camel"
 
-    # Perform the run
-    H, persis_info, flag = libE(
-        sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs, alloc_specs=alloc_specs
-    )
+        else:
+            sim_specs["user"]["app"] = "helloworld"
+            if prob_id == 1:
+                libE_specs["ensemble_dir_path"] = "ensemble_hw_fork"
+                set_start_method('fork', force=True)
+            else:
+                libE_specs["ensemble_dir_path"] = "ensemble_hw_spawn"
+                set_start_method('spawn', force=True)
 
-    if is_manager:
-        assert flag == 0
-        save_libE_output(H, persis_info, __file__, nworkers)
+        persis_info = add_unique_random_streams({}, nworkers + 1)
+
+        # Perform the run
+        H, persis_info, flag = libE(
+            sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs, alloc_specs=alloc_specs
+        )
+
+        if is_manager:
+            assert flag == 0
+            save_libE_output(H, persis_info, __file__, nworkers)

--- a/libensemble/tests/scaling_tests/forces/forces_gpu/forces_simf.py
+++ b/libensemble/tests/scaling_tests/forces/forces_gpu/forces_simf.py
@@ -23,6 +23,8 @@ def run_forces(H, persis_info, sim_specs, libE_info):
 
     resources.set_env_to_slots("CUDA_VISIBLE_DEVICES")
 
+    # print(f"SIM Nodes {resources.local_node_count} Slots per node: {resources.slot_count}")
+
     # Submit our forces app for execution. Block until the task starts.
     task = exctr.submit(
         app_name="forces",
@@ -30,6 +32,7 @@ def run_forces(H, persis_info, sim_specs, libE_info):
         num_nodes=resources.local_node_count,
         procs_per_node=resources.slot_count,
         wait_on_start=True,
+        # extra_args="--gpus-per-task=1"  # Let slurm assign GPUs
     )
 
     # Block until the task finishes

--- a/libensemble/tests/scaling_tests/forces/forces_gpu/run_libe_forces.py
+++ b/libensemble/tests/scaling_tests/forces/forces_gpu/run_libe_forces.py
@@ -5,7 +5,13 @@ import numpy as np
 from forces_simf import run_forces  # Sim func from current dir
 
 from libensemble.libE import libE
-from libensemble.gen_funcs.sampling import uniform_random_sample
+
+# Fixed resources (one resource set per worker)
+from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
+
+# Uncomment for var resources
+# from libensemble.gen_funcs.sampling import uniform_random_sample_with_variable_resources as gen_f
+
 from libensemble.tools import parse_args, add_unique_random_streams
 from libensemble.executors import MPIExecutor
 
@@ -32,13 +38,17 @@ sim_specs = {
 
 # State the gen_f, inputs, outputs, additional parameters
 gen_specs = {
-    "gen_f": uniform_random_sample,  # Generator function
+    "gen_f": gen_f,  # Generator function
     "in": ["sim_id"],  # Generator input
-    "out": [("x", float, (1,))],  # Name, type and size of data from gen_f
+    "out": [
+        ("x", float, (1,)),  # Name, type and size of data from gen_f
+        # ("resource_sets", int)  # Uncomment for var resources
+    ],
     "user": {
         "lb": np.array([1000]),  # User parameters for the gen_f
         "ub": np.array([3000]),
         "gen_batch_size": 8,
+        # "max_resource_sets": nworkers  # Uncomment for var resources
     },
 }
 

--- a/libensemble/tests/unit_tests_nompi/test_aaa_comms.py
+++ b/libensemble/tests/unit_tests_nompi/test_aaa_comms.py
@@ -22,7 +22,7 @@ def test_qcomm_proc_terminate1():
     def worker_main(comm):
         return
 
-    with comms.QCommProcess(worker_main) as mgr_comm:
+    with comms.QCommProcess(worker_main, 2) as mgr_comm:
         time.sleep(0.5)
         mgr_comm.terminate(timeout=30)
         assert not mgr_comm.running
@@ -35,7 +35,7 @@ def test_qcomm_proc_terminate2():
         while True:
             time.sleep(1)
 
-    with comms.QCommProcess(worker_main) as mgr_comm:
+    with comms.QCommProcess(worker_main, 2) as mgr_comm:
         mgr_comm.terminate(timeout=30)
         assert not mgr_comm.running
 
@@ -52,7 +52,7 @@ def test_qcomm_proc_terminate3():
         while not comm.mail_flag():
             pass
 
-    with comms.QCommProcess(worker_main) as mgr_comm:
+    with comms.QCommProcess(worker_main, 2) as mgr_comm:
         time.sleep(0.5)
 
         flag = True
@@ -91,7 +91,7 @@ def test_qcomm_proc_terminate4():
             comm.send("Hello")
             time.sleep(0.01)
 
-    with comms.QCommProcess(worker_main) as mgr_comm:
+    with comms.QCommProcess(worker_main, 2) as mgr_comm:
         time.sleep(0.5)
 
         flag = True

--- a/libensemble/worker.py
+++ b/libensemble/worker.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 task_timing = False
 
 
-def worker_main(comm, sim_specs, gen_specs, libE_specs, workerID=None, log_comm=True):
+def worker_main(comm, sim_specs, gen_specs, libE_specs, workerID=None, log_comm=True, resources=None, executor=None):
     """Evaluates calculations given to it by the manager.
 
     Creates a worker object, receives work from manager, runs worker,
@@ -62,6 +62,12 @@ def worker_main(comm, sim_specs, gen_specs, libE_specs, workerID=None, log_comm=
     if libE_specs.get("profile"):
         pr = cProfile.Profile()
         pr.enable()
+
+    # If resources / executor passed in, then use those.
+    if resources is not None:
+        Resources.resources = resources
+    if executor is not None:
+        Executor.executor = executor
 
     # Receive dtypes from manager
     _, dtypes = comm.recv()


### PR DESCRIPTION
Currently I have modified the code to pass nworkers statically - though its possible to maintain an option to do it dynamically (when using fork), or to use that simply if nworkers is not passed to QCommProcess. 

With Spawn working we should decide whether to take out the setting to 'fork' under macOS, and just let the OS decide this.
There is still the need to put the calling script code inside `if __name__ == "__main__":`

Also we should test on windows, at least for cores tests.