### PR TITLE
Simple-add of setuptools as dependency?

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,7 @@ Required dependencies:
 * Python_ 3.7 or above
 * NumPy_
 * psutil_
+* setuptools_
 
 When using  ``mpi4py`` for libEnsemble communications:
 
@@ -339,6 +340,7 @@ See a complete list of `example user scripts`_.
 .. _ReadtheDocs: http://libensemble.readthedocs.org/
 .. _SciPy: http://www.scipy.org
 .. _scipy.optimize: https://docs.scipy.org/doc/scipy/reference/optimize.html
+.. _setuptools: https://setuptools.pypa.io/en/latest/
 .. _Spack: https://spack.readthedocs.io/en/latest
 .. _Summit: https://www.olcf.ornl.gov/olcf-resources/compute-systems/summit/
 .. _Surmise: https://surmise.readthedocs.io/en/latest/index.html

--- a/docs/introduction_latex.rst
+++ b/docs/introduction_latex.rst
@@ -64,6 +64,7 @@ We now present further information on running and testing libEnsemble.
 .. _ReadtheDocs: http://libensemble.readthedocs.org/
 .. _SciPy: http://www.scipy.org
 .. _scipy.optimize: https://docs.scipy.org/doc/scipy/reference/optimize.html
+.. _setuptools: https://setuptools.pypa.io/en/latest/
 .. _Spack: https://spack.readthedocs.io/en/latest
 .. _Summit: https://www.olcf.ornl.gov/olcf-resources/compute-systems/summit/
 .. _Surmise: https://surmise.readthedocs.io/en/latest/index.html

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
         "libensemble.tests.regression_tests",
     ],
     package_data={"libensemble.sim_funcs.branin": ["known_minima_and_func_values"]},
-    install_requires=["numpy", "psutil"],
+    install_requires=["numpy", "psutil", "setuptools"],
     # If run tests through setup.py - downloads these but does not install
     tests_require=[
         "pytest>=3.1",


### PR DESCRIPTION
Adds dependency so ``pkg_resources`` can be used to evaluate what packages have been installed, and then import the corresponding Balsam executor or (potentially) APOSMM local-opt methods.