### PR TITLE
Feature / parse PBS nodefile in env_resources

### DIFF
--- a/examples/libE_submission_scripts/edtb_submit_pbspro_central.sh
+++ b/examples/libE_submission_scripts/edtb_submit_pbspro_central.sh
@@ -1,0 +1,39 @@
+#!/bin/bash -x
+#PBS -l walltime=00:30:00
+#PBS -l select=4:ncpus=128
+#PBS -A <project_code>
+
+# Script to run libEnsemble using multiprocessing on launch nodes.
+# Assumes Conda environment is set up.
+
+# To be run with central job management
+# - Manager and workers run on launch node.
+# - Workers submit tasks to the compute nodes in the allocation.
+
+# Name of calling script
+
+source ~/.bashrc
+
+export EXE=<libE_calling_script.py>
+
+# Communication Method
+export COMMS="--comms local"
+
+# Number of workers.
+export NWORKERS="--nworkers 4"
+
+# Name of Conda environment
+export CONDA_ENV_NAME=<conda_env_name>
+
+# Activate conda environment
+export PYTHONNOUSERSITE=1
+conda activate $CONDA_ENV_NAME
+
+cd $PBS_O_WORKDIR
+
+# openMPI on edtb
+export LD_LIBRARY_PATH=/lus/theta-fs0/software/edtb/openmpi/4.1.1/lib:$LD_LIBRARY_PATH
+export PATH=/lus/theta-fs0/software/edtb/openmpi/4.1.1/bin:$PATH
+
+# Launch libE
+python $EXE $COMMS $NWORKERS > out.txt 2>&1

--- a/libensemble/tests/unit_tests/test_env_resources.py
+++ b/libensemble/tests/unit_tests/test_env_resources.py
@@ -169,6 +169,7 @@ def test_pbs_nodelist_nofile():
     nodelist = EnvResources.get_pbs_nodelist(node_list_env="LIBE_RESOURCES_TEST_NODE_LIST")
     assert nodelist == exp_out, "Nodelist returned should be empty if nodefile inaccessible"
 
+
 def test_pbs_nodelist_empty():
     nodefile = "pbs_empty"
     open(nodefile, "w").close()
@@ -178,6 +179,7 @@ def test_pbs_nodelist_empty():
     nodelist = EnvResources.get_pbs_nodelist(node_list_env="LIBE_RESOURCES_TEST_NODE_LIST")
     assert nodelist == exp_out, "Nodelist returned should be empty if nodefile empty"
     os.remove(nodefile)
+
 
 def test_pbs_nodelist_single():
     nodefile = "pbs_single"
@@ -192,6 +194,7 @@ def test_pbs_nodelist_single():
     assert nodelist == exp_out, "Nodelist returned does not match expected"
     os.remove(nodefile)
 
+
 def test_pbs_nodelist_seq():
     nodefile = "pbs_seq"
     in_lines = ['edtb-01.mcp.alcf.anl.gov\n', 'edtb-02.mcp.alcf.anl.gov\n']
@@ -204,6 +207,7 @@ def test_pbs_nodelist_seq():
     nodelist = EnvResources.get_pbs_nodelist(node_list_env="LIBE_RESOURCES_TEST_NODE_LIST")
     assert nodelist == exp_out, "Nodelist returned does not match expected"
     os.remove(nodefile)
+
 
 # These dont apply to the lsf lists as they are listed in full
 # def test_lsf_nodelist_groups():

--- a/libensemble/tests/unit_tests/test_env_resources.py
+++ b/libensemble/tests/unit_tests/test_env_resources.py
@@ -162,6 +162,49 @@ def test_lsf_nodelist_seq():
     assert nodelist == exp_out, "Nodelist returned does not match expected"
 
 
+def test_pbs_nodelist_nofile():
+    nodefile = "./pbs_nofile"
+    os.environ["LIBE_RESOURCES_TEST_NODE_LIST"] = nodefile
+    exp_out = []
+    nodelist = EnvResources.get_pbs_nodelist(node_list_env="LIBE_RESOURCES_TEST_NODE_LIST")
+    assert nodelist == exp_out, "Nodelist returned should be empty if nodefile inaccessible"
+
+def test_pbs_nodelist_empty():
+    nodefile = "pbs_empty"
+    open(nodefile, "w").close()
+
+    os.environ["LIBE_RESOURCES_TEST_NODE_LIST"] = nodefile
+    exp_out = []
+    nodelist = EnvResources.get_pbs_nodelist(node_list_env="LIBE_RESOURCES_TEST_NODE_LIST")
+    assert nodelist == exp_out, "Nodelist returned should be empty if nodefile empty"
+    os.remove(nodefile)
+
+def test_pbs_nodelist_single():
+    nodefile = "pbs_single"
+    in_lines = ['edtb-01.mcp.alcf.anl.gov\n', 'edtb-01.mcp.alcf.anl.gov\n', 'edtb-01.mcp.alcf.anl.gov\n']
+    with open(nodefile, "w") as f:
+        for line in in_lines:
+            f.write(line)
+
+    os.environ["LIBE_RESOURCES_TEST_NODE_LIST"] = nodefile
+    exp_out = ['edtb-01.mcp.alcf.anl.gov']
+    nodelist = EnvResources.get_pbs_nodelist(node_list_env="LIBE_RESOURCES_TEST_NODE_LIST")
+    assert nodelist == exp_out, "Nodelist returned does not match expected"
+    os.remove(nodefile)
+
+def test_pbs_nodelist_seq():
+    nodefile = "pbs_seq"
+    in_lines = ['edtb-01.mcp.alcf.anl.gov\n', 'edtb-02.mcp.alcf.anl.gov\n']
+    with open(nodefile, "w") as f:
+        for line in in_lines:
+            f.write(line)
+
+    os.environ["LIBE_RESOURCES_TEST_NODE_LIST"] = nodefile
+    exp_out = ['edtb-01.mcp.alcf.anl.gov', 'edtb-02.mcp.alcf.anl.gov']
+    nodelist = EnvResources.get_pbs_nodelist(node_list_env="LIBE_RESOURCES_TEST_NODE_LIST")
+    assert nodelist == exp_out, "Nodelist returned does not match expected"
+    os.remove(nodefile)
+
 # These dont apply to the lsf lists as they are listed in full
 # def test_lsf_nodelist_groups():
 # def test_lsf_nodelist_reverse_grp():
@@ -253,6 +296,11 @@ if __name__ == "__main__":
     test_lsf_nodelist_empty()
     test_lsf_nodelist_single()
     test_lsf_nodelist_seq()
+
+    test_pbs_nodelist_nofile()
+    test_pbs_nodelist_empty()
+    test_pbs_nodelist_single()
+    test_pbs_nodelist_seq()
 
     test_lsf_nodelist_shortform_empty()
     test_lsf_nodelist_shortform_single()


### PR DESCRIPTION
While other schedulers set some environment variable to contain the actual nodelist for a job, PBS has a ``PBS_NODEFILE`` environment variable, "The filename containing a list of vnodes assigned to the job."

Adds an additional ``env_resources.py`` nodelist entry for PBS that reads and processes the list of vnodes within the file pointed to by ``PBS_NODEFILE``.