### PR TITLE
Testing funcX worker code in unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,6 @@ jobs:
             # end heffte build and dependencies
 
             # pip install dragonfly-opt
-            pip uninstall setuptools; pip install setuptools==64.0.1
             pip install git+https://github.com/dragonfly/dragonfly.git
 
             pip install torch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,7 @@ jobs:
             pip install -r install/testing_requirements.txt
             pip install psutil
             pip install pyyaml
+            pip install funcx
 
         - name: Install Tasmanian on Ubuntu
           if: matrix.os == 'ubuntu-latest' && matrix.do-balsam == false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
             cd heffte/build
             pwd
             cmake -D CMAKE_BUILD_TYPE=Release -D BUILD_SHARED_LIBS=ON -D CMAKE_INSTALL_PREFIX=./ -D Heffte_ENABLE_AVX=ON -D Heffte_ENABLE_FFTW=ON ../
-            make
+            make -j 4
             make install
             cp ./benchmarks/speed3d_c2c ../../libensemble/tests/regression_tests/
             # end heffte build and dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,7 @@ jobs:
             # end heffte build and dependencies
 
             # pip install dragonfly-opt
+            pip uninstall setuptools; pip install setuptools==64.0.1
             pip install git+https://github.com/dragonfly/dragonfly.git
 
             pip install torch

--- a/libensemble/tests/.coveragerc
+++ b/libensemble/tests/.coveragerc
@@ -24,7 +24,6 @@ omit =
     */legacy_balsam_executor.py
     */forkable_pdb.py
     */parse_args.py
-    */runners.py
     */gen_funcs/old_aposmm.py
     */alloc_funcs/fast_alloc_to_aposmm.py
 exclude_lines =

--- a/libensemble/tests/unit_tests/test_make_runners.py
+++ b/libensemble/tests/unit_tests/test_make_runners.py
@@ -55,58 +55,69 @@ def test_funcx_runner_init():
     calc_in, sim_specs, gen_specs = get_ufunc_args()
 
     sim_specs["funcx_endpoint"] = "1234"
-    runners = Runners(sim_specs, gen_specs)
-    assert (
-        runners.funcx_exctr is not None
-    ), "FuncXExecutor should have been instantiated when funcx_endpoint found in specs"
+
+    with mock.patch("funcx.FuncXClient"):
+
+        runners = Runners(sim_specs, gen_specs)
+
+        assert (
+            runners.funcx_exctr is not None
+        ), "FuncXExecutor should have been instantiated when funcx_endpoint found in specs"
 
 
 def test_funcx_runner_pass():
     calc_in, sim_specs, gen_specs = get_ufunc_args()
 
     sim_specs["funcx_endpoint"] = "1234"
-    runners = Runners(sim_specs, gen_specs)
 
-    #  Creating Mock funcXExecutor and funcX future object - no exception
-    funcx_mock = mock.Mock()
-    funcx_future = mock.Mock()
-    funcx_mock.submit.return_value = funcx_future
-    funcx_future.exception.return_value = None
-    funcx_future.result.return_value = (True, True)
+    with mock.patch("funcx.FuncXClient"):
 
-    runners.funcx_exctr = funcx_mock
-    ro = runners.make_runners()
+        runners = Runners(sim_specs, gen_specs)
 
-    libE_info = {"H_rows": np.array([2, 3, 4]), "workerID": 1, "comm": "fakecomm"}
-    out, persis_info = ro[1](calc_in, {}, libE_info)
+        #  Creating Mock funcXExecutor and funcX future object - no exception
+        funcx_mock = mock.Mock()
+        funcx_future = mock.Mock()
+        funcx_mock.submit.return_value = funcx_future
+        funcx_future.exception.return_value = None
+        funcx_future.result.return_value = (True, True)
 
-    assert all([out, persis_info]), "funcX runner correctly returned results"
+        runners.funcx_exctr = funcx_mock
+        ro = runners.make_runners()
+
+        libE_info = {"H_rows": np.array([2, 3, 4]), "workerID": 1, "comm": "fakecomm"}
+        out, persis_info = ro[1](calc_in, {}, libE_info)
+
+        assert all([out, persis_info]), "funcX runner correctly returned results"
 
 
 def test_funcx_runner_fail():
     calc_in, sim_specs, gen_specs = get_ufunc_args()
 
     gen_specs["funcx_endpoint"] = "4321"
-    runners = Runners(sim_specs, gen_specs)
 
-    #  Creating Mock funcXExecutor and funcX future object - yes exception
-    funcx_mock = mock.Mock()
-    funcx_future = mock.Mock()
-    funcx_mock.submit.return_value = funcx_future
-    funcx_future.exception.return_value = Exception
+    with mock.patch("funcx.FuncXClient"):
 
-    runners.funcx_exctr = funcx_mock
-    ro = runners.make_runners()
+        runners = Runners(sim_specs, gen_specs)
 
-    libE_info = {"H_rows": np.array([2, 3, 4]), "workerID": 1, "comm": "fakecomm"}
+        #  Creating Mock funcXExecutor and funcX future object - yes exception
+        funcx_mock = mock.Mock()
+        funcx_future = mock.Mock()
+        funcx_mock.submit.return_value = funcx_future
+        funcx_future.exception.return_value = Exception
 
-    with pytest.raises(Exception):
-        out, persis_info = ro[2](calc_in, {}, libE_info)
-        pytest.fail("Expected exception")
+        runners.funcx_exctr = funcx_mock
+        ro = runners.make_runners()
+
+        libE_info = {"H_rows": np.array([2, 3, 4]), "workerID": 1, "comm": "fakecomm"}
+
+        with pytest.raises(Exception):
+            out, persis_info = ro[2](calc_in, {}, libE_info)
+            pytest.fail("Expected exception")
 
 
 if __name__ == "__main__":
     test_normal_runners()
     test_normal_no_gen()
+    test_funcx_runner_init()
     test_funcx_runner_pass()
     test_funcx_runner_fail()

--- a/libensemble/tests/unit_tests/test_make_runners.py
+++ b/libensemble/tests/unit_tests/test_make_runners.py
@@ -1,11 +1,9 @@
-import os
 import numpy as np
 import pytest
 import mock
 
 import libensemble.tests.unit_tests.setup as setup
 from libensemble.tools.fields_keys import libE_fields
-from libensemble.resources.resources import Resources
 from libensemble.message_numbers import EVAL_SIM_TAG, EVAL_GEN_TAG
 from libensemble.utils.runners import Runners
 

--- a/libensemble/tests/unit_tests/test_make_runners.py
+++ b/libensemble/tests/unit_tests/test_make_runners.py
@@ -1,0 +1,80 @@
+import os
+import numpy as np
+import pytest
+import mock
+
+import libensemble.tests.unit_tests.setup as setup
+from libensemble.tools.fields_keys import libE_fields
+from libensemble.resources.resources import Resources
+from libensemble.utils import runners
+
+
+def test_normal_runners():
+    sim_specs, gen_specs, exit_criteria = setup.make_criteria_and_specs_0()
+
+
+
+
+def test_manager_exception():
+    """Checking dump of history and pickle file on abort"""
+    sim_specs, gen_specs, exit_criteria = setup.make_criteria_and_specs_0()
+    remove_file_if_exists(hfile_abort)
+    remove_file_if_exists(pfile_abort)
+
+    with mock.patch("libensemble.manager.manager_main") as managerMock:
+        managerMock.side_effect = Exception
+        # Collision between libE.py and libE() (after mods to __init__.py) means
+        #   libensemble.libE.comms_abort tries to refer to the function, not file
+        with mock.patch("libensemble.comms_abort") as abortMock:
+            abortMock.side_effect = Exception
+            # Need fake MPI to get past the Manager only check and dump history
+            with pytest.raises(Exception):
+                libE_specs = {"mpi_comm": fake_mpi, "disable_resource_manager": True}
+                libE(sim_specs, gen_specs, exit_criteria, libE_specs=libE_specs)
+                pytest.fail("Expected exception")
+            assert os.path.isfile(hfile_abort), "History file not dumped"
+            assert os.path.isfile(pfile_abort), "Pickle file not dumped"
+            os.remove(hfile_abort)
+            os.remove(pfile_abort)
+
+            # Test that History and Pickle files NOT created when disabled
+            with pytest.raises(Exception):
+                libE_specs = {"mpi_comm": fake_mpi, "save_H_and_persis_on_abort": False}
+                libE(sim_specs, gen_specs, exit_criteria, libE_specs=libE_specs)
+                pytest.fail("Expected exception")
+            assert not os.path.isfile(hfile_abort), "History file dumped"
+            assert not os.path.isfile(pfile_abort), "Pickle file dumped"
+
+
+# Note - this could be combined now with above tests as fake_MPI prevents need for use of mock module
+# Only way that is better is that this will simply hit first code exception - (when fake_MPI tries to isend)
+# While first test triggers on call to manager
+def test_exception_raising_manager_with_abort():
+    """Running until fake_MPI tries to send msg to test (mocked) comm.Abort is called
+
+    Manager should raise MPISendException when fakeMPI tries to send message, which
+    will be caught by libE and raise MPIAbortException from fakeMPI.Abort"""
+    with pytest.raises(MPIAbortException):
+        sim_specs, gen_specs, exit_criteria = setup.make_criteria_and_specs_0()
+        libE_specs = {"mpi_comm": fake_mpi, "disable_resource_manager": True}
+        libE(sim_specs, gen_specs, exit_criteria, libE_specs=libE_specs)
+        pytest.fail("Expected MPIAbortException exception")
+
+
+def test_exception_raising_manager_no_abort():
+    """Running until fake_MPI tries to send msg to test (mocked) comm.Abort is called
+
+    Manager should raise MPISendException when fakeMPI tries to send message, which
+    will be caught by libE and raise MPIAbortException from fakeMPI.Abort"""
+    libE_specs = {"abort_on_exception": False, "mpi_comm": fake_mpi, "disable_resource_manager": True}
+    with pytest.raises(LoggedException):
+        sim_specs, gen_specs, exit_criteria = setup.make_criteria_and_specs_0()
+        libE(sim_specs, gen_specs, exit_criteria, libE_specs=libE_specs)
+        pytest.fail("Expected MPISendException exception")
+
+
+
+if __name__ == "__main__":
+    test_manager_exception()
+    test_exception_raising_manager_with_abort()
+    test_exception_raising_manager_no_abort()

--- a/libensemble/tests/unit_tests/test_make_runners.py
+++ b/libensemble/tests/unit_tests/test_make_runners.py
@@ -20,7 +20,12 @@ def get_ufunc_args():
     H["sim_started_time"][-L:] = np.inf
 
     sim_ids = np.zeros(1, dtype=int)
-    Work = {"tag": EVAL_SIM_TAG, "persis_info": {}, "libE_info": {"H_rows": sim_ids}, "H_fields": sim_specs["in"]}
+    Work = {
+        "tag": EVAL_SIM_TAG,
+        "persis_info": {},
+        "libE_info": {"H_rows": sim_ids},
+        "H_fields": sim_specs["in"],
+    }
     calc_in = H[Work["H_fields"]][Work["libE_info"]["H_rows"]]
     return calc_in, sim_specs, gen_specs
 
@@ -29,12 +34,14 @@ def test_normal_runners():
     calc_in, sim_specs, gen_specs = get_ufunc_args()
 
     runners = Runners(sim_specs, gen_specs)
-    assert not runners.has_funcx_sim and not runners.has_funcx_gen, \
-        "funcX use should not be detected without setting endpoint fields"
+    assert (
+        not runners.has_funcx_sim and not runners.has_funcx_gen
+    ), "funcX use should not be detected without setting endpoint fields"
 
     ro = runners.make_runners()
-    assert all([i in ro for i in [EVAL_SIM_TAG, EVAL_GEN_TAG]]), \
-        "Both user function tags should be included in runners dictionary"
+    assert all(
+        [i in ro for i in [EVAL_SIM_TAG, EVAL_GEN_TAG]]
+    ), "Both user function tags should be included in runners dictionary"
 
 
 def test_normal_no_gen():
@@ -43,43 +50,65 @@ def test_normal_no_gen():
     runners = Runners(sim_specs, {})
     ro = runners.make_runners()
 
-    assert not ro[2], \
-        "generator function shouldn't be provided if not using gen_specs"
+    assert not ro[2], "generator function shouldn't be provided if not using gen_specs"
 
 
-def test_manager_exception():
-    """Checking dump of history and pickle file on abort"""
-    sim_specs, gen_specs, exit_criteria = setup.make_criteria_and_specs_0()
-    remove_file_if_exists(hfile_abort)
-    remove_file_if_exists(pfile_abort)
+def test_funcx_runner_init():
+    calc_in, sim_specs, gen_specs = get_ufunc_args()
 
-    with mock.patch("libensemble.manager.manager_main") as managerMock:
-        managerMock.side_effect = Exception
-        # Collision between libE.py and libE() (after mods to __init__.py) means
-        #   libensemble.libE.comms_abort tries to refer to the function, not file
-        with mock.patch("libensemble.comms_abort") as abortMock:
-            abortMock.side_effect = Exception
-            # Need fake MPI to get past the Manager only check and dump history
-            with pytest.raises(Exception):
-                libE_specs = {"mpi_comm": fake_mpi, "disable_resource_manager": True}
-                libE(sim_specs, gen_specs, exit_criteria, libE_specs=libE_specs)
-                pytest.fail("Expected exception")
-            assert os.path.isfile(hfile_abort), "History file not dumped"
-            assert os.path.isfile(pfile_abort), "Pickle file not dumped"
-            os.remove(hfile_abort)
-            os.remove(pfile_abort)
-
-            # Test that History and Pickle files NOT created when disabled
-            with pytest.raises(Exception):
-                libE_specs = {"mpi_comm": fake_mpi, "save_H_and_persis_on_abort": False}
-                libE(sim_specs, gen_specs, exit_criteria, libE_specs=libE_specs)
-                pytest.fail("Expected exception")
-            assert not os.path.isfile(hfile_abort), "History file dumped"
-            assert not os.path.isfile(pfile_abort), "Pickle file dumped"
+    sim_specs["funcx_endpoint"] = "1234"
+    runners = Runners(sim_specs, gen_specs)
+    assert (
+        runners.funcx_exctr is not None
+    ), "FuncXExecutor should have been instantiated when funcx_endpoint found in specs"
 
 
+def test_funcx_runner_pass():
+    calc_in, sim_specs, gen_specs = get_ufunc_args()
+
+    sim_specs["funcx_endpoint"] = "1234"
+    runners = Runners(sim_specs, gen_specs)
+
+    #  Creating Mock funcXExecutor and funcX future object - no exception
+    funcx_mock = mock.Mock()
+    funcx_future = mock.Mock()
+    funcx_mock.submit.return_value = funcx_future
+    funcx_future.exception.return_value = None
+    funcx_future.result.return_value = (True, True)
+
+    runners.funcx_exctr = funcx_mock
+    ro = runners.make_runners()
+
+    libE_info = {"H_rows": np.array([2, 3, 4]), "workerID": 1, "comm": "fakecomm"}
+    out, persis_info = ro[1](calc_in, {}, libE_info)
+
+    assert all([out, persis_info]), "funcX runner correctly returned results"
+
+
+def test_funcx_runner_fail():
+    calc_in, sim_specs, gen_specs = get_ufunc_args()
+
+    gen_specs["funcx_endpoint"] = "4321"
+    runners = Runners(sim_specs, gen_specs)
+
+    #  Creating Mock funcXExecutor and funcX future object - no exception
+    funcx_mock = mock.Mock()
+    funcx_future = mock.Mock()
+    funcx_mock.submit.return_value = funcx_future
+    funcx_future.exception.return_value = Exception
+
+    runners.funcx_exctr = funcx_mock
+    ro = runners.make_runners()
+
+    libE_info = {"H_rows": np.array([2, 3, 4]), "workerID": 1, "comm": "fakecomm"}
+
+    with pytest.raises(Exception):
+        out, persis_info = ro[2](calc_in, {}, libE_info)
+        pytest.fail("Expected exception")
 
 
 if __name__ == "__main__":
     test_normal_runners()
-    test_no_gen()
+    test_normal_no_gen()
+    test_funcx_runner_pass()
+    test_funcx_runner_fail()

--- a/libensemble/tests/unit_tests/test_make_runners.py
+++ b/libensemble/tests/unit_tests/test_make_runners.py
@@ -91,7 +91,7 @@ def test_funcx_runner_fail():
     gen_specs["funcx_endpoint"] = "4321"
     runners = Runners(sim_specs, gen_specs)
 
-    #  Creating Mock funcXExecutor and funcX future object - no exception
+    #  Creating Mock funcXExecutor and funcX future object - yes exception
     funcx_mock = mock.Mock()
     funcx_future = mock.Mock()
     funcx_mock.submit.return_value = funcx_future

--- a/libensemble/utils/runners.py
+++ b/libensemble/utils/runners.py
@@ -5,64 +5,67 @@ from libensemble.message_numbers import EVAL_SIM_TAG, EVAL_GEN_TAG
 
 logger = logging.getLogger(__name__)
 
+class Runners:
+    """Determines and returns methods for workers to run user functions.
 
-def _funcx_result(funcx_exctr, user_f, calc_in, persis_info, specs, libE_info):
-    from libensemble.worker import Worker
-    libE_info["comm"] = None  # 'comm' object not pickle-able
-    Worker._set_executor(0, None)  # ditto for executor
+        Currently supported: direct-call and funcX
+    """
 
-    future = funcx_exctr.submit(user_f, calc_in, persis_info, specs, libE_info, endpoint_id=specs["funcx_endpoint"])
-    remote_exc = future.exception()  # blocks until exception or None
-    if remote_exc is None:
-        return future.result()
-    else:
-        raise remote_exc
+    def __init__(self, sim_specs, gen_specs):
+        self.sim_specs = sim_specs
+        self.gen_specs = gen_specs
+        self.sim_f = sim_specs["sim_f"]
+        self.gen_f = gen_specs.get("gen_f")
+        self.has_funcx_sim = len(sim_specs.get("funcx_endpoint", "")) > 0
+        self.has_funcx_gen = len(gen_specs.get("funcx_endpoint", "")) > 0
 
+        if any([self.has_funcx_sim, self.has_funcx_gen]):
+            try:
+                from funcx import FuncXClient
+                from funcx.sdk.executor import FuncXExecutor
+                self.funcx_exctr = FuncXExecutor(FuncXClient())
 
-def _get_funcx_exctr(sim_specs, gen_specs):
-    funcx_sim = len(sim_specs.get("funcx_endpoint", "")) > 0
-    funcx_gen = len(gen_specs.get("funcx_endpoint", "")) > 0
-
-    if any([funcx_sim, funcx_gen]):
-        try:
-            from funcx import FuncXClient
-            from funcx.sdk.executor import FuncXExecutor
-
-            return FuncXExecutor(FuncXClient()), funcx_sim, funcx_gen
-        except ModuleNotFoundError:
-            logger.warning("funcX use detected but funcX not importable. Is it installed?")
-            return None, False, False
-        except Exception:
-            return None, False, False
-    else:
-        return None, False, False
+            except ModuleNotFoundError:
+                logger.warning("funcX use detected but funcX not importable. Is it installed?")
 
 
-def make_runners(sim_specs, gen_specs):
-    """Creates functions to run a sim or gen. These functions are either
-    called directly by the worker or submitted to a funcX endpoint."""
+    def make_runners(self):
+        """Creates functions to run a sim or gen. These functions are either
+        called directly by the worker or submitted to a funcX endpoint."""
 
-    funcx_exctr, funcx_sim, funcx_gen = _get_funcx_exctr(sim_specs, gen_specs)
-    sim_f = sim_specs["sim_f"]
-
-    def run_sim(calc_in, persis_info, libE_info):
-        """Calls or submits the sim func."""
-        if funcx_sim and funcx_exctr:
-            return _funcx_result(funcx_exctr, sim_f, calc_in, persis_info, sim_specs, libE_info)
-        else:
-            return sim_f(calc_in, persis_info, sim_specs, libE_info)
-
-    if gen_specs:
-        gen_f = gen_specs["gen_f"]
-
-        def run_gen(calc_in, persis_info, libE_info):
-            """Calls or submits the gen func."""
-            if funcx_gen and funcx_exctr:
-                return _funcx_result(funcx_exctr, gen_f, calc_in, persis_info, gen_specs, libE_info)
+        def run_sim(calc_in, persis_info, libE_info):
+            """Calls or submits the sim func."""
+            if self.has_funcx_sim and self.funcx_exctr:
+                return self._funcx_result(calc_in, persis_info, self.sim_specs, libE_info, self.sim_f)
             else:
-                return gen_f(calc_in, persis_info, gen_specs, libE_info)
+                return self._normal_result(calc_in, persis_info, self.sim_specs, libE_info, self.sim_f)
 
-    else:
-        run_gen = []
+        if self.gen_specs:
 
-    return {EVAL_SIM_TAG: run_sim, EVAL_GEN_TAG: run_gen}
+            def run_gen(calc_in, persis_info, libE_info):
+                """Calls or submits the gen func."""
+                if self.has_funcx_gen and self.funcx_exctr:
+                    return self._funcx_result(calc_in, persis_info, self.gen_specs, libE_info, self.gen_f)
+                else:
+                    return self._normal_result(calc_in, persis_info, self.gen_specs, libE_info, self.gen_f)
+
+        else:
+            run_gen = []
+
+        return {EVAL_SIM_TAG: run_sim, EVAL_GEN_TAG: run_gen}
+
+
+    def _normal_result(self, calc_in, persis_info, specs, libE_info, user_f):
+        return user_f(calc_in, persis_info, specs, libE_info)
+
+    def _funcx_result(self, calc_in, persis_info, specs, libE_info, user_f):
+        from libensemble.worker import Worker
+        libE_info["comm"] = None  # 'comm' object not pickle-able
+        Worker._set_executor(0, None)  # ditto for executor
+
+        future = self.funcx_exctr.submit(user_f, calc_in, persis_info, specs, libE_info, endpoint_id=specs["funcx_endpoint"])
+        remote_exc = future.exception()  # blocks until exception or None
+        if remote_exc is None:
+            return future.result()
+        else:
+            raise remote_exc

--- a/libensemble/utils/runners.py
+++ b/libensemble/utils/runners.py
@@ -5,10 +5,11 @@ from libensemble.message_numbers import EVAL_SIM_TAG, EVAL_GEN_TAG
 
 logger = logging.getLogger(__name__)
 
+
 class Runners:
     """Determines and returns methods for workers to run user functions.
 
-        Currently supported: direct-call and funcX
+    Currently supported: direct-call and funcX
     """
 
     def __init__(self, sim_specs, gen_specs):
@@ -18,52 +19,70 @@ class Runners:
         self.gen_f = gen_specs.get("gen_f")
         self.has_funcx_sim = len(sim_specs.get("funcx_endpoint", "")) > 0
         self.has_funcx_gen = len(gen_specs.get("funcx_endpoint", "")) > 0
+        self.funcx_exctr = None
 
         if any([self.has_funcx_sim, self.has_funcx_gen]):
             try:
                 from funcx import FuncXClient
                 from funcx.sdk.executor import FuncXExecutor
+
                 self.funcx_exctr = FuncXExecutor(FuncXClient())
 
             except ModuleNotFoundError:
-                logger.warning("funcX use detected but funcX not importable. Is it installed?")
-
+                logger.warning(
+                    "funcX use detected but funcX not importable. Is it installed?"
+                )
 
     def make_runners(self):
         """Creates functions to run a sim or gen. These functions are either
         called directly by the worker or submitted to a funcX endpoint."""
 
         def run_sim(calc_in, persis_info, libE_info):
-            """Calls or submits the sim func."""
+            """Determines how to run sim."""
             if self.has_funcx_sim and self.funcx_exctr:
-                return self._funcx_result(calc_in, persis_info, self.sim_specs, libE_info, self.sim_f)
+                result = self._funcx_result
             else:
-                return self._normal_result(calc_in, persis_info, self.sim_specs, libE_info, self.sim_f)
+                result = self._normal_result
+
+            return result(calc_in, persis_info, self.sim_specs, libE_info, self.sim_f)
 
         if self.gen_specs:
 
             def run_gen(calc_in, persis_info, libE_info):
-                """Calls or submits the gen func."""
+                """Determines how to run gen."""
                 if self.has_funcx_gen and self.funcx_exctr:
-                    return self._funcx_result(calc_in, persis_info, self.gen_specs, libE_info, self.gen_f)
+                    result = self._funcx_result
                 else:
-                    return self._normal_result(calc_in, persis_info, self.gen_specs, libE_info, self.gen_f)
+                    result = self._normal_result
+
+                return result(
+                    calc_in, persis_info, self.gen_specs, libE_info, self.gen_f
+                )
 
         else:
             run_gen = []
 
         return {EVAL_SIM_TAG: run_sim, EVAL_GEN_TAG: run_gen}
 
-
     def _normal_result(self, calc_in, persis_info, specs, libE_info, user_f):
+        """User function called in-place"""
         return user_f(calc_in, persis_info, specs, libE_info)
 
     def _funcx_result(self, calc_in, persis_info, specs, libE_info, user_f):
+        """User function submitted to funcX"""
         from libensemble.worker import Worker
+
         libE_info["comm"] = None  # 'comm' object not pickle-able
         Worker._set_executor(0, None)  # ditto for executor
 
-        future = self.funcx_exctr.submit(user_f, calc_in, persis_info, specs, libE_info, endpoint_id=specs["funcx_endpoint"])
+        future = self.funcx_exctr.submit(
+            user_f,
+            calc_in,
+            persis_info,
+            specs,
+            libE_info,
+            endpoint_id=specs["funcx_endpoint"],
+        )
         remote_exc = future.exception()  # blocks until exception or None
         if remote_exc is None:
             return future.result()

--- a/libensemble/worker.py
+++ b/libensemble/worker.py
@@ -19,7 +19,7 @@ from libensemble.output_directory import EnsembleDirectory
 
 from libensemble.utils.misc import extract_H_ranges
 from libensemble.utils.timer import Timer
-from libensemble.utils.runners import make_runners
+from libensemble.utils.runners import Runners
 from libensemble.executors.executor import Executor
 from libensemble.resources.resources import Resources
 from libensemble.comms.logs import worker_logging_config
@@ -136,7 +136,7 @@ class Worker:
         self.stats_fmt = libE_specs.get("stats_fmt", {})
 
         self.calc_iter = {EVAL_SIM_TAG: 0, EVAL_GEN_TAG: 0}
-        self._run_calc = make_runners(sim_specs, gen_specs)
+        self._run_calc = Runners(sim_specs, gen_specs).make_runners()
         Worker._set_executor(self.workerID, self.comm)
         Worker._set_resources(self.workerID, self.comm)
         self.EnsembleDirectory = EnsembleDirectory(libE_specs=libE_specs)

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
         "libensemble.tests.regression_tests",
     ],
     package_data={"libensemble.sim_funcs.branin": ["known_minima_and_func_values"]},
-    install_requires=["numpy", "psutil", "setuptools"],
+    install_requires=["numpy", "psutil", "setuptools==64.0.1"],
     # If run tests through setup.py - downloads these but does not install
     tests_require=[
         "pytest>=3.1",

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
         "libensemble.tests.regression_tests",
     ],
     package_data={"libensemble.sim_funcs.branin": ["known_minima_and_func_values"]},
-    install_requires=["numpy", "psutil", "setuptools==64.0.1"],
+    install_requires=["numpy", "psutil", "setuptools"],
     # If run tests through setup.py - downloads these but does not install
     tests_require=[
         "pytest>=3.1",


### PR DESCRIPTION
Also refactors `utils/runners.py`.

Basically `mock` is used to create pretend funcX Executors and futures, with which we can finally test our funcX code within the unit tests.

Addresses #883 