### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,23 +1,19 @@
-Copyright (c) 2018, UChicago Argonne, LLC
-
-All Rights Reserved
-Software Name: LibEnsemble
-By: Argonne National Laboratory
-OPEN SOURCE LICENSE (BSD)
+Copyright (c) 2018-2022, UChicago Argonne, LLC and the libEnsemble Development Team
+All Rights Reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-1 Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-2 Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-3 Neither the name of the copyright holder nor the names of its contributors
-  may be used to endorse or promote products derived from this software without
-  specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software without
+   specific prior written permission.
 
 
 ********************************************************************************


### PR DESCRIPTION
Elsewhere I recently ran into an oddity with the Argonne license for deephyper (basically the open source initiative flagged it as a custom Argonne license rather than the BSD 3-clause). 

This PR cleans things up for libEnsemble and makes things consistent with packages such as:

- https://github.com/petsc/petsc/blob/main/LICENSE
- https://github.com/parmoo/parmoo/blob/develop/LICENSE

I would like for each author (@dbindel , @jmlarson1 , @jlnav , @shuds13 ) to agree or otherwise chime in here since it might be considered a license change.

