### PR TITLE
Add GPU detection module

### DIFF
--- a/docs/data_structures/libE_specs.rst
+++ b/docs/data_structures/libE_specs.rst
@@ -188,6 +188,8 @@ The allowable ``libE_specs["resource_info"]`` fields are::
 
     "cores_on_node" [tuple (int, int)]:
         Tuple (physical cores, logical cores) on nodes.
+    "gpus_on_node" [int]:
+        Number of GPUs on each node.
     "node_file" [str]:
         Name of file containing a node-list. Default is "node_list".
     "nodelist_env_slurm" [str]:

--- a/libensemble/resources/env_resources.py
+++ b/libensemble/resources/env_resources.py
@@ -100,7 +100,7 @@ class EnvResources:
             env_var = self.nodelists[env]
             logger.debug(f"{env} env found - getting nodelist from {env_var}")
             get_list_func = self.ndlist_funcs[env]
-            global_nodelist = get_list_func(env_var)
+            global_nodelist = self.shortnames(get_list_func(env_var))
             return global_nodelist
         return []
 

--- a/libensemble/resources/gpu_detect.py
+++ b/libensemble/resources/gpu_detect.py
@@ -1,0 +1,95 @@
+import os
+import ast
+import subprocess
+
+# SH TODO - Remove prints
+
+
+def pynvml():
+    """Detect GPU from pynvml or return None"""
+    try:
+        import pynvml
+
+        pynvml.nvmlInit()
+        gpu_count = pynvml.nvmlDeviceGetCount()
+        pynvml.nvmlShutdown()
+    except Exception:
+        print("pynvml (optional) not found or failed")
+        return None
+    return gpu_count
+
+
+def nvidia_smi():
+    """Detect GPU from nvidia-smi or return None"""
+    try:
+        output = subprocess.check_output(["nvidia-smi", "--query-gpu=index", "--format=csv,noheader,nounits"])
+        gpu_count = len(output.decode().split())
+    except Exception:
+        print("nvidia-smi (optional) not found or failed")
+        return None
+    return gpu_count
+
+
+def pyadl():
+    """Detect GPU from pyadl or return None"""
+    try:
+        from pyadl import ADLManager
+
+        devices = ADLManager.getInstance().getDevices()
+        gpu_count = len(devices)
+    except Exception:
+        print("pyadl (optional) not found or failed")
+        return None
+    return gpu_count
+
+
+def rocm_smi():
+    """Detect GPU from rocm-smi or return None"""
+    try:
+        output = subprocess.check_output(["rocm-smi", "-i", "--json"])
+        gpu_count = len(ast.literal_eval(output.decode()))
+        print("gpu count from rocm-smi", gpu_count)
+    except Exception:
+        print("rocm-smi (optional) not found or failed")
+        return None
+    return gpu_count
+
+
+METHODS = {
+    "pynvml": pynvml,
+    "nvidia_smi": nvidia_smi,
+    "pyadl": pyadl,
+    "rocm_smi": rocm_smi,
+}
+
+
+def get_num_gpus():
+    """Return number of GPUs on node if can detect - else None"""
+
+    # Default zero or None
+    gpu_count = None
+
+    for method in METHODS:
+        gpu_count = METHODS[method]()
+        if isinstance(gpu_count, int):
+            return gpu_count
+
+    # gpus not found
+    # Simpler for string conversion to return int.
+    return 0
+    # return None
+
+
+def get_gpus_from_env(env_resources=None):
+    """Returns gpus per node by querying environment or None"""
+
+    if not env_resources:
+        return None
+
+    if env_resources.scheduler == "Slurm":
+        gpu_count = os.getenv("SLURM_GPUS_ON_NODE")
+        print("gpu count from SLURM_GPUS_ON_NODE", gpu_count)
+        # return os.getenv("SLURM_GPUS_ON_NODE")
+        return int(gpu_count)
+
+    return None

--- a/libensemble/resources/gpu_detect.py
+++ b/libensemble/resources/gpu_detect.py
@@ -65,11 +65,25 @@ def rocm_smi():
     return gpu_count
 
 
+def zeinfo():
+    """Detect GPU from zeinfo or return None"""
+    try:
+        ps = subprocess.Popen(('zeinfo'), stderr=subprocess.PIPE)
+        output = subprocess.check_output(('grep', 'Number of devices'), stdin=ps.stderr)
+        gpu_count = int(output.decode().split()[3])
+        eprint("gpu count from zeinfo", gpu_count)
+    except Exception:
+        eprint("zeinfo (optional) not found or failed")
+        return None
+    return gpu_count
+
+
 METHODS = {
     "pynvml": pynvml,
     "nvidia_smi": nvidia_smi,
     "pyadl": pyadl,
     "rocm_smi": rocm_smi,
+    "zeinfo": zeinfo,
 }
 
 

--- a/libensemble/resources/gpu_detect.py
+++ b/libensemble/resources/gpu_detect.py
@@ -93,7 +93,7 @@ def get_gpus_from_env(env_resources=None):
         gpu_count = os.getenv("SLURM_GPUS_ON_NODE")
         print("gpu count from SLURM_GPUS_ON_NODE", gpu_count)
         # return os.getenv("SLURM_GPUS_ON_NODE")
-        return int(gpu_count)
+        return gpu_count
 
     return None
 

--- a/libensemble/resources/gpu_detect.py
+++ b/libensemble/resources/gpu_detect.py
@@ -2,7 +2,14 @@ import os
 import ast
 import subprocess
 
-# SH TODO - Remove prints
+# SH TODO while testing - REMOVE
+from libensemble.tools import eprint
+
+# SH TODO - Remove eprints
+# import sys
+# def eprint(*args, **kwargs):
+#    """Prints a user message to standard error"""
+#    print(*args, file=sys.stderr, **kwargs)
 
 
 def pynvml():
@@ -13,9 +20,9 @@ def pynvml():
         pynvml.nvmlInit()
         gpu_count = pynvml.nvmlDeviceGetCount()
         pynvml.nvmlShutdown()
-        print("gpu count from pynvml", gpu_count)
+        eprint("gpu count from pynvml", gpu_count)
     except Exception:
-        print("pynvml (optional) not found or failed")
+        eprint("pynvml (optional) not found or failed")
         return None
     return gpu_count
 
@@ -25,9 +32,9 @@ def nvidia_smi():
     try:
         output = subprocess.check_output(["nvidia-smi", "--query-gpu=index", "--format=csv,noheader,nounits"])
         gpu_count = len(output.decode().split())
-        print("gpu count from nvidia-smi", gpu_count)
+        eprint("gpu count from nvidia-smi", gpu_count)
     except Exception:
-        print("nvidia-smi (optional) not found or failed")
+        eprint("nvidia-smi (optional) not found or failed")
         return None
     return gpu_count
 
@@ -39,9 +46,9 @@ def pyadl():
 
         devices = ADLManager.getInstance().getDevices()
         gpu_count = len(devices)
-        print("gpu count from pyadl", gpu_count)
+        eprint("gpu count from pyadl", gpu_count)
     except Exception:
-        print("pyadl (optional) not found or failed")
+        eprint("pyadl (optional) not found or failed")
         return None
     return gpu_count
 
@@ -51,9 +58,9 @@ def rocm_smi():
     try:
         output = subprocess.check_output(["rocm-smi", "-i", "--json"])
         gpu_count = len(ast.literal_eval(output.decode()))
-        print("gpu count from rocm-smi", gpu_count)
+        eprint("gpu count from rocm-smi", gpu_count)
     except Exception:
-        print("rocm-smi (optional) not found or failed")
+        eprint("rocm-smi (optional) not found or failed")
         return None
     return gpu_count
 
@@ -77,10 +84,7 @@ def get_num_gpus(testall=False):
         if isinstance(gpu_count, int) and not testall:
             return gpu_count
 
-    # gpus not found
-    # Simpler for string conversion to return int.
-    return 0
-    # return None
+    return None
 
 
 def get_gpus_from_env(env_resources=None):
@@ -91,13 +95,14 @@ def get_gpus_from_env(env_resources=None):
 
     if env_resources.scheduler == "Slurm":
         gpu_count = os.getenv("SLURM_GPUS_ON_NODE")
-        print("gpu count from SLURM_GPUS_ON_NODE", gpu_count)
+        eprint("gpu count from SLURM_GPUS_ON_NODE", gpu_count)
         # return os.getenv("SLURM_GPUS_ON_NODE")
         if gpu_count is not None:
             return int(gpu_count)
 
     return None
 
-# temp
+
+# for testing
 if __name__ == "__main__":
     get_num_gpus(testall=True)

--- a/libensemble/resources/gpu_detect.py
+++ b/libensemble/resources/gpu_detect.py
@@ -93,7 +93,8 @@ def get_gpus_from_env(env_resources=None):
         gpu_count = os.getenv("SLURM_GPUS_ON_NODE")
         print("gpu count from SLURM_GPUS_ON_NODE", gpu_count)
         # return os.getenv("SLURM_GPUS_ON_NODE")
-        return gpu_count
+        if gpu_count is not None:
+            return int(gpu_count)
 
     return None
 

--- a/libensemble/resources/gpu_detect.py
+++ b/libensemble/resources/gpu_detect.py
@@ -13,6 +13,7 @@ def pynvml():
         pynvml.nvmlInit()
         gpu_count = pynvml.nvmlDeviceGetCount()
         pynvml.nvmlShutdown()
+        print("gpu count from pynvml", gpu_count)
     except Exception:
         print("pynvml (optional) not found or failed")
         return None
@@ -24,6 +25,7 @@ def nvidia_smi():
     try:
         output = subprocess.check_output(["nvidia-smi", "--query-gpu=index", "--format=csv,noheader,nounits"])
         gpu_count = len(output.decode().split())
+        print("gpu count from nvidia-smi", gpu_count)
     except Exception:
         print("nvidia-smi (optional) not found or failed")
         return None
@@ -37,6 +39,7 @@ def pyadl():
 
         devices = ADLManager.getInstance().getDevices()
         gpu_count = len(devices)
+        print("gpu count from pyadl", gpu_count)
     except Exception:
         print("pyadl (optional) not found or failed")
         return None
@@ -63,7 +66,7 @@ METHODS = {
 }
 
 
-def get_num_gpus():
+def get_num_gpus(testall=False):
     """Return number of GPUs on node if can detect - else None"""
 
     # Default zero or None
@@ -71,7 +74,7 @@ def get_num_gpus():
 
     for method in METHODS:
         gpu_count = METHODS[method]()
-        if isinstance(gpu_count, int):
+        if isinstance(gpu_count, int) and not testall:
             return gpu_count
 
     # gpus not found
@@ -93,3 +96,7 @@ def get_gpus_from_env(env_resources=None):
         return int(gpu_count)
 
     return None
+
+# temp
+if __name__ == "__main__":
+    get_num_gpus(testall=True)

--- a/libensemble/resources/node_resources.py
+++ b/libensemble/resources/node_resources.py
@@ -89,7 +89,7 @@ def get_sub_node_resources(launcher=None, remote_mode=False, env_resources=None)
 
     # In some cases may be worth getting GPUs from env even when local
     num_gpus = get_gpus_from_env(env_resources=env_resources)
-    print(f"{num_gpus=}")
+    # print(f"{num_gpus=}")
 
     if remote_mode:
         # May be unnecessary condition

--- a/libensemble/resources/node_resources.py
+++ b/libensemble/resources/node_resources.py
@@ -6,12 +6,52 @@ This module for detects and returns intranode resources
 import os
 import psutil
 import logging
+import subprocess
 import collections
 from libensemble.resources.gpu_detect import get_num_gpus, get_gpus_from_env
+from libensemble.resources.platforms import detect_systems
 
 logger = logging.getLogger(__name__)
 
 REMOTE_LAUNCH_LIST = ["aprun", "jsrun", "srun"]  # Move to feature of mpi_runner
+
+
+def known_sys_check():
+    """Detect system domain name and return any CPU / GPU data found as a tuple
+
+    If the system is found, will return an int tuple of (cores, logical cores, gpus),
+    where any missing entry will be None.
+
+    If system is not found in known list, then returns None.
+
+    """
+
+    try:
+        domain_name = subprocess.check_output(["hostname", "-d"]).decode().rstrip()
+
+        print("domain", domain_name)
+
+        if isinstance(domain_name, str) and len(domain_name):
+            system_name = detect_systems.get(domain_name)
+
+            print("system", system_name)
+
+            if system_name is None:
+                print("System not in known list", domain_name)
+                return None
+
+            physical_cores = system_name.get("cores_per_node")
+            logical_cores = system_name.get("logical_cores_per_node")
+            gpu_count = system_name.get("gpus_per_node")
+
+            return (physical_cores, logical_cores, gpu_count)
+        else:
+            print("Could not get valid domain name")
+            return None
+
+    except Exception:
+        print("Known system detection failed")
+        return None
 
 
 def get_cpu_cores(hyperthreads=False):
@@ -26,22 +66,21 @@ def get_cpu_cores(hyperthreads=False):
     return psutil.cpu_count(logical=hyperthreads)  # This is ranks available per node
 
 
-# SH TODO: Rename for gpu resources also
-def _get_local_cpu_resources():
+def _get_local_resources():
     """Returns logical and physical cores on the local node"""
-    logical_cores_avail_per_node = get_cpu_cores(hyperthreads=True)
-    physical_cores_avail_per_node = get_cpu_cores(hyperthreads=False)
-    gpus_avail_per_node = get_num_gpus()
-    return (physical_cores_avail_per_node, logical_cores_avail_per_node, gpus_avail_per_node)
+    physical_cores = get_cpu_cores(hyperthreads=False)
+    logical_cores = get_cpu_cores(hyperthreads=True)
+    num_gpus = get_num_gpus()
+    return (physical_cores, logical_cores, num_gpus)
 
 
-def _print_local_cpu_resources():
+def _print_local_resources():
     """Prints logical and physical cores on the local node"""
-    cores_info = _get_local_cpu_resources()
+    cores_info = _get_local_resources()
     print(cores_info[0], cores_info[1], cores_info[2], flush=True)
 
 
-def _get_remote_cpu_resources(launcher):
+def _get_remote_resources(launcher):
     """Launches a probe job to obtain logical and physical cores on remote node"""
     import subprocess
 
@@ -81,49 +120,122 @@ def _get_cpu_resources_from_env(env_resources=None):
         return None
 
 
-def get_sub_node_resources(launcher=None, remote_mode=False, env_resources=None):
-    """Returns logical and physical cores per node as a tuple"""
-    remote_detection = False
-    cores_info = None
-    num_gpus = 0
+# tuple or change to list? or dict? - do for all 3 funcs
+def _cpu_info_complete(cores_info):
+    """Returns true if cpu tuple values have an integer value, else False"""
 
-    # In some cases may be worth getting GPUs from env even when local
-    num_gpus = get_gpus_from_env(env_resources=env_resources)
-    # print(f"{num_gpus=}")
+    if cores_info is None:
+        return False
 
-    if remote_mode:
-        # May be unnecessary condition
-        print("launcher is", launcher)
-        if launcher in REMOTE_LAUNCH_LIST:
-            cores_info = _get_cpu_resources_from_env(env_resources=env_resources)
-            if cores_info and num_gpus:
-                return cores_info + num_gpus
-            remote_detection = True  # Cannot obtain from environment
+    for val in cores_info[:2]:
+        if not isinstance(val, int):
+            return False
+    return True
 
-    if remote_detection:
-        cores_info_str = _get_remote_cpu_resources(launcher=launcher)
-        cores_phy, cores_log, num_gpus, *_ = cores_info_str.split()
 
-        if cores_info:
-            # If got from environment, do not replace
-            cores_info = cores_info + int(num_gpus)
+def _gpu_info_complete(cores_info):
+    """Returns true if gpu tuple values have an integer value, else False"""
 
-            # testing if match
-            if cores_info[0] == cores_phy and cores_info[1] == cores_log:
-                print("Env and detected match")
-            else:
-                print(f"Env and detected DONT match env: {cores_info} detect: {cores_phy} {cores_log}")
-        else:
-            cores_info = (int(cores_phy), int(cores_log), int(num_gpus))
-    else:
-        cores_info = _get_local_cpu_resources()
+    if cores_info is None:
+        return False
 
-        if cores_info[2] == 0:
-            if num_gpus is not None and num_gpus > 0:
-                cores_info = (cores_info[0], cores_info[1], int(num_gpus))
+    for val in cores_info[2:]:
+        if not isinstance(val, int):
+            return False
+    return True
+
+
+def _complete_set(cores_info):
+    """Returns True if all tuple entries have an integer value, else False"""
+
+    if cores_info is None:
+        return False
+
+    for val in cores_info:
+        if not isinstance(val, int):
+            return False
+    return True
+
+
+def _update_values(cores_info, cores_info_updates):
+    """Update values that are not set"""
+    if not _cpu_info_complete(cores_info):
+        cores_info[:2] = list(cores_info_updates[:2] or [None, None])
+    if not _gpu_info_complete(cores_info):
+        cores_info[2] = cores_info_updates[2]
+    return cores_info
+
+
+def _update_from_str(cores_info, cores_info_str):
+    """Update values that are not set from a string"""
+    cores_phy, cores_log, num_gpus, *_ = cores_info_str.split()
+
+    if not _cpu_info_complete(cores_info):
+        try:
+            cores_info[:2] = [int(cores_phy), int(cores_log)]
+        except ValueError:
+            pass
+
+    if not _gpu_info_complete(cores_info):
+        try:
+            cores_info[2] = int(num_gpus)
+        except ValueError:
+            pass
 
     return cores_info
 
 
+def get_sub_node_resources(launcher=None, remote_mode=False, env_resources=None):
+    """Returns logical and physical cores and GPUs per node as a tuple
+
+    First checks for known system values, then for environment values, and finally
+    for detected values. If remote_mode is True, then detection launches a job
+    via the MPI launcher.
+
+    Any value that is already valid, is not overwritten by successive stages.
+
+    """
+
+    # SH TODO: Could receive if cpu/gpu is already set by resource_info so don't need to get.
+    #          Though will be not overwrite anyway.
+
+    remote_detection = False
+    cores_info = [None, None, None]
+    num_gpus = 0
+
+    print("type is", type(cores_info))
+
+    # Check for known system
+    cores_info = known_sys_check() or [None, None, None]
+    print("known system ", cores_info)
+    if _complete_set(cores_info):
+        print("known system provided all info")
+        return tuple(cores_info)
+
+    # Check environment
+    if not _cpu_info_complete(cores_info):
+        cores_info[:2] = list(_get_cpu_resources_from_env(env_resources=env_resources) or [None, None])
+    if not _gpu_info_complete(cores_info):
+        cores_info[2] = get_gpus_from_env(env_resources=env_resources)
+    if _complete_set(cores_info):
+        print("known system and/or env provided all info")
+        return tuple(cores_info)
+
+    # Detection of cpu/gpu resources
+    # If remote then launch probe, else detect locally
+    if remote_mode:
+        cores_info_str = _get_remote_resources(launcher=launcher)
+        cores_info = _update_from_str(cores_info, cores_info_str)
+        print("called remote detection")
+    else:
+        cores_info_detected = _get_local_resources()
+        cores_info = _update_values(cores_info, cores_info_detected)
+        print("called local detection")
+
+    # Convert Nones to zeros and return
+    cores_info = [0 if v is None else v for v in cores_info]
+    return tuple(cores_info)
+
+
 if __name__ == "__main__":
-    _print_local_cpu_resources()
+    _print_local_resources()

--- a/libensemble/resources/node_resources.py
+++ b/libensemble/resources/node_resources.py
@@ -122,7 +122,6 @@ def _get_cpu_resources_from_env(env_resources=None):
         return None
 
 
-# tuple or change to list? or dict? - do for all 3 funcs
 def _cpu_info_complete(cores_info):
     """Returns true if cpu tuple/list entries have an integer value, else False"""
 
@@ -160,7 +159,10 @@ def _complete_set(cores_info):
 
 
 def _update_values(cores_info, cores_info_updates):
-    """Update list entries in cores_info that are not set"""
+    """Update list entries in cores_info that are not set
+
+    Both CPU core entries will get overwritten if one is not set
+    """
     if not _cpu_info_complete(cores_info):
         cores_info[:2] = list(cores_info_updates[:2] or [None, None])
     if not _gpu_info_complete(cores_info):
@@ -169,7 +171,10 @@ def _update_values(cores_info, cores_info_updates):
 
 
 def _update_from_str(cores_info, cores_info_str):
-    """Update entries in cores_info that are not set from a string"""
+    """Update unset entries in cores_info from a string
+
+    Both CPU core entries will get overwritten if one is not set
+    """
     cores_phy, cores_log, num_gpus, *_ = cores_info_str.split()
 
     if not _cpu_info_complete(cores_info):

--- a/libensemble/resources/node_resources.py
+++ b/libensemble/resources/node_resources.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 REMOTE_LAUNCH_LIST = ["aprun", "jsrun", "srun"]  # Move to feature of mpi_runner
 
 
-def known_sys_check():
+def known_sys_check(cmd="hostname -d"):
     """Detect system domain name and return any CPU / GPU data found as a tuple
 
     If the system is found, will return an int tuple of (cores, logical cores, gpus),
@@ -26,8 +26,10 @@ def known_sys_check():
 
     """
 
+    run_cmd = cmd.split()
+
     try:
-        domain_name = subprocess.check_output(["hostname", "-d"]).decode().rstrip()
+        domain_name = subprocess.check_output(run_cmd).decode().rstrip()
 
         print("domain", domain_name)
 
@@ -122,7 +124,7 @@ def _get_cpu_resources_from_env(env_resources=None):
 
 # tuple or change to list? or dict? - do for all 3 funcs
 def _cpu_info_complete(cores_info):
-    """Returns true if cpu tuple values have an integer value, else False"""
+    """Returns true if cpu tuple/list entries have an integer value, else False"""
 
     if cores_info is None:
         return False
@@ -134,7 +136,7 @@ def _cpu_info_complete(cores_info):
 
 
 def _gpu_info_complete(cores_info):
-    """Returns true if gpu tuple values have an integer value, else False"""
+    """Returns true if gpu tuple/list entries have an integer value, else False"""
 
     if cores_info is None:
         return False
@@ -146,7 +148,7 @@ def _gpu_info_complete(cores_info):
 
 
 def _complete_set(cores_info):
-    """Returns True if all tuple entries have an integer value, else False"""
+    """Returns True if all tuple/list entries have an integer value, else False"""
 
     if cores_info is None:
         return False
@@ -158,7 +160,7 @@ def _complete_set(cores_info):
 
 
 def _update_values(cores_info, cores_info_updates):
-    """Update values that are not set"""
+    """Update list entries in cores_info that are not set"""
     if not _cpu_info_complete(cores_info):
         cores_info[:2] = list(cores_info_updates[:2] or [None, None])
     if not _gpu_info_complete(cores_info):
@@ -167,7 +169,7 @@ def _update_values(cores_info, cores_info_updates):
 
 
 def _update_from_str(cores_info, cores_info_str):
-    """Update values that are not set from a string"""
+    """Update entries in cores_info that are not set from a string"""
     cores_phy, cores_log, num_gpus, *_ = cores_info_str.split()
 
     if not _cpu_info_complete(cores_info):

--- a/libensemble/resources/node_resources.py
+++ b/libensemble/resources/node_resources.py
@@ -199,11 +199,7 @@ def get_sub_node_resources(launcher=None, remote_mode=False, env_resources=None)
     # SH TODO: Could receive if cpu/gpu is already set by resource_info so don't need to get.
     #          Though will be not overwrite anyway.
 
-    remote_detection = False
     cores_info = [None, None, None]
-    num_gpus = 0
-
-    print("type is", type(cores_info))
 
     # Check for known system
     cores_info = known_sys_check() or [None, None, None]

--- a/libensemble/resources/node_resources.py
+++ b/libensemble/resources/node_resources.py
@@ -7,6 +7,7 @@ import os
 import psutil
 import logging
 import collections
+from libensemble.resources.gpu_detect import get_num_gpus, get_gpus_from_env
 
 logger = logging.getLogger(__name__)
 
@@ -25,17 +26,19 @@ def get_cpu_cores(hyperthreads=False):
     return psutil.cpu_count(logical=hyperthreads)  # This is ranks available per node
 
 
+# SH TODO: Rename for gpu resources also
 def _get_local_cpu_resources():
     """Returns logical and physical cores on the local node"""
     logical_cores_avail_per_node = get_cpu_cores(hyperthreads=True)
     physical_cores_avail_per_node = get_cpu_cores(hyperthreads=False)
-    return (physical_cores_avail_per_node, logical_cores_avail_per_node)
+    gpus_avail_per_node = get_num_gpus()
+    return (physical_cores_avail_per_node, logical_cores_avail_per_node, gpus_avail_per_node)
 
 
 def _print_local_cpu_resources():
     """Prints logical and physical cores on the local node"""
     cores_info = _get_local_cpu_resources()
-    print(cores_info[0], cores_info[1], flush=True)
+    print(cores_info[0], cores_info[1], cores_info[2], flush=True)
 
 
 def _get_remote_cpu_resources(launcher):
@@ -81,20 +84,44 @@ def _get_cpu_resources_from_env(env_resources=None):
 def get_sub_node_resources(launcher=None, remote_mode=False, env_resources=None):
     """Returns logical and physical cores per node as a tuple"""
     remote_detection = False
+    cores_info = None
+    num_gpus = 0
+
+    # In some cases may be worth getting GPUs from env even when local
+    num_gpus = get_gpus_from_env(env_resources=env_resources)
+    print(f"{num_gpus=}")
+
     if remote_mode:
         # May be unnecessary condition
+        print("launcher is", launcher)
         if launcher in REMOTE_LAUNCH_LIST:
             cores_info = _get_cpu_resources_from_env(env_resources=env_resources)
-            if cores_info:
-                return cores_info
+            if cores_info and num_gpus:
+                return cores_info + num_gpus
             remote_detection = True  # Cannot obtain from environment
 
     if remote_detection:
         cores_info_str = _get_remote_cpu_resources(launcher=launcher)
-        cores_log, cores_phy, *_ = cores_info_str.split()
-        cores_info = (int(cores_log), int(cores_phy))
+        cores_phy, cores_log, num_gpus, *_ = cores_info_str.split()
+
+        if cores_info:
+            # If got from environment, do not replace
+            cores_info = cores_info + int(num_gpus)
+
+            # testing if match
+            if cores_info[0] == cores_phy and cores_info[1] == cores_log:
+                print("Env and detected match")
+            else:
+                print(f"Env and detected DONT match env: {cores_info} detect: {cores_phy} {cores_log}")
+        else:
+            cores_info = (int(cores_phy), int(cores_log), int(num_gpus))
     else:
         cores_info = _get_local_cpu_resources()
+
+        if cores_info[2] == 0:
+            if num_gpus is not None and num_gpus > 0:
+                cores_info = (cores_info[0], cores_info[1], int(num_gpus))
+
     return cores_info
 
 

--- a/libensemble/resources/platforms.py
+++ b/libensemble/resources/platforms.py
@@ -1,0 +1,19 @@
+"""Known platforms default configuration"""
+
+# SH TODO
+# gpu_setting may need two values - one for type and one for name
+# e.g. gpu_set_type = "env" or gpu_set_type = "argument"
+#      gpu_setting_name = "CUDA_VISIBLE_DEVICES" or gpu_setting_name = "gpus_per_task"
+
+
+summit = {
+    "mpi_runner": "jsrun",
+    "cores_per_node": 42,
+    "logical_cores_per_node": 168,
+    "gpus_per_node": 6,
+    "GPU_setting": None,  # System automatically finds GPUs
+    "scheduler_match_slots": False,
+}
+
+# Return the dictionary
+detect_systems = {"summit.olcf.ornl.gov": summit}

--- a/libensemble/resources/platforms.py
+++ b/libensemble/resources/platforms.py
@@ -2,7 +2,7 @@
 
 # SH TODO
 # gpu_setting may need two values - one for type and one for name
-# e.g. gpu_set_type = "env" or gpu_set_type = "argument"
+# e.g. gpu_setting_type = "env" or gpu_set_type = "arg" (or 1 / 2)
 #      gpu_setting_name = "CUDA_VISIBLE_DEVICES" or gpu_setting_name = "gpus_per_task"
 
 
@@ -11,7 +11,8 @@ summit = {
     "cores_per_node": 42,
     "logical_cores_per_node": 168,
     "gpus_per_node": 6,
-    "GPU_setting": None,  # System automatically finds GPUs
+    "gpu_setting_type": "arg",
+    "gpu_setting_name": "-g",
     "scheduler_match_slots": False,
 }
 

--- a/libensemble/resources/resources.py
+++ b/libensemble/resources/resources.py
@@ -212,8 +212,6 @@ class GlobalResources:
 
         if not cores_on_node:
             cores_on_node = detected_cores_on_node[0:2]
-            # print('nnnn cores_on_node', cores_on_node)
-            # print('nnnn cores_on_node type', type(cores_on_node))
 
         if not gpus_on_node:
             gpus_on_node = detected_cores_on_node[2]

--- a/libensemble/resources/resources.py
+++ b/libensemble/resources/resources.py
@@ -206,6 +206,8 @@ class GlobalResources:
             )
         self.physical_cores_avail_per_node = cores_on_node[0]
         self.logical_cores_avail_per_node = cores_on_node[1]
+        self.gpus_avail_per_node = cores_on_node[2]
+        print(f"From resources: {cores_on_node=}")  # testing - and rename!
         self.libE_nodes = None
 
     def add_comm_info(self, libE_nodes):

--- a/libensemble/resources/rset_resources.py
+++ b/libensemble/resources/rset_resources.py
@@ -44,6 +44,8 @@ class RSetResources:
         self.total_num_rsets = resources.num_resource_sets or self.num_workers_2assign2
         self.split_list, self.local_rsets_list = RSetResources.get_partitioned_nodelist(self.total_num_rsets, resources)
         self.rsets_per_node = RSetResources.get_rsets_on_a_node(self.total_num_rsets, resources)
+        self.gpus_per_rset = resources.gpus_avail_per_node // self.rsets_per_node
+        print("gpus per rset is", self.gpus_per_rset)
 
     @staticmethod
     def best_split(a, n):

--- a/libensemble/resources/rset_resources.py
+++ b/libensemble/resources/rset_resources.py
@@ -44,7 +44,10 @@ class RSetResources:
         self.total_num_rsets = resources.num_resource_sets or self.num_workers_2assign2
         self.split_list, self.local_rsets_list = RSetResources.get_partitioned_nodelist(self.total_num_rsets, resources)
         self.rsets_per_node = RSetResources.get_rsets_on_a_node(self.total_num_rsets, resources)
-        self.gpus_per_rset = resources.gpus_avail_per_node // self.rsets_per_node
+        self.gpus_per_node = resources.gpus_avail_per_node
+        self.gpus_per_rset = self.gpus_per_node // self.rsets_per_node
+        # print("gpus per node is", self.gpus_per_node)
+        # print("rsets_per_node", self.rsets_per_node)
         print("gpus per rset is", self.gpus_per_rset)
 
     @staticmethod

--- a/libensemble/sim_funcs/six_hump_camel.py
+++ b/libensemble/sim_funcs/six_hump_camel.py
@@ -141,8 +141,9 @@ def six_hump_camel_CUDA_variable_resources(H, persis_info, sim_specs, libE_info)
     # Interrogate resources available to this worker
     resources = Resources.resources.worker_resources
     slots = resources.slots
+    gpus_per_node = resources.gpus_per_node
     gpus_per_slot = resources.gpus_per_rset
-    print(f"From sim func: {gpus_per_slot=}")
+    print(f"From sim func: {gpus_per_node=}  {gpus_per_slot=}")
 
     assert resources.matching_slots, f"Error: Cannot set CUDA_VISIBLE_DEVICES when unmatching slots on nodes {slots}"
 

--- a/libensemble/sim_funcs/six_hump_camel.py
+++ b/libensemble/sim_funcs/six_hump_camel.py
@@ -141,12 +141,14 @@ def six_hump_camel_CUDA_variable_resources(H, persis_info, sim_specs, libE_info)
     # Interrogate resources available to this worker
     resources = Resources.resources.worker_resources
     slots = resources.slots
+    gpus_per_slot = resources.gpus_per_rset
+    print(f"From sim func: {gpus_per_slot=}")
 
     assert resources.matching_slots, f"Error: Cannot set CUDA_VISIBLE_DEVICES when unmatching slots on nodes {slots}"
 
-    resources.set_env_to_slots("CUDA_VISIBLE_DEVICES")
+    resources.set_env_to_slots("CUDA_VISIBLE_DEVICES", multiplier=gpus_per_slot)
     num_nodes = resources.local_node_count
-    cores_per_node = resources.slot_count  # One CPU per GPU
+    cores_per_node = resources.slot_count * gpus_per_slot  # One CPU per GPU
 
     print(
         f"Worker {libE_info['workerID']}: CUDA_VISIBLE_DEVICES={os.environ['CUDA_VISIBLE_DEVICES']}"

--- a/libensemble/tests/unit_tests/test_node_resources.py
+++ b/libensemble/tests/unit_tests/test_node_resources.py
@@ -91,6 +91,53 @@ def test_get_cpu_resources_from_env_unknown_env():
     assert cores_info is None, "cores_info should be None"
 
 
+def test_known_sys_check():
+    get_sys_cmd = "echo summit.olcf.ornl.gov"  # Overrides default "hostname -d"
+    core_info = node_resources.known_sys_check(cmd=get_sys_cmd)
+    assert core_info == (42, 168, 6), "Summit cores/gpus does not match expected"
+
+    # Try unknown system
+    get_sys_cmd = "echo madeup.system"  # Overrides default "hostname -d"
+    core_info = node_resources.known_sys_check(cmd=get_sys_cmd)
+    assert core_info is None, "Expected known_sys_check to return None for unknown system"
+    #print('core_info is', core_info)
+
+
+def test_complete_set():
+    assert not node_resources._complete_set([None, None, None])
+    assert not node_resources._complete_set([2, None, 5])
+    assert not node_resources._complete_set([2, 8, None])
+    assert node_resources._complete_set([2, 4, 6])
+    assert node_resources._complete_set([2, 0, 5])
+
+
+def test_cpu_info_complete():
+    assert not node_resources._cpu_info_complete([None, None, None])
+    assert not node_resources._cpu_info_complete([2, None, 5])
+    assert node_resources._cpu_info_complete([2, 8, None])
+    assert node_resources._cpu_info_complete([2, 4, 6])
+
+
+def test_gpu_info_complete():
+    assert not node_resources._gpu_info_complete([None, None, None])
+    assert node_resources._gpu_info_complete([2, None, 5])
+    assert not node_resources._gpu_info_complete([2, 8, None])
+    assert node_resources._gpu_info_complete([2, 4, 6])
+
+
+def test_update_values():
+    result = node_resources._update_values([None, 2, 3], [11, 12, 13])
+    assert result == [11, 12, 3], f"Unexpected result {result}"
+    result = node_resources._update_values([1, 2, None], [11, 12, 13])
+    assert result == [1, 2, 13], f"Unexpected result {result}"
+
+def test_update_from_str():
+    result = node_resources._update_from_str([None, 2, 3], "11 12 13")
+    assert result == [11, 12, 3], f"Unexpected result {result}"
+    result = node_resources._update_from_str([1, 2, None], "11 12 13")
+    assert result == [1, 2, 13], f"Unexpected result {result}"
+
+
 if __name__ == "__main__":
     setup_standalone_run()
 
@@ -98,5 +145,11 @@ if __name__ == "__main__":
     test_get_cpu_resources_from_env_lsf()
     test_get_cpu_resources_from_env_lsf_shortform()
     test_get_cpu_resources_from_env_unknown_env()
+    test_known_sys_check()
+    test_complete_set()
+    test_cpu_info_complete()
+    test_gpu_info_complete()
+    test_update_values()
+    test_update_from_str()
 
     teardown_standalone_run()


### PR DESCRIPTION
Add GPU detection module and use in dynamic resources examples.

- Needs to work on Summit
- Test across systems
- Add unit tests with resource_info options - need a test with `resource_info['gpus_per_node']`
- Update forces_gpu example / tutorial
- document changes - including dynamic resources overview / worker_resources ivars (gpus_per_...)
- Before merging - check prints are removed.

Discuss: 

For querying GPU info - we can get `gpus_per_node` (absolute value) `gpus_per_rset`, but what about gpus available to this worker (in total / on a node) - which depends on `rsets` and `gpus_per_rset`. How to use consistent terminology. This should be reviewed for existing variable names also (e.g. Clarify total v assigned to this worker - and total v per node).

e.g. slot_count  "The number of slots per node if even_slots is True, else None."
should be: "The number of slots per node assigned to this worker if even_slots is True, else None."

Names should distinguish in consistent way.

Main: https://libensemble.readthedocs.io/en/main/resource_manager/worker_resources.html
This branch: https://libensemble--928.org.readthedocs.build/en/928/resource_manager/worker_resources.html

We could also automate setting eg.,~ `CUDA_VISIBLE_DEVICES` directly to the available GPUs - similarly could set `num_procs` to the total GPUs available OR `procs_per_node` in a similar way.
