### PR TITLE
Allows workers and rsets to be set by detected GPUs.

### DIFF
--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -478,6 +478,13 @@ def libE_local(sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs, li
     if resources is not None:
         local_host = [socket.gethostname()]
         resources.add_comm_info(libE_nodes=local_host)
+        if libE_specs.get("set_workers_by_gpus", False):
+            # set num_resource_sets and nworkers is that + 1 incase have a persistent gen
+            num_resource_sets = resources.glob_resources.num_resource_sets
+            nworkers = num_resource_sets + 1  # Should I honor workers if exist (whether more or less than rsets)
+            print(f"\nChange nworkers from {libE_specs['nworkers']} to {nworkers}")  # SH: remove after testing
+            print(f"num_resource_sets {num_resource_sets}\n")  # SH: remove after testing
+            # libE_specs["nworkers"] = nworkers
 
     exctr = Executor.executor
     if exctr is not None:

--- a/libensemble/resources/resources.py
+++ b/libensemble/resources/resources.py
@@ -166,6 +166,7 @@ class GlobalResources:
         self.num_resource_sets = libE_specs.get("num_resource_sets", None)
         self.enforce_worker_core_bounds = libE_specs.get("enforce_worker_core_bounds", False)
 
+        set_workers_by_gpus = libE_specs["set_workers_by_gpus"]
         resource_info = libE_specs.get("resource_info", {})
         cores_on_node = resource_info.get("cores_on_node", None)
         gpus_on_node = resource_info.get("gpus_on_node", None)
@@ -225,6 +226,10 @@ class GlobalResources:
         print(f"From resources: {cores_on_node=}")  # testing
         print(f"From resources: {gpus_on_node=}")  # testing
         self.libE_nodes = None
+
+        if set_workers_by_gpus:
+            new_rsets = self.gpus_avail_per_node * len(self.global_nodelist)
+            self.num_resource_sets = new_rsets
 
     def add_comm_info(self, libE_nodes):
         """Adds comms-specific information to resources

--- a/libensemble/specs.py
+++ b/libensemble/specs.py
@@ -220,6 +220,9 @@ class LibeSpecs(BaseModel):
     nworkers: Optional[int]
     """ Number of worker processes to spawn (only in local/tcp modes) """
 
+    set_workers_by_gpus: Optional[bool] = False
+    """Allow nworkers to be set by number of GPUs available"""
+
     port: Optional[int] = 0
     """ TCP Only: Port number for Manager's system """
 

--- a/libensemble/tests/functionality_tests/test_persistent_sampling_CUDA_variable_resources.py
+++ b/libensemble/tests/functionality_tests/test_persistent_sampling_CUDA_variable_resources.py
@@ -30,11 +30,22 @@ if __name__ == "__main__":
 
     nworkers, is_manager, libE_specs, _ = parse_args()
 
+    # ---------------- Alt. settings for workers/resource sets ----------------
+
     # The persistent gen does not need resources
 
-    libE_specs["num_resource_sets"] = nworkers - 1  # Any worker can be the gen
+    # libE_specs["num_resource_sets"] = nworkers - 1  # Any worker can be the gen
 
     # libE_specs["zero_resource_workers"] = [1]  # If first worker must be gen, use this instead
+
+    # Or do not give nworkers - and allow workers and resource sets to be set by no. of gpus.
+
+    libE_specs["set_workers_by_gpus"] = True
+
+    # For laptop testing - comment out for testing on actual GPU system
+    libE_specs["resource_info"] = {"gpus_on_node": 4}
+
+    # ----------------------------------------------------------
 
     libE_specs["sim_dirs_make"] = True
     libE_specs["ensemble_dir_path"] = "./ensemble_CUDA_variable_w" + str(nworkers)


### PR DESCRIPTION
Decide option name and type `set_workers_by_gpus`.
Sets resource_sets to no. of GPUs, and currently sets workers to rsets+1. But maybe we don't want to expose users to `resource_sets` terminology, as intended to be simplified.

But consider setting rsets and honor workers if exists. Only for local comms - unless honoring workers. rsets is more elegant as can establish basic configuration and then just have a multiplier. 

Could allow the user to set up resources in their calling script, similar to the executor. This could include the configuration of a resource set. The user could also use the returned attributes in calling script if want - including `nworkers` (when set by detection). If set by user, would not get re-calculated within libE. This would also allow checks before calling libE. You could specify system / code / env variables here - or get back whether a known system is detected. It may be also that you want to access some shared configuration file - and that could also be specified here (or a common location could be looked for). Would need to be added to YAML parsing - as with any additions. Then, do you set the above here, instead of libE_specs?


