### PR TITLE
initial commit for experimenting with profiling libE

### DIFF
--- a/libensemble/manager.py
+++ b/libensemble/manager.py
@@ -9,7 +9,6 @@ import glob
 import logging
 import os
 import platform
-import pstats
 import socket
 import sys
 import time
@@ -126,10 +125,7 @@ def manager_main(hist, libE_specs, alloc_specs, sim_specs, gen_specs, exit_crite
     if libE_specs.get("profile"):
         pr.disable()
         profile_stats_fname = "manager.prof"
-
-        with open(profile_stats_fname, "w") as f:
-            ps = pstats.Stats(pr, stream=f).sort_stats("cumulative")
-            ps.print_stats()
+        pr.dump_stats(profile_stats_fname)
 
     return result
 

--- a/libensemble/tests/functionality_tests/test_1d_sampling_with_profile.py
+++ b/libensemble/tests/functionality_tests/test_1d_sampling_with_profile.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
         print("\nlibEnsemble with random sampling has generated enough points")
 
         assert "manager.prof" in os.listdir(), "Expected manager profile not found after run"
-        os.remove("manager.prof")
+        # os.remove("manager.prof")
 
         prof_files = [f"worker_{i+1}.prof" for i in range(nworkers)]
 
@@ -75,4 +75,4 @@ if __name__ == "__main__":
                 "Insufficient number of " + "worker functions profiled: " + str(num_worker_funcs_profiled)
             )
 
-            os.remove(file)
+            # os.remove(file)

--- a/libensemble/worker.py
+++ b/libensemble/worker.py
@@ -6,7 +6,6 @@ libEnsemble worker class
 import cProfile
 import logging
 import logging.handlers
-import pstats
 import socket
 from itertools import count
 from traceback import format_exc
@@ -93,10 +92,7 @@ def worker_main(comm, sim_specs, gen_specs, libE_specs, workerID=None, log_comm=
     if libE_specs.get("profile"):
         pr.disable()
         profile_state_fname = "worker_%d.prof" % (workerID)
-
-        with open(profile_state_fname, "w") as f:
-            ps = pstats.Stats(pr, stream=f).sort_stats("cumulative")
-            ps.print_stats()
+        pr.dump_stats(profile_state_fname)
 
 
 ######################################################################


### PR DESCRIPTION
When the output profile files are dumped by the profiler itself, they can be visualized by `snakeviz`: https://jiffyclub.github.io/snakeviz/

Within any test: `libE_specs["profile"] = True`

Then run snakeviz on the resulting files: `snakeviz manager.prof`

This opens a browser window with the usual statistics plus visualizations of the data.

TODO: 

- [ ] See if there's a way to combine results from the workers