### PR TITLE
Whats wrong with Actions getting stuck on Unit tests?

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
                       python-version: "3.10"
                       mpi-version: "mpich"
                       comms-type: t
-                    - os: ubuntu-latest
-                      mpi-version: "openmpi"
-                      python-version: "3.10"
-                      comms-type: l
+                    # - os: ubuntu-latest
+                      # mpi-version: "openmpi"
+                      # python-version: "3.10"
+                      # comms-type: l
                     # - os: windows-latest
                     #   python-version: "3.10"
                     #   comms-type: l

--- a/libensemble/tests/unit_tests/test_allocation_funcs_and_support.py
+++ b/libensemble/tests/unit_tests/test_allocation_funcs_and_support.py
@@ -423,7 +423,6 @@ def test_als_points_by_priority():
 
 if __name__ == "__main__":
     test_decide_work_and_resources()
-
     test_als_init_normal()
     test_als_init_withresources()
     test_als_assign_resources()


### PR DESCRIPTION
Now really just temporarily disables the openmpi job