### PR TITLE
Create parent directories of `workflow_dir`

### DIFF
--- a/libensemble/comms/logs.py
+++ b/libensemble/comms/logs.py
@@ -52,7 +52,7 @@ class LogConfig:
         """Sets target directory to contain logfiles if loggers not yet created"""
         dirname = Path(dirname)
         if not dirname.exists():
-            dirname.mkdir()
+            dirname.mkdir(parents=True)
         if self.logger_set:
             logger = logging.getLogger(self.name)
             logger.warning("Cannot set directory after loggers initialized")


### PR DESCRIPTION
When using a `workflow_dir`, libEnsemble fails if the `'workflow_dir_path'` has a parent directory that does not exist. This is the case, for example, if `libE_specs['workflow_dir_path'] = './my_workflows/workflow_1'` and the `my_workflows` folder has not yet been created.

This PR makes sure that the parent folders are also created.