### PR TITLE
Do not preinitialize "shared" queue

### DIFF
--- a/libensemble/comms/tcp_mgr.py
+++ b/libensemble/comms/tcp_mgr.py
@@ -9,7 +9,7 @@ from multiprocessing.managers import BaseManager
 
 from libensemble.comms.comms import QComm
 
-queues = {"shared": Queue()}
+queues = {}
 
 
 def get_queue(name):


### PR DESCRIPTION
Currently, the `tcp_mgr` module initializes a `"shared"` multiprocessing `Queue`, even if the `ServerQueueManager` is not being used. This leads to the inconvenient issue that the `set_start_method` cannot be called after importing libEnsemble.

This means that since `v0.10.0`, doing
```python

from multiprocessing import set_start_method
import libensemble
if __name__ == "__main__"
    set_start_method("spawn")
```
results in
```
RuntimeError: context has already been set
```

This PR fixes that by avoiding the preinitialzation of the `"shared"` `Queue`. Although I haven't tested this myself, it looks like this queue will anyways be created when the `get_shared` method is called for the first time.