### PR TITLE
Refactor 1d_tests (or others?) into new interface

### DIFF
--- a/libensemble/ensemble.py
+++ b/libensemble/ensemble.py
@@ -253,7 +253,7 @@ class Ensemble:
         self.sim_specs = sim_specs
         self.gen_specs = gen_specs
         self.exit_criteria = exit_criteria
-        self.libE_specs = libE_specs
+        self._libE_specs = libE_specs
         self.alloc_specs = alloc_specs
         self.persis_info = persis_info
         self.H0 = H0
@@ -263,12 +263,22 @@ class Ensemble:
         self.logger = logger
         self.logger.set_level("INFO")
 
-        if not self.libE_specs:
-            self.libE_specs = LibeSpecs(**libE_specs_parsed)
+        if not self._libE_specs:
+            self._libE_specs = LibeSpecs(**libE_specs_parsed)
 
     def ready(self) -> bool:
         """Quickly verify that all necessary data has been provided"""
-        return all([i for i in [self.exit_criteria, self.libE_specs, self.sim_specs]])
+        return all([i for i in [self.exit_criteria, self._libE_specs, self.sim_specs]])
+
+    @property
+    def libE_specs(self):
+        return self._libE_specs
+
+    @libE_specs.setter
+    def libE_specs(self, new_specs):
+        if not isinstance(new_specs, dict):
+            new_specs = new_specs.dict(by_alias=True, exclude_none=True, exclude_unset=True)
+        self._libE_specs.__dict__.update(**new_specs)
 
     def run(self) -> (npt.NDArray, dict, int):
         """

--- a/libensemble/ensemble.py
+++ b/libensemble/ensemble.py
@@ -278,6 +278,8 @@ class Ensemble:
     def libE_specs(self, new_specs):
         if not isinstance(new_specs, dict):
             new_specs = new_specs.dict(by_alias=True, exclude_none=True, exclude_unset=True)
+        if isinstance(self._libE_specs, dict):
+            self._libE_specs = LibeSpecs(**self._libE_specs)
         self._libE_specs.__dict__.update(**new_specs)
 
     def run(self) -> (npt.NDArray, dict, int):

--- a/libensemble/tests/regression_tests/test_1d_sampling.py
+++ b/libensemble/tests/regression_tests/test_1d_sampling.py
@@ -15,40 +15,34 @@ The number of concurrent evaluations of the objective function will be 4-1=3.
 
 import numpy as np
 
+from libensemble import Ensemble
 from libensemble.gen_funcs.sampling import latin_hypercube_sample as gen_f
 
 # Import libEnsemble items for this test
-from libensemble.libE import libE
 from libensemble.sim_funcs.one_d_func import one_d_example as sim_f
-from libensemble.tools import add_unique_random_streams, parse_args, save_libE_output
+from libensemble.specs import ExitCriteria, GenSpecs, LibeSpecs, SimSpecs
 
 # Main block is necessary only when using local comms with spawn start method (default on macOS and Windows).
 if __name__ == "__main__":
-    nworkers, is_manager, libE_specs, _ = parse_args()
-    libE_specs["save_every_k_gens"] = 300
-    libE_specs["safe_mode"] = False
-    libE_specs["disable_log_files"] = True
 
-    sim_specs = {"sim_f": sim_f, "in": ["x"], "out": [("f", float)]}
-
-    gen_specs = {
-        "gen_f": gen_f,
-        "out": [("x", float, (1,))],
-        "user": {
+    sampling = Ensemble()
+    sampling.libE_specs = LibeSpecs(save_every_k_gens=300, safe_mode=False, disable_log_files=True)
+    sampling.sim_specs = SimSpecs(sim_f=sim_f, inputs=["x"], out=[("f", float)])
+    sampling.gen_specs = GenSpecs(
+        gen_f=gen_f,
+        out=[("x", float, (1,))],
+        user={
             "gen_batch_size": 500,
             "lb": np.array([-3]),
             "ub": np.array([3]),
         },
-    }
+    )
 
-    persis_info = add_unique_random_streams({}, nworkers + 1, seed=1234)
+    sampling.add_random_streams()
+    sampling.exit_criteria = ExitCriteria(gen_max=501)
 
-    exit_criteria = {"gen_max": 501}
-
-    # Perform the run
-    H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
-
-    if is_manager:
-        assert len(H) >= 501
+    sampling.run()
+    if sampling.is_manager:
+        assert len(sampling.H) >= 501
         print("\nlibEnsemble with random sampling has generated enough points")
-        save_libE_output(H, persis_info, __file__, nworkers)
+        sampling.save_output(__file__)


### PR DESCRIPTION
Also includes a fix so an ensemble's libE_specs gets *updated* by setting the attribute, so the comms/nworkers values don't get overwritten