### PR TITLE
Bump isort in pre-commit, only check for msmpi on windows

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       exclude: ^(.*\.xml|.*\.svg)$
 
 - repo: https://github.com/pycqa/isort
-  rev: 5.11.4
+  rev: 5.12.0
   hooks:
     - id: isort
       args: [--profile=black, --line-length=120]

--- a/libensemble/resources/mpi_resources.py
+++ b/libensemble/resources/mpi_resources.py
@@ -4,6 +4,7 @@ Manages libensemble resources related to MPI tasks launched from nodes.
 
 import logging
 import os
+import platform
 import subprocess
 from typing import Optional, Tuple, Union
 
@@ -44,16 +45,17 @@ def get_MPI_variant() -> str:
     except Exception:
         pass
 
-    try:
-        with subprocess.Popen(["mpiexec"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as try_msmpi:
-            stdout, _ = try_msmpi.communicate(timeout=4)
-        if "Microsoft" in stdout.decode():
-            return "msmpi"
-    except FileNotFoundError:
-        pass
-    except Exception:
-        try_msmpi.kill()
-        pass
+    if platform.system() == "Windows":
+        try:
+            with subprocess.Popen(["mpiexec"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as try_msmpi:
+                stdout, _ = try_msmpi.communicate(timeout=4)
+            if "Microsoft" in stdout.decode():
+                return "msmpi"
+        except FileNotFoundError:
+            pass
+        except Exception:
+            try_msmpi.kill()
+            pass
 
     try:
         # Explore mpi4py.MPI.get_vendor() and mpi4py.MPI.Get_library_version() for mpi4py


### PR DESCRIPTION
Should allow a slight speedup on initial resource detection; don't bother checking for msmpi if we're not running on windows.

also bumps isort in pre-commit to address a bug I ran into when starting a new python 3.11 environment