### PR TITLE
Add gpu_env_fallback platform attribute

### DIFF
--- a/libensemble/resources/platforms.py
+++ b/libensemble/resources/platforms.py
@@ -89,6 +89,23 @@ class Platform(BaseModel):
 
     """
 
+    gpu_env_fallback: Optional[str]
+    """GPU fallback environment setting if not using an MPI runner.
+
+    For example:
+
+    .. code-block:: python
+
+        "gpu_setting_type" = "runner_default"
+        "gpu_env_fallback" = "ROCR_VISIBLE_DEVICES"
+
+    This example will use the MPI runner default settings when using an MPI runner, but
+    will otherwise use ROCR_VISIBLE_DEVICES (e.g. if setting via function set_env_to_gpus).
+
+    If this is not set, the default is "CUDA_VISIBLE_DEVICES"
+
+    """
+
     scheduler_match_slots: Optional[bool]
     """
     Whether the libEnsemble resource scheduler should only assign matching slots when
@@ -137,6 +154,7 @@ class Crusher(Platform):
     logical_cores_per_node: int = 128
     gpus_per_node: int = 8
     gpu_setting_type: str = "runner_default"
+    gpu_env_fallback: str = "ROCR_VISIBLE_DEVICES"
     scheduler_match_slots: bool = False
 
 
@@ -146,6 +164,7 @@ class Frontier(Platform):
     logical_cores_per_node: int = 128
     gpus_per_node: int = 8
     gpu_setting_type: str = "runner_default"
+    gpu_env_fallback: str = "ROCR_VISIBLE_DEVICES"
     scheduler_match_slots: bool = False
 
 
@@ -170,6 +189,7 @@ class PerlmutterCPU(Perlmutter):
 class PerlmutterGPU(Perlmutter):
     gpus_per_node: int = 4
     gpu_setting_type: str = "runner_default"
+    gpu_env_fallback: str = "CUDA_VISIBLE_DEVICES"
     scheduler_match_slots: bool = False
 
 
@@ -180,6 +200,7 @@ class Polaris(Platform):
     logical_cores_per_node: int = 64
     gpus_per_node: int = 4
     gpu_setting_type: str = "runner_default"
+    gpu_env_fallback: str = "CUDA_VISIBLE_DEVICES"
     scheduler_match_slots: bool = True
 
 
@@ -189,6 +210,7 @@ class Spock(Platform):
     logical_cores_per_node: int = 128
     gpus_per_node: int = 4
     gpu_setting_type: str = "runner_default"
+    gpu_setting_name: str = "ROCR_VISIBLE_DEVICES"
     scheduler_match_slots: bool = False
 
 

--- a/libensemble/resources/worker_resources.py
+++ b/libensemble/resources/worker_resources.py
@@ -276,6 +276,9 @@ class WorkerResources(RSetResources):
                         env_var = self.platform_info.get("gpu_setting_name")
                     else:
                         env_var = self.platform_info.get("gpu_env_fallback") or "CUDA_VISIBLE_DEVICES"
+                else:
+                    env_var = "CUDA_VISIBLE_DEVICES"
+
             os.environ[env_var] = env_value
 
     # libEnsemble functions ---------------------------------------------------

--- a/libensemble/resources/worker_resources.py
+++ b/libensemble/resources/worker_resources.py
@@ -199,6 +199,7 @@ class WorkerResources(RSetResources):
         self.set_slot_count()
         self.gen_nprocs = None
         self.gen_ngpus = None
+        self.platform_info = resources.platform_info
 
     # User convenience functions ----------------------------------------------
 
@@ -244,7 +245,7 @@ class WorkerResources(RSetResources):
         """
         os.environ[env_var] = self.get_slots_as_string(multiplier, delimiter)
 
-    def set_env_to_gpus(self, env_var, delimiter=","):
+    def set_env_to_gpus(self, env_var=None, delimiter=","):
         """Sets the given environment variable to GPUs
 
         :param env_var: String. Name of environment variable to set.
@@ -269,6 +270,12 @@ class WorkerResources(RSetResources):
         assert self.matching_slots, f"Cannot assign GPUs to non-matching slots per node {self.slots}"
         if self.doihave_gpus():
             env_value = self.get_slots_as_string(multiplier=self.gpus_per_rset, limit=self.gen_ngpus)
+            if env_var is None:
+                if self.platform_info is not None:
+                    if self.platform_info.get("gpu_setting_type") == "env":
+                        env_var = self.platform_info.get("gpu_setting_name")
+                    else:
+                        env_var = self.platform_info.get("gpu_env_fallback") or "CUDA_VISIBLE_DEVICES"
             os.environ[env_var] = env_value
 
     # libEnsemble functions ---------------------------------------------------

--- a/libensemble/tests/unit_tests/test_platform.py
+++ b/libensemble/tests/unit_tests/test_platform.py
@@ -17,6 +17,7 @@ summit_spec = {
     "gpu_setting_type": "option_gpus_per_task",
     "gpu_setting_name": "-g",
     "scheduler_match_slots": False,
+    "gpu_env_fallback": None,
 }
 
 


### PR DESCRIPTION
For when setting GPUs to slots in a sim function, without using the MPI executor. Find correct setting for platform.

- [x] Add gpu_env_fallback attribute (used if no env var given to  `set_env_to_gpus` function.
- [x] Add unit tests
- [x] Check shows up in docs