### PR TITLE
Add mpi_runner_type submit option to executor

### DIFF
--- a/libensemble/executors/mpi_executor.py
+++ b/libensemble/executors/mpi_executor.py
@@ -115,10 +115,7 @@ class MPIExecutor(Executor):
         """
         if not self.mpi_runner_type:
             self.mpi_runner_type = get_MPI_variant()
-        mpi_runner_obj = MPIRunner.get_runner(self.mpi_runner_type, self.runner_name, self.platform_info)
-        if self.subgroup_launch is not None:
-            mpi_runner_obj.subgroup_launch = self.subgroup_launch
-        return mpi_runner_obj
+        return self._create_mpi_runner_obj(self.mpi_runner_type, self.runner_name, self.subgroup_launch)
 
     def add_platform_info(self, platform_info={}):
         """Add user supplied platform info to executor"""

--- a/libensemble/executors/mpi_executor.py
+++ b/libensemble/executors/mpi_executor.py
@@ -90,6 +90,9 @@ class MPIExecutor(Executor):
         self.runner_name = custom_info.get("runner_name")
         self.subgroup_launch = custom_info.get("subgroup_launch")
 
+        self.gen_nprocs = None
+        self.gen_ngpus = None
+
     def add_platform_info(self, platform_info={}):
         """Add user supplied platform info to executor"""
 
@@ -105,9 +108,6 @@ class MPIExecutor(Executor):
 
         if self.subgroup_launch is not None:
             self.mpi_runner.subgroup_launch = self.subgroup_launch
-
-        self.gen_nprocs = None
-        self.gen_ngpus = None
 
     def set_gen_procs_gpus(self, libE_info):
         """Add gen supplied procs and gpus"""

--- a/libensemble/executors/mpi_executor.py
+++ b/libensemble/executors/mpi_executor.py
@@ -92,7 +92,7 @@ class MPIExecutor(Executor):
         self.mpi_runner_type = custom_info.get("mpi_runner")
         self.runner_name = custom_info.get("runner_name")
         self.subgroup_launch = custom_info.get("subgroup_launch")
-        self._set_mpi_runner()  # For standalone - else overidden by add_platform_info
+        self.mpi_runner = None  # Do not set here or will override platform
 
     def _create_mpi_runner(self, custom_info: dict = {}) -> MPIRunner:
         """Return an mpi_runner object from given info"""
@@ -328,7 +328,7 @@ class MPIExecutor(Executor):
                 custom_info = mpi_runner_type
             mpi_runner = self._create_mpi_runner(custom_info)
         else:
-            mpi_runner = self.mpi_runner
+            mpi_runner = self.mpi_runner or self._set_mpi_runner()
 
         mpi_specs = mpi_runner.get_mpi_specs(
             task,

--- a/libensemble/sim_funcs/var_resources.py
+++ b/libensemble/sim_funcs/var_resources.py
@@ -18,6 +18,7 @@ interrogates available resources and sets explicitly.
 __all__ = [
     "gpu_variable_resources",
     "gpu_variable_resources_from_gen",
+    "gpu_variable_resources_subenv",
     "multi_points_with_variable_resources",
     "CUDA_variable_resources",
 ]
@@ -30,7 +31,7 @@ from libensemble.executors.executor import Executor
 from libensemble.message_numbers import TASK_FAILED, UNSET_TAG, WORKER_DONE
 from libensemble.resources.resources import Resources
 from libensemble.sim_funcs.six_hump_camel import six_hump_camel_func
-from libensemble.tools.test_support import check_gpu_setting
+from libensemble.tools.test_support import check_gpu_setting, check_mpi_runner
 
 
 def gpu_variable_resources(H, persis_info, sim_specs, libE_info):
@@ -96,6 +97,75 @@ def gpu_variable_resources_from_gen(H, persis_info, sim_specs, libE_info):
         stderr="err.txt",
         dry_run=dry_run,
     )
+
+    if not dry_run:
+        task.wait()  # Wait for run to complete
+
+        # Access app output
+        with open("out.txt") as f:
+            H_o["f"] = float(f.readline().strip())  # Read just first line
+
+    # Asserts GPU set correctly (for known MPI runners)
+    check_gpu_setting(task, print_setting=True)
+
+    calc_status = WORKER_DONE if task.state == "FINISHED" else "FAILED"
+    return H_o, persis_info, calc_status
+
+
+def _launch_with_env_and_mpi(exctr, inpt, dry_run, env_script_path, mpi_runner):
+    """Used to launch each application in a chain"""
+
+    task = exctr.submit(
+        app_name="six_hump_camel",
+        app_args=inpt,
+        auto_assign_gpus=True,
+        match_procs_to_gpus=True,
+        dry_run=dry_run,
+        env_script=env_script_path,
+        mpi_runner_type=mpi_runner,
+    )
+
+    if isinstance(mpi_runner, dict):
+        mpi_runner = mpi_runner["runner_name"]
+
+    check_mpi_runner(task, mpi_runner, print_setting=True)
+    check_gpu_setting(task, print_setting=True)
+
+
+def gpu_variable_resources_subenv(H, persis_info, sim_specs, libE_info):
+    """Launches a chain of apps via bash scripts in different sub-processes.
+
+    Different MPI runners are specified for each submit. To run without dry_run
+    these MPI runners need to be present. Dry_run is used by default.
+
+    Otherwise, this test is similar to ``gpu_variable_resources``.
+
+    """
+    x = H["x"][0]
+    H_o = np.zeros(1, dtype=sim_specs["out"])
+    dry_run = sim_specs["user"].get("dry_run", False)  # logs run lines instead of running
+    env_script_path = sim_specs["user"]["env_script"]  # Script to run in subprocess
+    inpt = " ".join(map(str, x))  # Application input
+
+    exctr = Executor.executor  # Get Executor
+
+    # Launch application via given MPI runner, using assigned resources.
+    _launch_with_env_and_mpi(exctr, inpt, dry_run, env_script_path, "openmpi")
+    _launch_with_env_and_mpi(exctr, inpt, dry_run, env_script_path, "srun")
+
+    mpi_runner_type = {"mpi_runner": "openmpi", "runner_name": "special_mpi"}
+    _launch_with_env_and_mpi(exctr, inpt, dry_run, env_script_path, mpi_runner_type)
+
+    # Now run in current environment.
+    task = exctr.submit(
+        app_name="six_hump_camel",
+        app_args=inpt,
+        auto_assign_gpus=True,
+        match_procs_to_gpus=True,
+        dry_run=dry_run,
+    )
+    check_mpi_runner(task, "mpich", print_setting=True)
+    check_gpu_setting(task, print_setting=True)
 
     if not dry_run:
         task.wait()  # Wait for run to complete

--- a/libensemble/tests/functionality_tests/env_script_in.sh
+++ b/libensemble/tests/functionality_tests/env_script_in.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+export LIBE_TEST_SUB_ENV_VAR="testvalue"

--- a/libensemble/tests/functionality_tests/test_mpi_gpu_settings_env.py
+++ b/libensemble/tests/functionality_tests/test_mpi_gpu_settings_env.py
@@ -1,0 +1,102 @@
+"""
+Tests options to run an an applcation in a bash specified environment, without
+affecting the parent environment.
+
+This is based on the variable resource detection and automatic GPU assignment test.
+
+This test uses the dry_run option to test correct runline and GPU settings for
+different mocked up systems. Test assertions are in the sim function via the
+check_mpi_runner and check_gpu_setting functions.
+
+Execute via one of the following commands (e.g. 5 workers):
+   mpiexec -np 6 python test_mpi_gpu_settings_env.py
+   python test_mpi_gpu_settings_env.py --comms local --nworkers 5
+
+When running with the above command, the number of concurrent evaluations of
+the objective function will be 4, as one of the five workers will be the
+persistent generator.
+"""
+
+# Do not change these lines - they are parsed by run-tests.sh
+# TESTSUITE_COMMS: mpi local
+# TESTSUITE_NPROCS: 3 6
+
+import os
+import sys
+
+import numpy as np
+
+from libensemble.alloc_funcs.start_only_persistent import only_persistent_gens as alloc_f
+from libensemble.executors.mpi_executor import MPIExecutor
+from libensemble.gen_funcs.persistent_sampling_var_resources import uniform_sample as gen_f
+
+# Import libEnsemble items for this test
+from libensemble.libE import libE
+from libensemble.sim_funcs import six_hump_camel
+from libensemble.sim_funcs.var_resources import gpu_variable_resources_subenv as sim_f
+from libensemble.tools import add_unique_random_streams, parse_args
+
+# from libensemble import logger
+# logger.set_level("DEBUG")  # For testing the test
+
+
+# Main block is necessary only when using local comms with spawn start method (default on macOS and Windows).
+if __name__ == "__main__":
+    nworkers, is_manager, libE_specs, _ = parse_args()
+    libE_specs["num_resource_sets"] = nworkers - 1  # Persistent gen does not need resources
+    libE_specs["use_workflow_dir"] = True  # Only a place for Open MPI machinefiles
+
+    # Optional for organization of output scripts
+    libE_specs["sim_dirs_make"] = True
+
+    if libE_specs["comms"] == "tcp":
+        sys.exit("This test only runs with MPI or local -- aborting...")
+
+    # Get paths for applications to run
+    six_hump_camel_app = six_hump_camel.__file__
+
+    env_script_path = os.path.join(os.getcwd(), "./env_script_in.sh")
+
+    n = 2
+    sim_specs = {
+        "sim_f": sim_f,
+        "in": ["x"],
+        "out": [("f", float)],
+        "user": {"dry_run": True, "env_script": env_script_path},
+    }
+
+    gen_specs = {
+        "gen_f": gen_f,
+        "persis_in": ["f", "x", "sim_id"],
+        "out": [("priority", float), ("resource_sets", int), ("x", float, n)],
+        "user": {
+            "initial_batch_size": nworkers - 1,
+            "max_resource_sets": nworkers - 1,  # Any sim created can req. 1 worker up to all.
+            "lb": np.array([-3, -2]),
+            "ub": np.array([3, 2]),
+        },
+    }
+
+    alloc_specs = {
+        "alloc_f": alloc_f,
+        "user": {
+            "give_all_with_same_priority": False,
+            "async_return": False,  # False batch returns
+        },
+    }
+
+    persis_info = add_unique_random_streams({}, nworkers + 1)
+    exit_criteria = {"sim_max": 10}
+
+    # Ensure LIBE_PLATFORM environment variable is not set.
+    if "LIBE_PLATFORM" in os.environ:
+        del os.environ["LIBE_PLATFORM"]
+
+    # First set - use executor setting ------------------------------------------------------------
+    libE_specs["resource_info"] = {"gpus_on_node": 4}  # Mock GPU system / remove to detect GPUs
+
+    exctr = MPIExecutor(custom_info={"mpi_runner": "mpich"})
+    exctr.register_app(full_path=six_hump_camel_app, app_name="six_hump_camel")
+
+    # Perform the run
+    H, _, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs, alloc_specs=alloc_specs)

--- a/libensemble/tests/functionality_tests/test_mpi_gpu_settings_env.py
+++ b/libensemble/tests/functionality_tests/test_mpi_gpu_settings_env.py
@@ -92,7 +92,6 @@ if __name__ == "__main__":
     if "LIBE_PLATFORM" in os.environ:
         del os.environ["LIBE_PLATFORM"]
 
-    # First set - use executor setting ------------------------------------------------------------
     libE_specs["resource_info"] = {"gpus_on_node": 4}  # Mock GPU system / remove to detect GPUs
 
     exctr = MPIExecutor(custom_info={"mpi_runner": "mpich"})


### PR DESCRIPTION
The supplied MPI runner will be used for this submit only.

This is useful in combination with the environment script option, when a different MPI runner may be needed for a particular submit.

The option can be given as a string specifying the MPI runner (e.g. "mpich", "openmpi", "srun", "jsrun", "aprun"), or as a dictionary with the same options as `custom_info` when setting up the executor e.g : `{"mpi_runner": "openmpi", "runner_name": "myrunner"}`

Provides support for  optimas-org/optimas#108
- [x] Add functionality test
- [x] Discuss/agree name of argument (currently `mpi_runner_type`). Could be `mpi_runner`, `env_mpi`, `mpi_config` etc...
- [x] Check if this branch MPIExecutor works standalone @jlnav 

Another change is that when using an environment script, the generated script is logged to ensemble.log rather than the mpirun line itself (which is in the script). This could be either way - any feedback welcome.

Ideally, the mpi_runner_type option would match custom_info in executor __init__ function in name and accepted input.

