### PR TITLE
(Re)implement threading comms

### DIFF
--- a/libensemble/comms/comms.py
+++ b/libensemble/comms/comms.py
@@ -221,8 +221,17 @@ class QCommThread(Comm):
         return self._result
 
     def terminate(self, timeout=None):
-        """Terminate the thread."""
-        raise Timeout()
+        """Terminate the thread.
+        
+        A thread can't really be killed from the outside. Ideally the `main`
+        function would make periodic checks to some variable that determines
+        whether the function should continue. This is not implemented, so
+        it is currently no possible to terminate the thread when calling
+        this method.
+        """
+        self.thread.join(timeout=timeout)
+        if self.running:
+            raise Timeout()
 
     @property
     def running(self):

--- a/libensemble/comms/comms.py
+++ b/libensemble/comms/comms.py
@@ -222,7 +222,7 @@ class QCommThread(Comm):
 
     def terminate(self, timeout=None):
         """Terminate the thread.
-        
+
         A thread can't really be killed from the outside. Ideally the `main`
         function would make periodic checks to some variable that determines
         whether the function should continue. This is not implemented, so

--- a/libensemble/comms/comms.py
+++ b/libensemble/comms/comms.py
@@ -28,6 +28,7 @@ from abc import ABC, abstractmethod
 
 # from multiprocessing import Process, Queue, Value, Lock
 from multiprocessing import Process, Queue
+from threading import Thread
 from time import time
 from traceback import format_exc
 
@@ -147,6 +148,103 @@ class QComm(Comm):
     def mail_flag(self):
         """Check whether we know a message is ready for receipt."""
         return not self._inbox.empty()
+
+
+class QCommThread(Comm):
+    """Launch a user function in a thread with an attached QComm."""
+
+    def __init__(self, main, nworkers, *args, **kwargs):
+        self.inbox = thread_queue.Queue()
+        self.outbox = thread_queue.Queue()
+        self._result = None
+        self._exception = None
+        self._done = False
+        comm = QComm(self.inbox, self.outbox, nworkers)
+        self.thread = Thread(target=QCommThread._qcomm_main, args=(comm, main) + args, kwargs=kwargs)
+
+    def _is_result_msg(self, msg):
+        """Return true if message indicates final result (and set result/except)."""
+        if len(msg) and isinstance(msg[0], CommResult):
+            self._result = msg[0].value
+            self._done = True
+            return True
+        if len(msg) and isinstance(msg[0], CommResultErr):
+            self._exception = msg[0]
+            self._done = True
+            return True
+        return False
+
+    def send(self, *args):
+        """Send a message to the thread (called from creator)"""
+        self.inbox.put(args)
+
+    def recv(self, timeout=None):
+        """Return a message from the thread or raise TimeoutError."""
+        try:
+            if self._done:
+                raise CommFinishedException()
+            if not self.outbox.empty():
+                msg = self.outbox.get()
+            else:
+                msg = self.outbox.get(timeout=timeout)
+            if self._is_result_msg(msg):
+                raise CommFinishedException()
+            return msg
+        except thread_queue.Empty:
+            raise Timeout()
+
+    def mail_flag(self):
+        """Check whether we know a message is ready for receipt."""
+        return not self.outbox.empty()
+
+    def run(self):
+        """Start the thread."""
+        self.thread.start()
+
+    def result(self, timeout=None):
+        """Join and return the thread main result (or re-raise an exception)."""
+        get_timeout = _timeout_fun(timeout)
+        while not self._done and (timeout is None or timeout >= 0):
+            try:
+                msg = self.outbox.get(timeout=timeout)
+            except thread_queue.Empty:
+                raise Timeout()
+            self._is_result_msg(msg)
+            timeout = get_timeout()
+        if not self._done:
+            raise Timeout()
+        self.thread.join(timeout=timeout)
+        if self.running:
+            raise Timeout()
+        if self._exception is not None:
+            raise RemoteException(self._exception.msg, self._exception.exc)
+        return self._result
+
+    def terminate(self, timeout=None):
+        """Terminate the thread."""
+        raise Timeout()
+
+    @property
+    def running(self):
+        """Check if the thread is running."""
+        return self.thread.is_alive()
+
+    @staticmethod
+    def _qcomm_main(comm, main, *args, **kwargs):
+        """Main routine -- handles return values and exceptions."""
+        try:
+            _result = main(comm, *args, **kwargs)
+            comm.send(CommResult(_result))
+        except Exception as e:
+            comm.send(CommResultErr(str(e), format_exc()))
+            raise e
+
+    def __enter__(self):
+        self.run()
+        return self
+
+    def __exit__(self, etype, value, traceback):
+        self.thread.join()
 
 
 class QCommProcess(Comm):

--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -442,6 +442,7 @@ def start_proc_team(nworkers, sim_specs, gen_specs, libE_specs, log_comm=True):
         QCommWorker = QCommProcess
     else:
         QCommWorker = QCommThread
+        log_comm = False  # Prevents infinite loop of logging.
 
     wcomms = [
         QCommWorker(worker_main, nworkers, sim_specs, gen_specs, libE_specs, w, log_comm, resources, executor)

--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -119,7 +119,7 @@ from typing import Callable, Dict
 
 import numpy as np
 
-from libensemble.comms.comms import QCommProcess, Timeout
+from libensemble.comms.comms import QCommProcess, Timeout, QCommThread
 from libensemble.comms.logs import manager_logging_config
 from libensemble.comms.tcp_mgr import ClientQCommManager, ServerQCommManager
 from libensemble.executors.executor import Executor
@@ -437,8 +437,14 @@ def start_proc_team(nworkers, sim_specs, gen_specs, libE_specs, log_comm=True):
     resources = Resources.resources
     executor = Executor.executor
 
+    local_comms = libE_specs.get("local_comms", "multiprocessing")
+    if local_comms == "multiprocessing":
+        QCommWorker = QCommProcess
+    else:
+        QCommWorker = QCommThread
+
     wcomms = [
-        QCommProcess(worker_main, nworkers, sim_specs, gen_specs, libE_specs, w, log_comm, resources, executor)
+        QCommWorker(worker_main, nworkers, sim_specs, gen_specs, libE_specs, w, log_comm, resources, executor)
         for w in range(1, nworkers + 1)
     ]
 

--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -242,7 +242,7 @@ def libE(
         logger.manager_warning("Dry run. All libE() inputs validated. Exiting.")
         sys.exit()
 
-    libE_funcs = {"mpi": libE_mpi, "tcp": libE_tcp, "local": libE_local}
+    libE_funcs = {"mpi": libE_mpi, "tcp": libE_tcp, "local": libE_local, "local_threading": libE_local}
 
     Resources.init_resources(libE_specs, platform_info)
     if Executor.executor is not None:
@@ -251,7 +251,7 @@ def libE(
     # Reset gen counter.
     AllocSupport.gen_counter = 0
 
-    libE_funcs = {"mpi": libE_mpi, "tcp": libE_tcp, "local": libE_local}
+    libE_funcs = {"mpi": libE_mpi, "tcp": libE_tcp, "local": libE_local, "local_threading": libE_local}
 
     return libE_funcs[libE_specs.get("comms", "mpi")](
         sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs, libE_specs, H0
@@ -437,15 +437,14 @@ def start_proc_team(nworkers, sim_specs, gen_specs, libE_specs, log_comm=True):
     resources = Resources.resources
     executor = Executor.executor
 
-    local_comms = libE_specs.get("local_comms", "multiprocessing")
-    if local_comms == "multiprocessing":
-        QCommWorker = QCommProcess
-    else:
-        QCommWorker = QCommThread
+    if libE_specs["comms"] == "local":
+        QCommLocal = QCommProcess
+    else:  # local_threading
+        QCommLocal = QCommThread
         log_comm = False  # Prevents infinite loop of logging.
 
     wcomms = [
-        QCommWorker(worker_main, nworkers, sim_specs, gen_specs, libE_specs, w, log_comm, resources, executor)
+        QCommLocal(worker_main, nworkers, sim_specs, gen_specs, libE_specs, w, log_comm, resources, executor)
         for w in range(1, nworkers + 1)
     ]
 

--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -251,8 +251,6 @@ def libE(
     # Reset gen counter.
     AllocSupport.gen_counter = 0
 
-    libE_funcs = {"mpi": libE_mpi, "tcp": libE_tcp, "local": libE_local, "local_threading": libE_local}
-
     return libE_funcs[libE_specs.get("comms", "mpi")](
         sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs, libE_specs, H0
     )

--- a/libensemble/specs.py
+++ b/libensemble/specs.py
@@ -208,6 +208,9 @@ class LibeSpecs(BaseModel):
     comms: Optional[str] = "mpi"
     """ Manager/Worker communications mode. ``'mpi'``, ``'local'``, or ``'tcp'`` """
 
+    local_comms: Optional[str] = "multiprocessing"
+    """ Local Manager/Worker communications mode. ``'multiprocessing'`` or ``'threading'`` """
+
     nworkers: Optional[int]
     """ Number of worker processes in ``"local"`` or ``"tcp"``."""
 
@@ -501,6 +504,11 @@ class LibeSpecs(BaseModel):
     @validator("comms")
     def check_valid_comms_type(cls, value):
         assert value in ["mpi", "local", "tcp"], "Invalid comms type"
+        return value
+    
+    @validator("local_comms")
+    def check_valid_local_comms_type(cls, value):
+        assert value in ["multiprocessing", "threading"], "Invalid local comms type"
         return value
 
     @validator("platform_specs")

--- a/libensemble/specs.py
+++ b/libensemble/specs.py
@@ -206,10 +206,7 @@ class LibeSpecs(BaseModel):
     """
 
     comms: Optional[str] = "mpi"
-    """ Manager/Worker communications mode. ``'mpi'``, ``'local'``, or ``'tcp'`` """
-
-    local_comms: Optional[str] = "multiprocessing"
-    """ Local Manager/Worker communications mode. ``'multiprocessing'`` or ``'threading'`` """
+    """ Manager/Worker communications mode. ``'mpi'``, ``'local'``, ``'local_threading'``, or ``'tcp'`` """
 
     nworkers: Optional[int]
     """ Number of worker processes in ``"local"`` or ``"tcp"``."""
@@ -503,12 +500,7 @@ class LibeSpecs(BaseModel):
 
     @validator("comms")
     def check_valid_comms_type(cls, value):
-        assert value in ["mpi", "local", "tcp"], "Invalid comms type"
-        return value
-    
-    @validator("local_comms")
-    def check_valid_local_comms_type(cls, value):
-        assert value in ["multiprocessing", "threading"], "Invalid local comms type"
+        assert value in ["mpi", "local", "local_threading", "tcp"], "Invalid comms type"
         return value
 
     @validator("platform_specs")

--- a/libensemble/tests/unit_tests_nompi/test_aaa_comms.py
+++ b/libensemble/tests/unit_tests_nompi/test_aaa_comms.py
@@ -37,12 +37,15 @@ def worker_main_sending(comm):
 
 
 def test_qcomm_proc_terminate1():
-    "Test that an already-done QCommProcess gracefully handles terminate()."
+    "Test that an already-done QCommProcess/QCommThread gracefully handles terminate()."
 
-    with comms.QCommProcess(worker_main, 2) as mgr_comm:
-        time.sleep(0.5)
-        mgr_comm.terminate(timeout=30)
-        assert not mgr_comm.running
+    qcomms_to_test = [comms.QCommProcess, comms.QCommThread]
+
+    for QCommLocal in qcomms_to_test:
+        with QCommLocal(worker_main, 2) as mgr_comm:
+            time.sleep(0.5)
+            mgr_comm.terminate(timeout=30)
+            assert not mgr_comm.running
 
 
 def test_qcomm_proc_terminate2():
@@ -92,18 +95,21 @@ def test_qcomm_proc_terminate2():
 
 
 def test_qcomm_proc_terminate4():
-    "Test that a QCommProcess can handle event timeouts correctly."
+    "Test that a QCommProcess/QCommThread can handle event timeouts correctly."
 
-    with comms.QCommProcess(worker_main_sending, 2) as mgr_comm:
-        time.sleep(0.5)
+    qcomms_to_test = [comms.QCommProcess, comms.QCommThread]
 
-        flag = True
-        try:
-            mgr_comm.result(timeout=0.5)
-            flag = False
-        except comms.Timeout:
-            pass
-        assert flag, "Should time out on result"
+    for QCommLocal in qcomms_to_test:
+        with QCommLocal(worker_main_sending, 2) as mgr_comm:
+            time.sleep(0.5)
 
-        assert mgr_comm.running, "Should still be running"
-        mgr_comm.send("Done")
+            flag = True
+            try:
+                mgr_comm.result(timeout=0.5)
+                flag = False
+            except comms.Timeout:
+                pass
+            assert flag, "Should time out on result"
+
+            assert mgr_comm.running, "Should still be running"
+            mgr_comm.send("Done")


### PR DESCRIPTION
As discussed in past meetings, we are currently trying to support running Optimas on Jupyter notebooks to allow for a more interactive workflow. However, when testing this a couple of days ago I realized that this is currently not possible due to the use of `multiprocessing` for the local communications. Basically, `multiprocessing` and IPython/Jupyter don't play well together (especially on Windows and Mac, which use `spawn`) and I couldn't get optimas to run without significant workarounds.

The ideal solution would be that libEnsemble supported a `threading` local mode. I gave this a try and also found out that there was an early implementation of this in the `main` branch (was removed in https://github.com/Libensemble/libensemble/pull/1123). I updated the `QCommThread` class to be more similar to `QCommProcess` and exposed a new `local_threading` option in `libe_specs['comms']`. Using this option enables optimas to run on a notebook without any modifications or workarounds by the user.

There are still some issues in the current PR. For example, I had to set `log_comm=False` in the threading backend to prevent an infinite "loop" of logs that keeps filling up the outbox. I suspect this arises somehow because now the workers share the same memory. The shared memory might also lead to issues with how the resources are currently assigned to workers.

Having this threading backend would be great, and the suggested implementation already solves the issues that we need to (urgently) address in optimas. Do you think it is possible to fully support this mode in libEnsemble?

As a bonus, I think this would enable an alternative solution to https://github.com/optimas-org/optimas/pull/134, where we could define an option such as `libe_specs["run_persis_gen_on_thread"]=True` to run the generator on a thread (that is, it would be able to share the memory with the manager).