### PR TITLE
Manual extra-trigger for complete-CI on develop

### DIFF
--- a/.github/workflows/extra.yml
+++ b/.github/workflows/extra.yml
@@ -1,8 +1,8 @@
 name: libEnsemble-complete-CI
 
 on:
-  schedule:
-    - cron: '0 12 * * 1'
+  push:
+  workflow_dispatch:
 
 jobs:
     test-libE:
@@ -12,15 +12,15 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 mpi-version: [mpich]
-                python-version: [3.9, "3.10", "3.11"]
+                python-version: [3.9, "3.10", "3.11", "3.12"]
                 comms-type: [m, l]
                 include:
                     - os: macos-latest
-                      python-version: 3.9
+                      python-version: 3.11
                       mpi-version: "mpich=4.0.3"
                       comms-type: m
                     - os: macos-latest
-                      python-version: 3.9
+                      python-version: 3.11
                       mpi-version: "mpich=4.0.3"
                       comms-type: l
                     - os: ubuntu-latest

--- a/.github/workflows/extra.yml
+++ b/.github/workflows/extra.yml
@@ -1,7 +1,6 @@
 name: libEnsemble-complete-CI
 
 on:
-  push:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Should in theory be able to use UI or:

`gh workflow run libEnsemble-complete-CI --ref develop`