### PR TITLE
Don't assign user-function defaults to Sim/GenSpecs, but ensure at runtime

### DIFF
--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -118,8 +118,9 @@ from pathlib import Path
 from typing import Callable, Dict
 
 import numpy as np
+from pydantic import validate_arguments
 
-from libensemble.comms.comms import QCommProcess, Timeout, QCommThread
+from libensemble.comms.comms import QCommProcess, QCommThread, Timeout
 from libensemble.comms.logs import manager_logging_config
 from libensemble.comms.tcp_mgr import ClientQCommManager, ServerQCommManager
 from libensemble.executors.executor import Executor
@@ -141,6 +142,7 @@ logger = logging.getLogger(__name__)
 # logger.setLevel(logging.DEBUG)
 
 
+@validate_arguments
 def libE(
     sim_specs: SimSpecs,
     gen_specs: GenSpecs,

--- a/libensemble/specs.py
+++ b/libensemble/specs.py
@@ -7,9 +7,7 @@ import numpy as np
 from pydantic import BaseConfig, BaseModel, Field, root_validator, validator
 
 from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
-from libensemble.gen_funcs.sampling import latin_hypercube_sample
 from libensemble.resources.platforms import Platform
-from libensemble.sim_funcs.one_d_func import one_d_example
 from libensemble.utils.specs_checkers import (
     _check_any_workers_and_disable_rm_if_tcp,
     _check_exit_criteria,
@@ -39,7 +37,7 @@ class SimSpecs(BaseModel):
     Specifications for configuring a Simulation Function.
     """
 
-    sim_f: Callable = one_d_example
+    sim_f: Callable = None
     """
     Python function matching the ``sim_f`` interface. Evaluates parameters
     produced by a generator function.
@@ -101,7 +99,7 @@ class GenSpecs(BaseModel):
     Specifications for configuring a Generator Function.
     """
 
-    gen_f: Optional[Callable] = latin_hypercube_sample
+    gen_f: Optional[Callable] = None
     """
     Python function matching the ``gen_f`` interface. Produces parameters for evaluation by a
     simulator function, and makes decisions based on simulator function output.
@@ -579,6 +577,19 @@ class _EnsembleSpecs(BaseModel):
 
     class Config:
         arbitrary_types_allowed = True
+
+    @root_validator
+    def check_provided_ufuncs(cls, values):
+        sim_specs = values.get("sim_specs")
+        assert hasattr(sim_specs, "sim_f"), "Simulation function not provided to SimSpecs."
+        assert isinstance(sim_specs.sim_f, Callable), "Provided simulation function is not callable."
+
+        if values.get("alloc_specs").alloc_f.__name__ != "give_pregenerated_sim_work":
+            gen_specs = values.get("gen_specs")
+            assert hasattr(gen_specs, "gen_f"), "Generator function not provided to GenSpecs."
+            assert isinstance(gen_specs.gen_f, Callable), "Provided Generator function is not callable."
+
+        return values
 
     @root_validator
     def check_exit_criteria(cls, values):

--- a/libensemble/specs.py
+++ b/libensemble/specs.py
@@ -569,7 +569,7 @@ class _EnsembleSpecs(BaseModel):
     persis_info: Optional[dict]
     """ Per-worker information and structures to be passed between user function instances. """
 
-    alloc_specs: Optional[AllocSpecs]
+    alloc_specs: Optional[AllocSpecs] = AllocSpecs()
     """ Specifications for the allocation function. """
 
     nworkers: Optional[int]
@@ -582,12 +582,12 @@ class _EnsembleSpecs(BaseModel):
     def check_provided_ufuncs(cls, values):
         sim_specs = values.get("sim_specs")
         assert hasattr(sim_specs, "sim_f"), "Simulation function not provided to SimSpecs."
-        assert isinstance(sim_specs.sim_f, Callable), "Provided simulation function is not callable."
+        assert isinstance(sim_specs.sim_f, Callable), "Simulation function is not callable."
 
         if values.get("alloc_specs").alloc_f.__name__ != "give_pregenerated_sim_work":
             gen_specs = values.get("gen_specs")
             assert hasattr(gen_specs, "gen_f"), "Generator function not provided to GenSpecs."
-            assert isinstance(gen_specs.gen_f, Callable), "Provided Generator function is not callable."
+            assert isinstance(gen_specs.gen_f, Callable), "Generator function is not callable."
 
         return values
 

--- a/libensemble/tests/functionality_tests/test_persistent_uniform_sampling.py
+++ b/libensemble/tests/functionality_tests/test_persistent_uniform_sampling.py
@@ -46,6 +46,8 @@ if __name__ == "__main__":
         "out": [("f", float), ("grad", float, n)],
     }
 
+    sim_specs["in"] = (["x", "obj_component"],)
+
     gen_specs = {
         "persis_in": ["x", "f", "grad", "sim_id"],
         "out": [("x", float, (n,))],

--- a/libensemble/tests/functionality_tests/test_persistent_uniform_sampling.py
+++ b/libensemble/tests/functionality_tests/test_persistent_uniform_sampling.py
@@ -46,8 +46,6 @@ if __name__ == "__main__":
         "out": [("f", float), ("grad", float, n)],
     }
 
-    sim_specs["in"] = (["x", "obj_component"],)
-
     gen_specs = {
         "persis_in": ["x", "f", "grad", "sim_id"],
         "out": [("x", float, (n,))],

--- a/libensemble/tests/unit_tests_mpi_import/test_libE_main.py
+++ b/libensemble/tests/unit_tests_mpi_import/test_libE_main.py
@@ -158,7 +158,10 @@ def test_proc_not_in_communicator():
     libE_specs = {}
     libE_specs["mpi_comm"], mpi_comm_null = mpi_comm_excl()
     H, _, flag = libE(
-        {"in": ["x"], "out": [("f", float)]}, {"out": [("x", float)]}, {"sim_max": 1}, libE_specs=libE_specs
+        {"sim_f": print, "in": ["x"], "out": [("f", float)]},
+        {"gen_f": print, "out": [("x", float)]},
+        {"sim_max": 1},
+        libE_specs=libE_specs,
     )
     assert flag == 3, "libE return flag should be 3. Returned: " + str(flag)
 


### PR DESCRIPTION
Plus add pydantic's validate_arguments decorator to libE, turns out input dicts weren't being cast/validated like expected.