### PR TITLE
Allow overwriting history file on completion

### DIFF
--- a/libensemble/manager.py
+++ b/libensemble/manager.py
@@ -280,7 +280,8 @@ class Manager:
 
     def _save_every_k(self, fname: str, count: int, k: int, complete: bool) -> None:
         """Saves history every kth step"""
-        count = k * (count // k)
+        if not complete:
+            count = k * (count // k)
         date_start = self._get_date_start_str()
 
         filename = fname.format(self.libE_specs["H_file_prefix"], date_start, count)

--- a/libensemble/manager.py
+++ b/libensemble/manager.py
@@ -280,12 +280,11 @@ class Manager:
 
     def _save_every_k(self, fname: str, count: int, k: int, complete: bool) -> None:
         """Saves history every kth step"""
-        if not complete:
-            count = k * (count // k)
+        count = k * (count // k)
         date_start = self._get_date_start_str()
 
         filename = fname.format(self.libE_specs["H_file_prefix"], date_start, count)
-        if not os.path.isfile(filename) and count > 0:
+        if (not os.path.isfile(filename) and count > 0) or complete:
             for old_file in glob.glob(fname.format(self.libE_specs["H_file_prefix"], date_start, "*")):
                 os.remove(old_file)
             np.save(filename, self.hist.trim_H())

--- a/libensemble/tests/functionality_tests/test_persistent_uniform_sampling_running_mean.py
+++ b/libensemble/tests/functionality_tests/test_persistent_uniform_sampling_running_mean.py
@@ -70,12 +70,12 @@ if __name__ == "__main__":
         persis_info = add_unique_random_streams({}, nworkers + 1)
         H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs, libE_specs)
 
-        # Check that last saved history agrees with returned history.
-        H_saved = np.load(f"libE_history_after_sim_{sim_max}.npy")
-        for name in H.dtype.names:
-            np.testing.assert_array_equal(H_saved[name], H[name])
-
         if is_manager:
+            # Check that last saved history agrees with returned history.
+            H_saved = np.load(f"libE_history_after_sim_{sim_max}.npy")
+            for name in H.dtype.names:
+                np.testing.assert_array_equal(H_saved[name], H[name])
+
             assert np.all(H["f_est"][0:sim_max] != 0), "The persistent gen should have set these at shutdown"
             assert np.all(H["gen_informed"][0:sim_max]), "Need to mark the gen having been informed."
             save_libE_output(H, persis_info, __file__, nworkers)

--- a/libensemble/tests/functionality_tests/test_persistent_uniform_sampling_running_mean.py
+++ b/libensemble/tests/functionality_tests/test_persistent_uniform_sampling_running_mean.py
@@ -58,6 +58,7 @@ if __name__ == "__main__":
     sim_max = 120
     exit_criteria = {"sim_max": sim_max}
     libE_specs["final_gen_send"] = True
+    libE_specs["save_every_k_sims"] = 2
 
     for run in range(2):
         if run == 2:
@@ -68,6 +69,11 @@ if __name__ == "__main__":
 
         persis_info = add_unique_random_streams({}, nworkers + 1)
         H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs, libE_specs)
+
+        # Check that last saved history agrees with returned history.
+        H_saved = np.load(f"libE_history_after_sim_{sim_max}.npy")
+        for name in H.dtype.names:
+            np.testing.assert_array_equal(H_saved[name], H[name])
 
         if is_manager:
             assert np.all(H["f_est"][0:sim_max] != 0), "The persistent gen should have set these at shutdown"


### PR DESCRIPTION
This PR allows `_save_every_k` to overwrite the last saved history file on completion (when using the `"save_H_on_completion"` and/or `"save_every_k"` options). Otherwise, when using the `"final_gen_send"` option, there were cases in which "gen_informed" was still `False` in the saved file, while being `True` in the history array.
