### PR TITLE
Support `object` dtype in history array

### DIFF
--- a/libensemble/history.py
+++ b/libensemble/history.py
@@ -136,7 +136,7 @@ class History:
             for field in fields:
                 if safe_mode:
                     assert field not in protected_libE_fields, "The field '" + field + "' is protected"
-                if np.isscalar(returned_H[field][j]):
+                if np.isscalar(returned_H[field][j]) or returned_H.dtype[field].hasobject:
                     self.H[field][ind] = returned_H[field][j]
                 else:
                     # len or np.size


### PR DESCRIPTION
This PR fixes a bug when the `dtype` of a column in the history array is `object` (`"O"`). Supporting this `dtype` can be useful when the user needs the flexibility of storing any object in the history. For example, for storing an array at each evaluation whose size cannot be determined beforehand.

However, when storing an array, this currently results in the following error:

```
File "c:\users\ferran\repos\libensemble\libensemble\history.py", line 144, in update_history_f
    assert H0_size <= len(self.H[field][ind]), (
                      ^^^^^^^^^^^^^^^^^^^^^^^
TypeError: object of type 'int' has no len()
```

This is because `returned_H[field][j]` is not a scalar, but `self.H[field][ind]` is (since H is initialized using `np.zeros`).

The PR fixes this by checking whether the dtype is an object type.