### PR TITLE
Fixing many broken links

### DIFF
--- a/docs/data_structures/sim_specs.rst
+++ b/docs/data_structures/sim_specs.rst
@@ -72,6 +72,6 @@ Can be constructed and passed to libEnsemble as a Python class or a dictionary.
         :start-at: sim_f
         :end-before: end_sim_specs_rst_tag
 
-.. _forces_simf.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/scaling_tests/forces/forces_simf.py
-.. _run_libe_forces.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/scaling_tests/forces/run_libe_forces.py
+.. _forces_simf.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/scaling_tests/forces/forces_simple/forces_simf.py
+.. _run_libe_forces.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/scaling_tests/forces/forces_simple/run_libe_forces.py
 .. _test_uniform_sampling.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/functionality_tests/test_uniform_sampling.py

--- a/docs/function_guides/simulator.rst
+++ b/docs/function_guides/simulator.rst
@@ -83,4 +83,4 @@ function returns.
 .. note::
   An example routine using a persistent simulator can be found in test_persistent_sim_uniform_sampling_.
 
-.. _test_persistent_sim_uniform_sampling: https://github.com/Libensemble/libensemble/blob/main/libensemble/tests/regression_tests/test_persistent_sim_uniform_sampling.py
+.. _test_persistent_sim_uniform_sampling: https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/functionality_tests/test_persistent_sim_uniform_sampling.py

--- a/docs/function_guides/work_dict.rst
+++ b/docs/function_guides/work_dict.rst
@@ -34,4 +34,4 @@ or the equivalent "persis_in" variants.
 
 .. _start_only_persistent.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/alloc_funcs/start_only_persistent.py
 .. _start_persistent_local_opt_gens.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/alloc_funcs/start_persistent_local_opt_gens.py
-.. _test_uniform_sampling_with_variable_resources.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_uniform_sampling_with_variable_resources.py
+.. _test_uniform_sampling_with_variable_resources.py: https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/functionality_tests/test_uniform_sampling_with_variable_resources.py

--- a/libensemble/alloc_funcs/fast_alloc.py
+++ b/libensemble/alloc_funcs/fast_alloc.py
@@ -17,7 +17,7 @@ def give_sim_work_first(W, H, sim_specs, gen_specs, alloc_specs, persis_info, li
     tags: alloc, simple, fast
 
     .. seealso::
-        `test_fast_alloc.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_fast_alloc.py>`_ # noqa
+        `test_fast_alloc.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/functionality_tests/test_fast_alloc.py>`_ # noqa
     """
 
     if libE_info["sim_max_given"] or not libE_info["any_idle_workers"]:

--- a/libensemble/alloc_funcs/fast_alloc_and_pausing.py
+++ b/libensemble/alloc_funcs/fast_alloc_and_pausing.py
@@ -22,7 +22,7 @@ def give_sim_work_first(W, H, sim_specs, gen_specs, alloc_specs, persis_info, li
         combine_component_func is larger than a known upper bound on the objective.
 
     .. seealso::
-        `test_uniform_sampling_one_residual_at_a_time.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_uniform_sampling_one_residual_at_a_time.py>`_ # noqa
+        `test_uniform_sampling_one_residual_at_a_time.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/functionality_tests/test_uniform_sampling_one_residual_at_a_time.py>`_ # noqa
     """
 
     if libE_info["sim_max_given"] or not libE_info["any_idle_workers"]:

--- a/libensemble/alloc_funcs/give_pregenerated_work.py
+++ b/libensemble/alloc_funcs/give_pregenerated_work.py
@@ -7,7 +7,7 @@ def give_pregenerated_sim_work(W, H, sim_specs, gen_specs, alloc_specs, persis_i
     idle workers. It is an example use case where no gen_func is used.
 
     .. seealso::
-        `test_fast_alloc.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_fast_alloc.py>`_ # noqa
+        `test_fast_alloc.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/functionality_tests/test_fast_alloc.py>`_ # noqa
     """
 
     if libE_info["sim_max_given"] or not libE_info["any_idle_workers"]:

--- a/libensemble/alloc_funcs/only_one_gen_alloc.py
+++ b/libensemble/alloc_funcs/only_one_gen_alloc.py
@@ -8,7 +8,7 @@ def ensure_one_active_gen(W, H, sim_specs, gen_specs, alloc_specs, persis_info, 
     are given. If there is no active generator, then one is started.
 
     .. seealso::
-        `test_fast_alloc.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_fast_alloc.py>`_ # noqa
+        `test_fast_alloc.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/functionality_tests/test_fast_alloc.py>`_ # noqa
     """
 
     if libE_info["sim_max_given"] or not libE_info["any_idle_workers"]:

--- a/libensemble/alloc_funcs/start_only_persistent.py
+++ b/libensemble/alloc_funcs/start_only_persistent.py
@@ -42,10 +42,10 @@ def only_persistent_gens(W, H, sim_specs, gen_specs, alloc_specs, persis_info, l
     tags: alloc, batch, async, persistent, priority
 
     .. seealso::
-        `test_persistent_sampling.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_persistent_sampling.py>`_ # noqa
-        `test_persistent_sampling_async.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_persistent_sampling_async.py>`_ # noqa
+        `test_persistent_uniform_sampling.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/functionality_tests/test_persistent_uniform_sampling.py>`_ # noqa
+        `test_persistent_uniform_sampling_async.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/functionality_tests/test_persistent_uniform_sampling_async.py>`_ # noqa
         `test_persistent_surmise_calib.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_persistent_surmise_calib.py>`_ # noqa
-        `test_persistent_uniform_gen_decides_stop.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_persistent_uniform_gen_decides_stop.py>`_ # noqa
+        `test_persistent_uniform_gen_decides_stop.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/functionality_tests/test_persistent_uniform_gen_decides_stop.py>`_ # noqa
     """
 
     if libE_info["sim_max_given"] or not libE_info["any_idle_workers"]:
@@ -169,7 +169,7 @@ def only_persistent_workers(W, H, sim_specs, gen_specs, alloc_specs, persis_info
 
 
     .. seealso::
-        `test_persistent_gensim_uniform_sampling.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_persistent_gensim_uniform_sampling.py>`_ # noqa
+        `test_persistent_gensim_uniform_sampling.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/functionality_tests/test_persistent_sim_uniform_sampling.py>`_ # noqa
     """
 
     if libE_info["sim_max_given"] or not libE_info["any_idle_workers"]:

--- a/libensemble/alloc_funcs/start_persistent_local_opt_gens.py
+++ b/libensemble/alloc_funcs/start_persistent_local_opt_gens.py
@@ -21,7 +21,7 @@ def start_persistent_local_opt_gens(W, H, sim_specs, gen_specs, alloc_specs, per
     tags: alloc, persistent, aposmm
 
     .. seealso::
-        `test_uniform_sampling_then_persistent_localopt_runs.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_uniform_sampling_then_persistent_localopt_runs.py>`_ # noqa
+        `test_uniform_sampling_then_persistent_localopt_runs.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/functionality_tests/test_uniform_sampling_then_persistent_localopt_runs.py>`_ # noqa
     """
 
     if libE_info["sim_max_given"] or not libE_info["any_idle_workers"]:

--- a/libensemble/gen_funcs/persistent_sampling.py
+++ b/libensemble/gen_funcs/persistent_sampling.py
@@ -38,7 +38,7 @@ def persistent_uniform(_, persis_info, gen_specs, libE_info):
 
     .. seealso::
         `test_persistent_uniform_sampling.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/functionality_tests/test_persistent_uniform_sampling.py>`_
-        `test_persistent_sampling_async.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/functionality_tests/test_persistent_sampling_async.py>`_
+        `test_persistent_uniform_sampling_async.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/functionality_tests/test_persistent_uniform_sampling_async.py>`_
     """  # noqa
 
     b, n, lb, ub = _get_user_params(gen_specs["user"])

--- a/libensemble/gen_funcs/sampling.py
+++ b/libensemble/gen_funcs/sampling.py
@@ -21,7 +21,7 @@ def uniform_random_sample(_, persis_info, gen_specs):
     defined by ``gen_specs["user"]["ub"]`` and ``gen_specs["user"]["lb"]``.
 
     .. seealso::
-        `test_uniform_sampling.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_uniform_sampling.py>`_ # noqa
+        `test_uniform_sampling.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/functionality_tests/test_uniform_sampling.py>`_ # noqa
     """
     ub = gen_specs["user"]["ub"]
     lb = gen_specs["user"]["lb"]
@@ -46,7 +46,7 @@ def uniform_random_sample_with_variable_resources(_, persis_info, gen_specs):
     This generator is used to test/demonstrate setting of resource sets.
 
     #.. seealso::
-        #`test_uniform_sampling_with_variable_resources.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_uniform_sampling_with_variable_resources.py>`_ # noqa
+        #`test_uniform_sampling_with_variable_resources.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/functionality_tests/test_uniform_sampling_with_variable_resources.py>`_ # noqa
     """
 
     ub = gen_specs["user"]["ub"]
@@ -110,7 +110,7 @@ def uniform_random_sample_obj_components(H, persis_info, gen_specs):
     separately.
 
     .. seealso::
-        `test_uniform_sampling_one_residual_at_a_time.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_uniform_sampling_one_residual_at_a_time.py>`_ # noqa
+        `test_uniform_sampling_one_residual_at_a_time.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/functionality_tests/test_uniform_sampling_one_residual_at_a_time.py>`_ # noqa
     """
     ub = gen_specs["user"]["ub"]
     lb = gen_specs["user"]["lb"]

--- a/libensemble/gen_funcs/uniform_or_localopt.py
+++ b/libensemble/gen_funcs/uniform_or_localopt.py
@@ -21,7 +21,7 @@ def uniform_or_localopt(H, persis_info, gen_specs, libE_info):
     function starts a persistent nlopt local optimization run.
 
     .. seealso::
-        `test_uniform_sampling_then_persistent_localopt_runs.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_uniform_sampling_then_persistent_localopt_runs.py>`_ # noqa
+        `test_uniform_sampling_then_persistent_localopt_runs.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/functionality_tests/test_uniform_sampling_then_persistent_localopt_runs.py>`_ # noqa
     """
     if libE_info.get("persistent"):
         x_opt, persis_info_updates, tag_out = try_and_run_nlopt(H, gen_specs, libE_info)

--- a/libensemble/sim_funcs/chwirut1.py
+++ b/libensemble/sim_funcs/chwirut1.py
@@ -263,11 +263,11 @@ def chwirut_eval(H, _, sim_specs):
     are evaluated and returned in the ``"fvec"`` field.
 
     .. seealso::
-        `test_old_aposmm_pounders.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_old_aposmm_pounders.py>`_
+        `test_persistent_aposmm_pounders.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_persistent_aposmm_pounders.py>`_ # noqa
         for an example where the entire fvec is computed each call.
 
     .. seealso::
-        `test_old_aposmm_one_residual_at_a_time.py  <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_old_aposmm_one_residual_at_a_time.py>`_
+        `test_uniform_sampling_one_residual_at_a_time.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/functionality_tests/test_uniform_sampling_one_residual_at_a_time.py>`_ # noqa
         for an example where one component of fvec is computed per call
     """
 

--- a/libensemble/sim_funcs/one_d_func.py
+++ b/libensemble/sim_funcs/one_d_func.py
@@ -11,7 +11,7 @@ def one_d_example(x, persis_info, sim_specs, _):
     Evaluates the six hump camel function for a single point ``x``.
 
     .. seealso::
-        `test_fast_alloc.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_fast_alloc.py>`_ # noqa
+        `test_fast_alloc.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/functionality_tests/test_fast_alloc.py>`_ # noqa
     """
 
     H_o = np.zeros(1, dtype=sim_specs["out"])

--- a/libensemble/sim_funcs/six_hump_camel.py
+++ b/libensemble/sim_funcs/six_hump_camel.py
@@ -28,7 +28,7 @@ def six_hump_camel(H, persis_info, sim_specs, libE_info):
     defined.
 
     .. seealso::
-        `test_old_aposmm_with_gradients.py  <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_old_aposmm_with_gradients.py>`_ # noqa
+        `test_uniform_sampling.py  <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/functionality_tests/test_uniform_sampling.py>`_ # noqa
     """
 
     batch = len(H["x"])
@@ -51,7 +51,7 @@ def six_hump_camel_simple(x, _, sim_specs):
     Evaluates the six hump camel function for a single point ``x``.
 
     .. seealso::
-        `test_fast_alloc.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_fast_alloc.py>`_ # noqa
+        `test_fast_alloc.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/functionality_tests/test_fast_alloc.py>`_ # noqa
     """
 
     H_o = np.zeros(1, dtype=sim_specs["out"])

--- a/libensemble/sim_funcs/var_resources.py
+++ b/libensemble/sim_funcs/var_resources.py
@@ -193,7 +193,7 @@ def multi_points_with_variable_resources(H, _, sim_specs, libE_info):
     points (sim ids) in each call.
 
     .. seealso::
-        `test_uniform_sampling_with_variable_resources.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_uniform_sampling_with_variable_resources.py>`_ # noqa
+        `test_uniform_sampling_with_variable_resources.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/functionality_tests/test_uniform_sampling_with_variable_resources.py>`_ # noqa
     """
 
     batch = len(H["x"])

--- a/libensemble/tests/functionality_tests/test_persistent_uniform_sampling.py
+++ b/libensemble/tests/functionality_tests/test_persistent_uniform_sampling.py
@@ -3,7 +3,7 @@ Tests libEnsemble with a simple persistent uniform sampling generator
 function.
 
 Execute via one of the following commands (e.g. 3 workers):
-   mpiexec -np 4 python test_persistent_sampling.py
+   mpiexec -np 4 python test_persistent_uniform_sampling.py
    python test_persistent_uniform_sampling.py --nworkers 3 --comms local
    python test_persistent_uniform_sampling.py --nworkers 3 --comms tcp
 

--- a/libensemble/tests/functionality_tests/test_persistent_uniform_sampling_cancel.py
+++ b/libensemble/tests/functionality_tests/test_persistent_uniform_sampling_cancel.py
@@ -3,7 +3,7 @@ Tests libEnsemble with a simple persistent uniform sampling generator
 function.
 
 Execute via one of the following commands (e.g. 3 workers):
-   mpiexec -np 4 python test_persistent_sampling.py
+   mpiexec -np 4 python test_persistent_uniform_sampling_cancel.py
    python test_persistent_uniform_sampling_cancel.py --nworkers 3 --comms local
    python test_persistent_uniform_sampling_cancel.py --nworkers 3 --comms tcp
 


### PR DESCRIPTION
The splitting of some regression tests to functionality tests made some broken crossrefs. 

Also, some tests were renamed.