### PR TITLE
Refactor/user function handling modules +  Manager can run additional worker on thread

### DIFF
--- a/docs/data_structures/libE_specs.rst
+++ b/docs/data_structures/libE_specs.rst
@@ -30,12 +30,9 @@ libEnsemble is primarily customized by setting options within a ``LibeSpecs`` cl
                 **nworkers** [int]:
                     Number of worker processes in ``"local"``, ``"threads"``, or ``"tcp"``.
 
-                **manager_runs_additional_worker** [bool] = False
-                    Manager process launches an additional threaded Worker 0.
-                    This worker can access/modify user objects by reference.
-
                 **gen_on_manager** Optional[bool] = False
-                    Enable ``manager_runs_additional_worker`` and reserve that worker for a single generator.
+                    Instructs Manager process to run generator functions.
+                    This generator function can access/modify user objects by reference.
 
                 **mpi_comm** [MPI communicator] = ``MPI.COMM_WORLD``:
                     libEnsemble MPI communicator.

--- a/docs/data_structures/libE_specs.rst
+++ b/docs/data_structures/libE_specs.rst
@@ -55,6 +55,10 @@ libEnsemble is primarily customized by setting options within a ``LibeSpecs`` cl
                 **disable_log_files** [bool] = ``False``:
                     Disable ``ensemble.log`` and ``libE_stats.txt`` log files.
 
+                **gen_workers** [list of ints]:
+                    List of workers that should only run generators. All other workers will only
+                    run simulator functions.
+
         .. tab-item:: Directories
 
             .. tab-set::

--- a/docs/data_structures/libE_specs.rst
+++ b/docs/data_structures/libE_specs.rst
@@ -30,8 +30,12 @@ libEnsemble is primarily customized by setting options within a ``LibeSpecs`` cl
                 **nworkers** [int]:
                     Number of worker processes in ``"local"``, ``"threads"``, or ``"tcp"``.
 
-                **manager_runs_additional_worker** [int] = False
-                    Manager process can launch an additional threaded worker
+                **manager_runs_additional_worker** [bool] = False
+                    Manager process launches an additional threaded Worker 0.
+                    This worker can access/modify user objects by reference.
+
+                **gen_on_manager** Optional[bool] = False
+                    Enable ``manager_runs_additional_worker`` and reserve that worker for a single generator.
 
                 **mpi_comm** [MPI communicator] = ``MPI.COMM_WORLD``:
                     libEnsemble MPI communicator.

--- a/examples/calling_scripts/tutorial_calling.py
+++ b/examples/calling_scripts/tutorial_calling.py
@@ -1,1 +1,0 @@
-../tutorials/simple_sine/tutorial_calling.py

--- a/libensemble/alloc_funcs/fast_alloc.py
+++ b/libensemble/alloc_funcs/fast_alloc.py
@@ -45,7 +45,7 @@ def give_sim_work_first(W, H, sim_specs, gen_specs, alloc_specs, persis_info, li
     # Give gen work if possible
     if persis_info["next_to_give"] >= len(H):
         for wid in support.avail_worker_ids(gen_workers=True):
-            if gen_count < user.get("num_active_gens", gen_count + 1):
+            if wid not in Work and gen_count < user.get("num_active_gens", gen_count + 1):
                 return_rows = range(len(H)) if gen_in else []
                 try:
                     Work[wid] = support.gen_work(wid, gen_in, return_rows, persis_info.get(wid))

--- a/libensemble/alloc_funcs/fast_alloc.py
+++ b/libensemble/alloc_funcs/fast_alloc.py
@@ -42,6 +42,8 @@ def give_sim_work_first(W, H, sim_specs, gen_specs, alloc_specs, persis_info, li
                 break
             persis_info["next_to_give"] += 1
 
+        return Work, persis_info
+
     # Give gen work if possible
     if persis_info["next_to_give"] >= len(H):
         for wid in support.avail_worker_ids(gen_workers=True):

--- a/libensemble/alloc_funcs/fast_alloc.py
+++ b/libensemble/alloc_funcs/fast_alloc.py
@@ -33,16 +33,14 @@ def give_sim_work_first(W, H, sim_specs, gen_specs, alloc_specs, persis_info, li
     gen_in = gen_specs.get("in", [])
 
     # Give sim work if possible
-    if persis_info["next_to_give"] < len(H):
-        for wid in support.avail_worker_ids(gen_workers=False):
-            persis_info = support.skip_canceled_points(H, persis_info)
+    for wid in support.avail_worker_ids(gen_workers=False):
+        persis_info = support.skip_canceled_points(H, persis_info)
+        if persis_info["next_to_give"] < len(H):
             try:
                 Work[wid] = support.sim_work(wid, H, sim_specs["in"], [persis_info["next_to_give"]], [])
             except InsufficientFreeResources:
                 break
             persis_info["next_to_give"] += 1
-
-        return Work, persis_info
 
     # Give gen work if possible
     if persis_info["next_to_give"] >= len(H):

--- a/libensemble/alloc_funcs/fast_alloc.py
+++ b/libensemble/alloc_funcs/fast_alloc.py
@@ -32,19 +32,20 @@ def give_sim_work_first(W, H, sim_specs, gen_specs, alloc_specs, persis_info, li
     Work = {}
     gen_in = gen_specs.get("in", [])
 
-    for wid in support.avail_worker_ids():
-        persis_info = support.skip_canceled_points(H, persis_info)
+    persis_info = support.skip_canceled_points(H, persis_info)
 
-        # Give sim work if possible
-        if persis_info["next_to_give"] < len(H):
+    # Give sim work if possible
+    if persis_info["next_to_give"] < len(H):
+        for wid in support.avail_worker_ids(gen_workers=False):
             try:
                 Work[wid] = support.sim_work(wid, H, sim_specs["in"], [persis_info["next_to_give"]], [])
             except InsufficientFreeResources:
                 break
             persis_info["next_to_give"] += 1
 
-        elif gen_count < user.get("num_active_gens", gen_count + 1):
-            # Give gen work
+    # Give gen work if possible
+    elif gen_count < user.get("num_active_gens", gen_count + 1):
+        for wid in support.avail_worker_ids(gen_workers=True):
             return_rows = range(len(H)) if gen_in else []
             try:
                 Work[wid] = support.gen_work(wid, gen_in, return_rows, persis_info.get(wid))

--- a/libensemble/alloc_funcs/give_pregenerated_work.py
+++ b/libensemble/alloc_funcs/give_pregenerated_work.py
@@ -23,7 +23,7 @@ def give_pregenerated_sim_work(W, H, sim_specs, gen_specs, alloc_specs, persis_i
     if persis_info["next_to_give"] >= len(H):
         return Work, persis_info, 1
 
-    for i in support.avail_worker_ids():
+    for i in support.avail_sim_worker_ids():
         persis_info = support.skip_canceled_points(H, persis_info)
 
         # Give sim work

--- a/libensemble/alloc_funcs/give_pregenerated_work.py
+++ b/libensemble/alloc_funcs/give_pregenerated_work.py
@@ -23,7 +23,7 @@ def give_pregenerated_sim_work(W, H, sim_specs, gen_specs, alloc_specs, persis_i
     if persis_info["next_to_give"] >= len(H):
         return Work, persis_info, 1
 
-    for i in support.avail_sim_worker_ids():
+    for i in support.avail_worker_ids():
         persis_info = support.skip_canceled_points(H, persis_info)
 
         # Give sim work

--- a/libensemble/alloc_funcs/give_pregenerated_work.py
+++ b/libensemble/alloc_funcs/give_pregenerated_work.py
@@ -23,7 +23,7 @@ def give_pregenerated_sim_work(W, H, sim_specs, gen_specs, alloc_specs, persis_i
     if persis_info["next_to_give"] >= len(H):
         return Work, persis_info, 1
 
-    for i in support.avail_worker_ids():
+    for i in support.avail_worker_ids(gen_workers=False):
         persis_info = support.skip_canceled_points(H, persis_info)
 
         # Give sim work

--- a/libensemble/alloc_funcs/give_sim_work_first.py
+++ b/libensemble/alloc_funcs/give_sim_work_first.py
@@ -64,15 +64,19 @@ def give_sim_work_first(
     Work = {}
 
     points_to_evaluate = ~H["sim_started"] & ~H["cancel_requested"]
-    for wid in support.avail_worker_ids():
-        if np.any(points_to_evaluate):
+
+    if np.any(points_to_evaluate):
+        for wid in support.avail_worker_ids(gen_workers=False):
             sim_ids_to_send = support.points_by_priority(H, points_avail=points_to_evaluate, batch=batch_give)
             try:
                 Work[wid] = support.sim_work(wid, H, sim_specs["in"], sim_ids_to_send, persis_info.get(wid))
             except InsufficientFreeResources:
                 break
             points_to_evaluate[sim_ids_to_send] = False
-        else:
+            if not np.any(points_to_evaluate):
+                break
+    else:
+        for wid in support.avail_worker_ids(gen_workers=True):
             # Allow at most num_active_gens active generator instances
             if gen_count >= user.get("num_active_gens", gen_count + 1):
                 break

--- a/libensemble/alloc_funcs/inverse_bayes_allocf.py
+++ b/libensemble/alloc_funcs/inverse_bayes_allocf.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-from libensemble.message_numbers import EVAL_GEN_TAG
 from libensemble.tools.alloc_support import AllocSupport, InsufficientFreeResources
 
 
@@ -25,7 +24,7 @@ def only_persistent_gens_for_inverse_bayes(W, H, sim_specs, gen_specs, alloc_spe
 
     # If wid is idle, but in persistent mode, and generated work has all returned
     # give output back to wid. Otherwise, give nothing to wid
-    for wid in support.avail_worker_ids(persistent=EVAL_GEN_TAG):
+    for wid in support.avail_gen_worker_ids(persistent=True):
         # if > 1 persistent generator, assign the correct work to it
         inds_generated_by_wid = H["gen_worker"] == wid
         if support.all_sim_ended(H, inds_generated_by_wid):

--- a/libensemble/alloc_funcs/inverse_bayes_allocf.py
+++ b/libensemble/alloc_funcs/inverse_bayes_allocf.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from libensemble.message_numbers import EVAL_GEN_TAG
 from libensemble.tools.alloc_support import AllocSupport, InsufficientFreeResources
 
 
@@ -24,7 +25,7 @@ def only_persistent_gens_for_inverse_bayes(W, H, sim_specs, gen_specs, alloc_spe
 
     # If wid is idle, but in persistent mode, and generated work has all returned
     # give output back to wid. Otherwise, give nothing to wid
-    for wid in support.avail_gen_worker_ids(persistent=True):
+    for wid in support.avail_worker_ids(persistent=EVAL_GEN_TAG):
         # if > 1 persistent generator, assign the correct work to it
         inds_generated_by_wid = H["gen_worker"] == wid
         if support.all_sim_ended(H, inds_generated_by_wid):

--- a/libensemble/alloc_funcs/only_one_gen_alloc.py
+++ b/libensemble/alloc_funcs/only_one_gen_alloc.py
@@ -35,16 +35,16 @@ def ensure_one_active_gen(W, H, sim_specs, gen_specs, alloc_specs, persis_info, 
     elif not support.test_any_gen() and gen_flag:
         # Give gen work
         return_rows = range(len(H)) if gen_in else []
-        for wid in support.avail_worker_ids(gen_workers=True):
+        wid = support.avail_worker_ids(gen_workers=True)[0]
 
-            if not support.all_sim_ended(H):
-                break
+        if not support.all_sim_ended(H):
+            return Work, persis_info
 
-            try:
-                Work[wid] = support.gen_work(wid, gen_in, return_rows, persis_info.get(wid))
-            except InsufficientFreeResources:
-                break
-            gen_flag = False
-            persis_info["total_gen_calls"] += 1
+        try:
+            Work[wid] = support.gen_work(wid, gen_in, return_rows, persis_info.get(wid))
+        except InsufficientFreeResources:
+            return Work, persis_info
+        gen_flag = False
+        persis_info["total_gen_calls"] += 1
 
     return Work, persis_info

--- a/libensemble/alloc_funcs/only_one_gen_alloc.py
+++ b/libensemble/alloc_funcs/only_one_gen_alloc.py
@@ -21,10 +21,9 @@ def ensure_one_active_gen(W, H, sim_specs, gen_specs, alloc_specs, persis_info, 
     gen_flag = True
     gen_in = gen_specs.get("in", [])
 
-    persis_info = support.skip_canceled_points(H, persis_info)
-
     if persis_info["next_to_give"] < len(H):
         for wid in support.avail_worker_ids(gen_workers=False):
+            persis_info = support.skip_canceled_points(H, persis_info)
             try:
                 Work[wid] = support.sim_work(wid, H, sim_specs["in"], [persis_info["next_to_give"]], [])
             except InsufficientFreeResources:

--- a/libensemble/alloc_funcs/persistent_aposmm_alloc.py
+++ b/libensemble/alloc_funcs/persistent_aposmm_alloc.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from libensemble.message_numbers import EVAL_GEN_TAG
 from libensemble.tools.alloc_support import AllocSupport, InsufficientFreeResources
 
 
@@ -39,7 +40,7 @@ def persistent_aposmm_alloc(W, H, sim_specs, gen_specs, alloc_specs, persis_info
         return Work, persis_info, 1
 
     # If any persistent worker's calculated values have returned, give them back.
-    for wid in support.avail_gen_worker_ids(persistent=True):
+    for wid in support.avail_worker_ids(persistent=EVAL_GEN_TAG):
         if persis_info.get("sample_done") or sum(H["sim_ended"]) >= init_sample_size + persis_info["samples_in_H0"]:
             # Don't return if the initial sample is not complete
             persis_info["sample_done"] = True

--- a/libensemble/alloc_funcs/persistent_aposmm_alloc.py
+++ b/libensemble/alloc_funcs/persistent_aposmm_alloc.py
@@ -53,7 +53,7 @@ def persistent_aposmm_alloc(W, H, sim_specs, gen_specs, alloc_specs, persis_info
                 )
                 returned_but_not_given[point_ids] = False
 
-    for wid in support.avail_worker_ids(persistent=False):
+    for wid in support.avail_worker_ids(persistent=False, gen_workers=False):
         persis_info = support.skip_canceled_points(H, persis_info)
 
         if persis_info["next_to_give"] < len(H):
@@ -63,8 +63,11 @@ def persistent_aposmm_alloc(W, H, sim_specs, gen_specs, alloc_specs, persis_info
             except InsufficientFreeResources:
                 break
             persis_info["next_to_give"] += 1
+            if persis_info["next_to_give"] >= len(H):
+                break
 
-        elif persis_info.get("gen_started") is None:
+    if persis_info.get("gen_started") is None:
+        for wid in support.avail_worker_ids(persistent=False, gen_workers=True):
             # Finally, call a persistent generator as there is nothing else to do.
             persis_info.get(wid)["nworkers"] = len(W)
             try:
@@ -74,5 +77,6 @@ def persistent_aposmm_alloc(W, H, sim_specs, gen_specs, alloc_specs, persis_info
             except InsufficientFreeResources:
                 break
             persis_info["gen_started"] = True  # Must set after - in case break on resources
+            break
 
     return Work, persis_info

--- a/libensemble/alloc_funcs/persistent_aposmm_alloc.py
+++ b/libensemble/alloc_funcs/persistent_aposmm_alloc.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-from libensemble.message_numbers import EVAL_GEN_TAG
 from libensemble.tools.alloc_support import AllocSupport, InsufficientFreeResources
 
 
@@ -40,7 +39,7 @@ def persistent_aposmm_alloc(W, H, sim_specs, gen_specs, alloc_specs, persis_info
         return Work, persis_info, 1
 
     # If any persistent worker's calculated values have returned, give them back.
-    for wid in support.avail_worker_ids(persistent=EVAL_GEN_TAG):
+    for wid in support.avail_gen_worker_ids(persistent=True):
         if persis_info.get("sample_done") or sum(H["sim_ended"]) >= init_sample_size + persis_info["samples_in_H0"]:
             # Don't return if the initial sample is not complete
             persis_info["sample_done"] = True

--- a/libensemble/alloc_funcs/start_fd_persistent.py
+++ b/libensemble/alloc_funcs/start_fd_persistent.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-from libensemble.message_numbers import EVAL_GEN_TAG
 from libensemble.tools.alloc_support import AllocSupport, InsufficientFreeResources
 
 
@@ -30,7 +29,7 @@ def finite_diff_alloc(W, H, sim_specs, gen_specs, alloc_specs, persis_info, libE
 
     # If wid is in persistent mode, and all of its calculated values have
     # returned, give them back to wid. Otherwise, give nothing to wid
-    for wid in support.avail_worker_ids(persistent=EVAL_GEN_TAG):
+    for wid in support.avail_gen_worker_ids(persistent=True):
         # What (x_ind, f_ind) pairs have all of the evaluation of all n_ind
         # values complete.
         inds_not_sent_back = ~H["gen_informed"]

--- a/libensemble/alloc_funcs/start_fd_persistent.py
+++ b/libensemble/alloc_funcs/start_fd_persistent.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from libensemble.message_numbers import EVAL_GEN_TAG
 from libensemble.tools.alloc_support import AllocSupport, InsufficientFreeResources
 
 
@@ -29,7 +30,7 @@ def finite_diff_alloc(W, H, sim_specs, gen_specs, alloc_specs, persis_info, libE
 
     # If wid is in persistent mode, and all of its calculated values have
     # returned, give them back to wid. Otherwise, give nothing to wid
-    for wid in support.avail_gen_worker_ids(persistent=True):
+    for wid in support.avail_worker_ids(persistent=EVAL_GEN_TAG):
         # What (x_ind, f_ind) pairs have all of the evaluation of all n_ind
         # values complete.
         inds_not_sent_back = ~H["gen_informed"]

--- a/libensemble/alloc_funcs/start_only_persistent.py
+++ b/libensemble/alloc_funcs/start_only_persistent.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from libensemble.message_numbers import EVAL_GEN_TAG, EVAL_SIM_TAG
+from libensemble.message_numbers import EVAL_SIM_TAG
 from libensemble.tools.alloc_support import AllocSupport, InsufficientFreeResources
 
 
@@ -51,7 +51,6 @@ def only_persistent_gens(W, H, sim_specs, gen_specs, alloc_specs, persis_info, l
     if libE_info["sim_max_given"] or not libE_info["any_idle_workers"]:
         return {}, persis_info
 
-    # Initialize alloc_specs["user"] as user.
     user = alloc_specs.get("user", {})
     manage_resources = libE_info["use_resource_sets"]
 
@@ -71,7 +70,7 @@ def only_persistent_gens(W, H, sim_specs, gen_specs, alloc_specs, persis_info, l
         return Work, persis_info, 1
 
     # Give evaluated results back to a running persistent gen
-    for wid in support.avail_worker_ids(persistent=EVAL_GEN_TAG, active_recv=active_recv_gen):
+    for wid in support.avail_gen_worker_ids(persistent=True, active_recv=active_recv_gen):
         gen_inds = H["gen_worker"] == wid
         returned_but_not_given = np.logical_and.reduce((H["sim_ended"], ~H["gen_informed"], gen_inds))
         if np.any(returned_but_not_given):

--- a/libensemble/alloc_funcs/start_only_persistent.py
+++ b/libensemble/alloc_funcs/start_only_persistent.py
@@ -88,7 +88,7 @@ def only_persistent_gens(W, H, sim_specs, gen_specs, alloc_specs, persis_info, l
 
     # Now the give_sim_work_first part
     points_to_evaluate = ~H["sim_started"] & ~H["cancel_requested"]
-    avail_workers = support.avail_worker_ids(persistent=False, zero_resource_workers=False)
+    avail_workers = support.avail_sim_worker_ids(persistent=False, zero_resource_workers=False)
     if user.get("alt_type"):
         avail_workers = list(
             set(support.avail_worker_ids(persistent=False, zero_resource_workers=False))

--- a/libensemble/alloc_funcs/start_only_persistent.py
+++ b/libensemble/alloc_funcs/start_only_persistent.py
@@ -51,6 +51,7 @@ def only_persistent_gens(W, H, sim_specs, gen_specs, alloc_specs, persis_info, l
     if libE_info["sim_max_given"] or not libE_info["any_idle_workers"]:
         return {}, persis_info
 
+    # Initialize alloc_specs["user"] as user.
     user = alloc_specs.get("user", {})
     manage_resources = libE_info["use_resource_sets"]
 

--- a/libensemble/alloc_funcs/start_only_persistent.py
+++ b/libensemble/alloc_funcs/start_only_persistent.py
@@ -92,7 +92,7 @@ def only_persistent_gens(W, H, sim_specs, gen_specs, alloc_specs, persis_info, l
     if user.get("alt_type"):
         avail_workers = list(
             set(support.avail_worker_ids(persistent=False, zero_resource_workers=False))
-            | set(support.avail_worker_ids(persistent=EVAL_SIM_TAG, zero_resource_workers=False))
+            | set(support.avail_worker_ids(persistent=True, zero_resource_workers=False, worker_type=EVAL_SIM_TAG))
         )
     for wid in avail_workers:
         if not np.any(points_to_evaluate):

--- a/libensemble/alloc_funcs/start_only_persistent.py
+++ b/libensemble/alloc_funcs/start_only_persistent.py
@@ -89,7 +89,7 @@ def only_persistent_gens(W, H, sim_specs, gen_specs, alloc_specs, persis_info, l
 
     # Now the give_sim_work_first part
     points_to_evaluate = ~H["sim_started"] & ~H["cancel_requested"]
-    avail_workers = support.avail_worker_ids(persistent=False, zero_resource_workers=False)
+    avail_workers = support.avail_worker_ids(persistent=False, zero_resource_workers=False, gen_workers=False)
     if user.get("alt_type"):
         avail_workers = list(
             set(support.avail_worker_ids(persistent=False, zero_resource_workers=False))

--- a/libensemble/alloc_funcs/start_only_persistent.py
+++ b/libensemble/alloc_funcs/start_only_persistent.py
@@ -115,7 +115,7 @@ def only_persistent_gens(W, H, sim_specs, gen_specs, alloc_specs, persis_info, l
 
     # Start persistent gens if no worker to give out. Uses zero_resource_workers if defined.
     if not np.any(points_to_evaluate):
-        avail_workers = support.avail_worker_ids(persistent=False, zero_resource_workers=True)
+        avail_workers = support.avail_worker_ids(persistent=False, zero_resource_workers=True, gen_workers=True)
 
         for wid in avail_workers:
             if gen_count < user.get("num_active_gens", 1):

--- a/libensemble/alloc_funcs/start_only_persistent.py
+++ b/libensemble/alloc_funcs/start_only_persistent.py
@@ -88,7 +88,7 @@ def only_persistent_gens(W, H, sim_specs, gen_specs, alloc_specs, persis_info, l
 
     # Now the give_sim_work_first part
     points_to_evaluate = ~H["sim_started"] & ~H["cancel_requested"]
-    avail_workers = support.avail_sim_worker_ids(persistent=False, zero_resource_workers=False)
+    avail_workers = support.avail_worker_ids(persistent=False, zero_resource_workers=False)
     if user.get("alt_type"):
         avail_workers = list(
             set(support.avail_worker_ids(persistent=False, zero_resource_workers=False))

--- a/libensemble/alloc_funcs/start_only_persistent.py
+++ b/libensemble/alloc_funcs/start_only_persistent.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from libensemble.message_numbers import EVAL_SIM_TAG
+from libensemble.message_numbers import EVAL_GEN_TAG, EVAL_SIM_TAG
 from libensemble.tools.alloc_support import AllocSupport, InsufficientFreeResources
 
 
@@ -70,7 +70,7 @@ def only_persistent_gens(W, H, sim_specs, gen_specs, alloc_specs, persis_info, l
         return Work, persis_info, 1
 
     # Give evaluated results back to a running persistent gen
-    for wid in support.avail_gen_worker_ids(persistent=True, active_recv=active_recv_gen):
+    for wid in support.avail_worker_ids(persistent=EVAL_GEN_TAG, active_recv=active_recv_gen):
         gen_inds = H["gen_worker"] == wid
         returned_but_not_given = np.logical_and.reduce((H["sim_ended"], ~H["gen_informed"], gen_inds))
         if np.any(returned_but_not_given):
@@ -92,7 +92,7 @@ def only_persistent_gens(W, H, sim_specs, gen_specs, alloc_specs, persis_info, l
     if user.get("alt_type"):
         avail_workers = list(
             set(support.avail_worker_ids(persistent=False, zero_resource_workers=False))
-            | set(support.avail_worker_ids(persistent=True, zero_resource_workers=False, worker_type=EVAL_SIM_TAG))
+            | set(support.avail_worker_ids(persistent=EVAL_SIM_TAG, zero_resource_workers=False))
         )
     for wid in avail_workers:
         if not np.any(points_to_evaluate):

--- a/libensemble/alloc_funcs/start_persistent_local_opt_gens.py
+++ b/libensemble/alloc_funcs/start_persistent_local_opt_gens.py
@@ -46,7 +46,7 @@ def start_persistent_local_opt_gens(W, H, sim_specs, gen_specs, alloc_specs, per
 
     # If wid is idle, but in persistent mode, and its calculated values have
     # returned, give them back to i. Otherwise, give nothing to wid
-    for wid in support.avail_gen_worker_ids(persistent=True):
+    for wid in support.avail_worker_ids(persistent=EVAL_GEN_TAG):
         gen_inds = H["gen_worker"] == wid
         if support.all_sim_ended(H, gen_inds):
             last_time_pos = np.argmax(H["sim_started_time"][gen_inds])
@@ -90,9 +90,7 @@ def start_persistent_local_opt_gens(W, H, sim_specs, gen_specs, alloc_specs, per
                 break
             points_to_evaluate[sim_ids_to_send] = False
 
-        elif gen_count == 0 and not np.any(
-            np.logical_and((W["active"]), (W["persistent"] is False), (W["worker_type"] == EVAL_GEN_TAG))
-        ):
+        elif gen_count == 0 and not np.any(np.logical_and((W["active"] == EVAL_GEN_TAG), (W["persis_state"] == 0))):
             # Finally, generate points since there is nothing else to do (no resource sets req.)
             Work[wid] = support.gen_work(wid, gen_specs.get("in", []), [], persis_info[wid], rset_team=[])
             gen_count += 1

--- a/libensemble/alloc_funcs/start_persistent_local_opt_gens.py
+++ b/libensemble/alloc_funcs/start_persistent_local_opt_gens.py
@@ -90,7 +90,9 @@ def start_persistent_local_opt_gens(W, H, sim_specs, gen_specs, alloc_specs, per
                 break
             points_to_evaluate[sim_ids_to_send] = False
 
-        elif gen_count == 0 and not np.any(np.logical_and(W["active"] == EVAL_GEN_TAG, W["persis_state"] == 0)):
+        elif gen_count == 0 and not np.any(
+            np.logical_and((W["active"]), (W["persistent"] is False), (W["worker_type"] == EVAL_GEN_TAG))
+        ):
             # Finally, generate points since there is nothing else to do (no resource sets req.)
             Work[wid] = support.gen_work(wid, gen_specs.get("in", []), [], persis_info[wid], rset_team=[])
             gen_count += 1

--- a/libensemble/alloc_funcs/start_persistent_local_opt_gens.py
+++ b/libensemble/alloc_funcs/start_persistent_local_opt_gens.py
@@ -46,7 +46,7 @@ def start_persistent_local_opt_gens(W, H, sim_specs, gen_specs, alloc_specs, per
 
     # If wid is idle, but in persistent mode, and its calculated values have
     # returned, give them back to i. Otherwise, give nothing to wid
-    for wid in support.avail_worker_ids(persistent=EVAL_GEN_TAG):
+    for wid in support.avail_gen_worker_ids(persistent=True):
         gen_inds = H["gen_worker"] == wid
         if support.all_sim_ended(H, gen_inds):
             last_time_pos = np.argmax(H["sim_started_time"][gen_inds])

--- a/libensemble/alloc_funcs/start_persistent_local_opt_gens.py
+++ b/libensemble/alloc_funcs/start_persistent_local_opt_gens.py
@@ -90,7 +90,7 @@ def start_persistent_local_opt_gens(W, H, sim_specs, gen_specs, alloc_specs, per
                 break
             points_to_evaluate[sim_ids_to_send] = False
 
-        elif gen_count == 0 and not np.any(np.logical_and((W["active"] == EVAL_GEN_TAG), (W["persis_state"] == 0))):
+        elif gen_count == 0 and not np.any(np.logical_and(W["active"] == EVAL_GEN_TAG, W["persis_state"] == 0)):
             # Finally, generate points since there is nothing else to do (no resource sets req.)
             Work[wid] = support.gen_work(wid, gen_specs.get("in", []), [], persis_info[wid], rset_team=[])
             gen_count += 1

--- a/libensemble/comms/comms.py
+++ b/libensemble/comms/comms.py
@@ -255,9 +255,6 @@ class QCommThread(QCommLocal):
         self.handle.join(timeout=timeout)
         if self.running:
             raise Timeout()
-        self.handle = None
-        self.inbox = None
-        self.outbox = None
 
 
 class QCommProcess(QCommLocal):
@@ -277,6 +274,3 @@ class QCommProcess(QCommLocal):
         self.handle.join(timeout=timeout)
         if self.running:
             raise Timeout()
-        self.handle = None
-        self.inbox = None
-        self.outbox = None

--- a/libensemble/comms/comms.py
+++ b/libensemble/comms/comms.py
@@ -255,6 +255,9 @@ class QCommThread(QCommLocal):
         self.handle.join(timeout=timeout)
         if self.running:
             raise Timeout()
+        self.handle = None
+        self.inbox = None
+        self.outbox = None
 
 
 class QCommProcess(QCommLocal):
@@ -274,3 +277,6 @@ class QCommProcess(QCommLocal):
         self.handle.join(timeout=timeout)
         if self.running:
             raise Timeout()
+        self.handle = None
+        self.inbox = None
+        self.outbox = None

--- a/libensemble/comms/logs.py
+++ b/libensemble/comms/logs.py
@@ -204,7 +204,6 @@ def manager_logging_config(specs={}):
         stat_timer.stop()
         stat_logger.info(f"Exiting ensemble at: {stat_timer.date_end} Time Taken: {stat_timer.elapsed}")
         stat_logger.handlers[0].close()
-        print("Manager logger closed")
 
         # If closing logs - each libE() call will log to a new file.
         # fh.close()

--- a/libensemble/comms/logs.py
+++ b/libensemble/comms/logs.py
@@ -203,6 +203,7 @@ def manager_logging_config(specs={}):
     def exit_logger():
         stat_timer.stop()
         stat_logger.info(f"Exiting ensemble at: {stat_timer.date_end} Time Taken: {stat_timer.elapsed}")
+        stat_logger.handlers[0].close()
 
         # If closing logs - each libE() call will log to a new file.
         # fh.close()

--- a/libensemble/comms/logs.py
+++ b/libensemble/comms/logs.py
@@ -204,6 +204,7 @@ def manager_logging_config(specs={}):
         stat_timer.stop()
         stat_logger.info(f"Exiting ensemble at: {stat_timer.date_end} Time Taken: {stat_timer.elapsed}")
         stat_logger.handlers[0].close()
+        print("Manager logger closed")
 
         # If closing logs - each libE() call will log to a new file.
         # fh.close()

--- a/libensemble/ensemble.py
+++ b/libensemble/ensemble.py
@@ -327,7 +327,7 @@ class Ensemble:
 
         # Cast new libE_specs temporarily to dict
         if not isinstance(new_specs, dict):
-            new_specs = specs_dump(new_specs, by_alias=True, exclude_none=True, exclude_unset=True)
+            new_specs = specs_dump(new_specs, by_alias=True, exclude_none=True, exclude_defaults=True)
 
         # Unset "comms" if we already have a libE_specs that contains that field, that came from parse_args
         if new_specs.get("comms") and hasattr(self._libE_specs, "comms") and self.parsed:

--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -460,6 +460,9 @@ def kill_proc_team(wcomms, timeout):
             wcomm.result(timeout=timeout)
         except Timeout:
             wcomm.terminate()
+        wcomm.handle = None
+        wcomm.inbox = None
+        wcomm.outbox = None
 
 
 def libE_local(sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs, libE_specs, H0):

--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -460,9 +460,6 @@ def kill_proc_team(wcomms, timeout):
             wcomm.result(timeout=timeout)
         except Timeout:
             wcomm.terminate()
-        wcomm.handle = None
-        wcomm.inbox = None
-        wcomm.outbox = None
 
 
 def libE_local(sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs, libE_specs, H0):

--- a/libensemble/manager.py
+++ b/libensemble/manager.py
@@ -665,7 +665,7 @@ class Manager:
 
         alloc_f = self.alloc_specs["alloc_f"]
         output = alloc_f(
-            self.W,
+            self.W.iterable,
             H,
             self.sim_specs,
             self.gen_specs,

--- a/libensemble/manager.py
+++ b/libensemble/manager.py
@@ -302,6 +302,9 @@ class Manager:
         """Kills the workers"""
         for w in self.W["worker_id"]:
             self.wcomms[w].send(STOP_TAG, MAN_SIGNAL_FINISH)
+            if w == 0:
+                self.wcomms[0].result()
+                self.wcomms[0] = None
 
     # --- Checkpointing logic
 
@@ -691,6 +694,7 @@ class Manager:
         finally:
             # Return persis_info, exit_flag, elapsed time
             result = self._final_receive_and_kill(persis_info)
+            self.wcomms = None
             sys.stdout.flush()
             sys.stderr.flush()
         return result

--- a/libensemble/manager.py
+++ b/libensemble/manager.py
@@ -254,6 +254,10 @@ class Manager:
                 if wrk["worker_id"] in gresource.zero_resource_workers:
                     wrk["zero_resource_worker"] = True
 
+        for wrk in self.W:
+            if wrk["worker_id"] in self.libE_specs.get("gen_workers", []):
+                wrk["gen_worker"] = True
+
         try:
             temp_EnsembleDirectory.make_copyback()
         except AssertionError as e:  # Ensemble dir exists and isn't empty.

--- a/libensemble/manager.py
+++ b/libensemble/manager.py
@@ -166,6 +166,9 @@ class _WorkerIndexer:
         else:
             return self.iterable[key - 1]
 
+    def __setitem__(self, key, value):
+        self.iterable[key] = value
+
     def __len__(self):
         return len(self.iterable)
 

--- a/libensemble/manager.py
+++ b/libensemble/manager.py
@@ -622,7 +622,7 @@ class Manager:
             "use_resource_sets": self.use_resource_sets,
             "gen_num_procs": self.gen_num_procs,
             "gen_num_gpus": self.gen_num_gpus,
-            "manager_additional_worker": self.libE_specs.get("manager_runs_additional_worker", False),
+            "manager_runs_additional_worker": self.libE_specs.get("manager_runs_additional_worker", False),
             "gen_on_manager": self.libE_specs.get("gen_on_manager", False),
         }
 

--- a/libensemble/manager.py
+++ b/libensemble/manager.py
@@ -166,6 +166,12 @@ class _WorkerIndexer:
         else:
             return self.iterable[key - 1]
 
+    def __len__(self):
+        return len(self.iterable)
+
+    def __iter__(self):
+        return iter(self.iterable)
+
 
 class Manager:
     """Manager class for libensemble."""
@@ -256,7 +262,7 @@ class Manager:
         if self.resources is not None:
             gresource = self.resources.glob_resources
             self.scheduler_opts = gresource.update_scheduler_opts(self.scheduler_opts)
-            for wrk in self.W.iterable:  # "for wrk in self.W" produces a key of 0 when not applicable
+            for wrk in self.W:
                 if wrk["worker_id"] in gresource.zero_resource_workers:
                     wrk["zero_resource_worker"] = True
 

--- a/libensemble/manager.py
+++ b/libensemble/manager.py
@@ -256,7 +256,7 @@ class Manager:
         if self.resources is not None:
             gresource = self.resources.glob_resources
             self.scheduler_opts = gresource.update_scheduler_opts(self.scheduler_opts)
-            for wrk in self.W.iterable:
+            for wrk in self.W.iterable:  # "for wrk in self.W" produces a key of 0 when not applicable
                 if wrk["worker_id"] in gresource.zero_resource_workers:
                     wrk["zero_resource_worker"] = True
 

--- a/libensemble/manager.py
+++ b/libensemble/manager.py
@@ -185,6 +185,8 @@ class Manager:
         )
         local_worker_comm.run()
         local_worker_comm.send(0, dtypes)
+        if libE_specs.get("use_workflow_dir"):
+            local_worker_comm.send(0, libE_specs.get("workflow_dir_path"))
         return local_worker_comm
 
     def __init__(

--- a/libensemble/manager.py
+++ b/libensemble/manager.py
@@ -159,9 +159,9 @@ class Manager:
 
     worker_dtype = [
         ("worker_id", int),
-        ("worker_type", int),
+        ("gen_worker", bool),
         ("active", int),
-        ("persistent", bool),
+        ("persis_state", int),
         ("active_recv", bool),
         ("gen_started_time", float),
         ("zero_resource_worker", bool),
@@ -235,7 +235,7 @@ class Manager:
         self.W = np.zeros(len(self.wcomms) + gen_on_manager, dtype=Manager.worker_dtype)
         if gen_on_manager:
             self.W["worker_id"] = np.arange(len(self.wcomms) + 1)  # [0, 1, 2, ...]
-            self.W[0]["worker_type"] = EVAL_GEN_TAG
+            self.W[0]["gen_worker"] = True
             local_worker_comm = self._run_additional_worker(hist, sim_specs, gen_specs, libE_specs)
             self.wcomms = [local_worker_comm] + self.wcomms
         else:
@@ -428,9 +428,8 @@ class Manager:
         """Updates a workers' active/idle status following an allocation order"""
 
         self.W[w]["active"] = Work["tag"]
-        self.W[w]["worker_type"] = Work["tag"]
         if "persistent" in Work["libE_info"]:
-            self.W[w]["persistent"] = True
+            self.W[w]["persis_state"] = Work["tag"]
             if Work["libE_info"].get("active_recv", False):
                 self.W[w]["active_recv"] = True
         else:
@@ -480,7 +479,7 @@ class Manager:
                     self.hist.update_history_f(D_recv, self.kill_canceled_sims)
                 else:
                     logger.info(_PERSIS_RETURN_WARNING)
-            self.W[w]["persistent"] = False
+            self.W[w]["persis_state"] = 0
             if self.W[w]["active_recv"]:
                 self.W[w]["active"] = 0
                 self.W[w]["active_recv"] = False
@@ -494,11 +493,11 @@ class Manager:
             if calc_type == EVAL_GEN_TAG:
                 self.hist.update_history_x_in(w, D_recv["calc_out"], self.W[w]["gen_started_time"])
                 assert (
-                    len(D_recv["calc_out"]) or np.any(self.W["active"]) or self.W[w]["persistent"]
+                    len(D_recv["calc_out"]) or np.any(self.W["active"]) or self.W[w]["persis_state"]
                 ), "Gen must return work when is is the only thing active and not persistent."
             if "libE_info" in D_recv and "persistent" in D_recv["libE_info"]:
                 # Now a waiting, persistent worker
-                self.W[w]["persistent"] = True
+                self.W[w]["persis_state"] = D_recv["calc_type"]
             else:
                 self._freeup_resources(w)
 
@@ -562,8 +561,8 @@ class Manager:
         """
 
         # Send a handshake signal to each persistent worker.
-        if any(self.W["persistent"]):
-            for w in self.W["worker_id"][self.W["persistent"]]:
+        if any(self.W["persis_state"]):
+            for w in self.W["worker_id"][self.W["persis_state"] > 0]:
                 logger.debug(f"Manager sending PERSIS_STOP to worker {w}")
                 if self.libE_specs.get("final_gen_send", False):
                     rows_to_send = np.where(self.hist.H["sim_ended"] & ~self.hist.H["gen_informed"])[0]
@@ -580,15 +579,15 @@ class Manager:
                     self.wcomms[w].send(PERSIS_STOP, MAN_SIGNAL_KILL)
                 if not self.W[w]["active"]:
                     # Re-activate if necessary
-                    self.W[w]["active"] = self.W[w]["worker_type"] if self.W[w]["persistent"] else 0
+                    self.W[w]["active"] = self.W[w]["persis_state"]
                 self.persis_pending.append(w)
 
         exit_flag = 0
-        while (any(self.W["active"]) or any(self.W["persistent"])) and exit_flag == 0:
+        while (any(self.W["active"]) or any(self.W["persis_state"])) and exit_flag == 0:
             persis_info = self._receive_from_workers(persis_info)
             if self.term_test(logged=False) == 2:
                 # Elapsed Wallclock has expired
-                if not any(self.W["persistent"]):
+                if not any(self.W["persis_state"]):
                     if any(self.W["active"]):
                         logger.manager_warning(_WALLCLOCK_MSG_ACTIVE)
                     else:
@@ -611,7 +610,7 @@ class Manager:
         """Selected statistics useful for alloc_f"""
 
         return {
-            "any_idle_workers": any(~self.W["active"]),
+            "any_idle_workers": any(self.W["active"] == 0),
             "exit_criteria": self.exit_criteria,
             "elapsed_time": self.elapsed(),
             "gen_informed_count": self.hist.gen_informed_count,
@@ -681,7 +680,7 @@ class Manager:
                     self._send_work_order(Work[w], w)
                     self._update_state_on_alloc(Work[w], w)
                 assert self.term_test() or any(
-                    self.W["active"]
+                    self.W["active"] != 0
                 ), "alloc_f did not return any work, although all workers are idle."
         except WorkerException as e:
             report_worker_exc(e)

--- a/libensemble/manager.py
+++ b/libensemble/manager.py
@@ -304,7 +304,6 @@ class Manager:
             self.wcomms[w].send(STOP_TAG, MAN_SIGNAL_FINISH)
             if w == 0:
                 self.wcomms[0].result()
-                self.wcomms[0] = None
 
     # --- Checkpointing logic
 

--- a/libensemble/manager.py
+++ b/libensemble/manager.py
@@ -34,7 +34,7 @@ from libensemble.message_numbers import (
 from libensemble.resources.resources import Resources
 from libensemble.tools.fields_keys import protected_libE_fields
 from libensemble.tools.tools import _PERSIS_RETURN_WARNING, _USER_CALC_DIR_WARNING
-from libensemble.utils.misc import extract_H_ranges
+from libensemble.utils.misc import _WorkerIndexer, extract_H_ranges
 from libensemble.utils.output_directory import EnsembleDirectory
 from libensemble.utils.timer import Timer
 from libensemble.worker import WorkerErrMsg, worker_main
@@ -152,27 +152,6 @@ Termination due to wallclock_max has occurred.
 Some issued work has not been returned.
 Posting kill messages for all workers.
 """
-
-
-class _WorkerIndexer:
-    def __init__(self, iterable: list, additional_worker=False):
-        self.iterable = iterable
-        self.additional_worker = additional_worker
-
-    def __getitem__(self, key):
-        if self.additional_worker or isinstance(key, str):
-            return self.iterable[key]
-        else:
-            return self.iterable[key - 1]
-
-    def __setitem__(self, key, value):
-        self.iterable[key] = value
-
-    def __len__(self):
-        return len(self.iterable)
-
-    def __iter__(self):
-        return iter(self.iterable)
 
 
 class Manager:

--- a/libensemble/resources/scheduler.py
+++ b/libensemble/resources/scheduler.py
@@ -245,7 +245,7 @@ class ResourceScheduler:
             for g in groups:
                 self.avail_rsets_by_group[g] = []
             for ind, rset in enumerate(rsets):
-                if rset["assigned"] == -1:  # now default is -1.
+                if not rset["assigned"]:
                     g = rset["group"]
                     self.avail_rsets_by_group[g].append(ind)
         return self.avail_rsets_by_group

--- a/libensemble/resources/worker_resources.py
+++ b/libensemble/resources/worker_resources.py
@@ -50,10 +50,11 @@ class ResourceManager(RSetResources):
         )
 
         self.rsets = np.zeros(self.total_num_rsets, dtype=ResourceManager.man_rset_dtype)
-        self.rsets["assigned"] = -1  # Can assign to manager (=0) so make unset value -1
+        self.rsets["assigned"] = 0
         for field in self.all_rsets.dtype.names:
             self.rsets[field] = self.all_rsets[field]
         self.num_groups = self.rsets["group"][-1]
+
         self.rsets_free = self.total_num_rsets
         self.gpu_rsets_free = self.total_num_gpu_rsets
         self.nongpu_rsets_free = self.total_num_nongpu_rsets
@@ -69,7 +70,7 @@ class ResourceManager(RSetResources):
         if rset_team:
             rteam = self.rsets["assigned"][rset_team]
             for i, wid in enumerate(rteam):
-                if wid == -1:
+                if wid == 0:
                     self.rsets["assigned"][rset_team[i]] = worker_id
                     self.rsets_free -= 1
                     if self.rsets["gpus"][rset_team[i]]:
@@ -84,13 +85,13 @@ class ResourceManager(RSetResources):
     def free_rsets(self, worker=None):
         """Free up assigned resource sets"""
         if worker is None:
-            self.rsets["assigned"] = -1
+            self.rsets["assigned"] = 0
             self.rsets_free = self.total_num_rsets
             self.gpu_rsets_free = self.total_num_gpu_rsets
             self.nongpu_rsets_free = self.total_num_nongpu_rsets
         else:
             rsets_to_free = np.where(self.rsets["assigned"] == worker)[0]
-            self.rsets["assigned"][rsets_to_free] = -1
+            self.rsets["assigned"][rsets_to_free] = 0
             self.rsets_free += len(rsets_to_free)
             self.gpu_rsets_free += np.count_nonzero(self.rsets["gpus"][rsets_to_free])
             self.nongpu_rsets_free += np.count_nonzero(~self.rsets["gpus"][rsets_to_free])
@@ -199,6 +200,7 @@ class WorkerResources(RSetResources):
         self.gen_nprocs = None
         self.gen_ngpus = None
         self.platform_info = resources.platform_info
+        self.tiles_per_gpu = resources.tiles_per_gpu
 
     # User convenience functions ----------------------------------------------
 
@@ -216,6 +218,9 @@ class WorkerResources(RSetResources):
         slot_list = [j for i in self.slots_on_node for j in range(i * n, (i + 1) * n)]
         if limit is not None:
             slot_list = slot_list[:limit]
+        if self.tiles_per_gpu > 1:
+            ntiles = self.tiles_per_gpu
+            slot_list = [f"{i // ntiles}.{i % ntiles}" for i in slot_list]
         slots = delimiter.join(map(str, slot_list))
         return slots
 

--- a/libensemble/specs.py
+++ b/libensemble/specs.py
@@ -457,6 +457,12 @@ class LibeSpecs(BaseModel):
     For use with supported allocation functions.
     """
 
+    gen_workers: Optional[List[int]] = []
+    """
+    List of workers that should only run generators. All other workers will only
+    run simulator functions.
+    """
+
     resource_info: Optional[dict] = {}
     """
     Resource information to override automatically detected resources.

--- a/libensemble/specs.py
+++ b/libensemble/specs.py
@@ -172,8 +172,13 @@ class LibeSpecs(BaseModel):
     nworkers: Optional[int] = 0
     """ Number of worker processes in ``"local"``, ``"threads"``, or ``"tcp"``."""
 
-    manager_runs_additional_worker: Optional[int] = False
-    """ Manager process can launch an additional threaded worker """
+    manager_runs_additional_worker: Optional[bool] = False
+    """ Manager process launches an additional threaded Worker 0.
+    This worker can access/modify user objects by reference.
+    """
+
+    gen_on_manager: Optional[bool] = False
+    """ Enable ``manager_runs_additional_worker`` and reserve that worker for a single generator. """
 
     mpi_comm: Optional[Any] = None
     """ libEnsemble MPI communicator. Default: ``MPI.COMM_WORLD``"""

--- a/libensemble/specs.py
+++ b/libensemble/specs.py
@@ -172,13 +172,10 @@ class LibeSpecs(BaseModel):
     nworkers: Optional[int] = 0
     """ Number of worker processes in ``"local"``, ``"threads"``, or ``"tcp"``."""
 
-    manager_runs_additional_worker: Optional[bool] = False
-    """ Manager process launches an additional threaded Worker 0.
-    This worker can access/modify user objects by reference.
-    """
-
     gen_on_manager: Optional[bool] = False
-    """ Enable ``manager_runs_additional_worker`` and reserve that worker for a single generator. """
+    """ Instructs Manager process to run generator functions.
+    This generator function can access/modify user objects by reference.
+    """
 
     mpi_comm: Optional[Any] = None
     """ libEnsemble MPI communicator. Default: ``MPI.COMM_WORLD``"""

--- a/libensemble/tests/functionality_tests/check_libE_stats.py
+++ b/libensemble/tests/functionality_tests/check_libE_stats.py
@@ -39,11 +39,10 @@ def check_start_end_times(start="Start:", end="End:", everyline=True):
     with open(infile) as f:
         total_cnt = 0
         for line in f:
-            print(line)
             s_cnt = 0
             e_cnt = 0
             lst = line.split()
-            if lst[0] == "Manager":
+            if line.startswith("Manager     : Starting") or line.startswith("Manager     : Exiting"):
                 check_datetime(lst[5], lst[6])
                 continue
             for i, val in enumerate(lst):

--- a/libensemble/tests/functionality_tests/check_libE_stats.py
+++ b/libensemble/tests/functionality_tests/check_libE_stats.py
@@ -39,6 +39,7 @@ def check_start_end_times(start="Start:", end="End:", everyline=True):
     with open(infile) as f:
         total_cnt = 0
         for line in f:
+            print(line)
             s_cnt = 0
             e_cnt = 0
             lst = line.split()

--- a/libensemble/tests/functionality_tests/test_GPU_gen_resources.py
+++ b/libensemble/tests/functionality_tests/test_GPU_gen_resources.py
@@ -42,6 +42,12 @@ from libensemble.sim_funcs import six_hump_camel
 from libensemble.sim_funcs.var_resources import gpu_variable_resources_from_gen as sim_f
 from libensemble.tools import add_unique_random_streams, parse_args
 
+# TODO: multiple libE calls with gen-on-manager currently not supported with spawn on macOS
+if sys.platform == "darwin":
+    from multiprocessing import set_start_method
+
+    set_start_method("fork", force=True)
+
 # from libensemble import logger
 # logger.set_level("DEBUG")  # For testing the test
 
@@ -100,30 +106,32 @@ if __name__ == "__main__":
     libE_specs["resource_info"] = {"cores_on_node": (nworkers * 2, nworkers * 4), "gpus_on_node": nworkers}
 
     base_libE_specs = libE_specs.copy()
-    for run in range(5):
-        # reset
-        libE_specs = base_libE_specs.copy()
-        persis_info = add_unique_random_streams({}, nworkers + 1)
+    for gen_on_manager in [False, True]:
+        for run in range(5):
+            # reset
+            libE_specs = base_libE_specs.copy()
+            libE_specs["gen_on_manager"] = gen_on_manager
+            persis_info = add_unique_random_streams({}, nworkers + 1)
 
-        if run == 0:
-            libE_specs["gen_num_procs"] = 2
-        elif run == 1:
-            libE_specs["gen_num_gpus"] = 1
-        elif run == 2:
-            persis_info["gen_num_gpus"] = 1
-        elif run == 3:
-            # Two GPUs per resource set
-            libE_specs["resource_info"]["gpus_on_node"] = nworkers * 2
-            persis_info["gen_num_gpus"] = 1
-        elif run == 4:
-            # Two GPUs requested for gen
-            persis_info["gen_num_procs"] = 2
-            persis_info["gen_num_gpus"] = 2
-            gen_specs["user"]["max_procs"] = max(nworkers - 2, 1)
+            if run == 0:
+                libE_specs["gen_num_procs"] = 2
+            elif run == 1:
+                libE_specs["gen_num_gpus"] = 1
+            elif run == 2:
+                persis_info["gen_num_gpus"] = 1
+            elif run == 3:
+                # Two GPUs per resource set
+                libE_specs["resource_info"]["gpus_on_node"] = nworkers * 2
+                persis_info["gen_num_gpus"] = 1
+            elif run == 4:
+                # Two GPUs requested for gen
+                persis_info["gen_num_procs"] = 2
+                persis_info["gen_num_gpus"] = 2
+                gen_specs["user"]["max_procs"] = max(nworkers - 2, 1)
 
-        # Perform the run
-        H, persis_info, flag = libE(
-            sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs, alloc_specs=alloc_specs
-        )
+            # Perform the run
+            H, persis_info, flag = libE(
+                sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs, alloc_specs=alloc_specs
+            )
 
 # All asserts are in gen and sim funcs

--- a/libensemble/tests/functionality_tests/test_GPU_gen_resources.py
+++ b/libensemble/tests/functionality_tests/test_GPU_gen_resources.py
@@ -110,6 +110,8 @@ if __name__ == "__main__":
             if run == 0:
                 libE_specs["gen_num_procs"] = 2
             elif run == 1:
+                if gen_on_manager:
+                    print("SECOND LIBE CALL WITH GEN ON MANAGER")
                 libE_specs["gen_num_gpus"] = 1
             elif run == 2:
                 persis_info["gen_num_gpus"] = 1

--- a/libensemble/tests/functionality_tests/test_GPU_gen_resources.py
+++ b/libensemble/tests/functionality_tests/test_GPU_gen_resources.py
@@ -42,12 +42,6 @@ from libensemble.sim_funcs import six_hump_camel
 from libensemble.sim_funcs.var_resources import gpu_variable_resources_from_gen as sim_f
 from libensemble.tools import add_unique_random_streams, parse_args
 
-# TODO: multiple libE calls with gen-on-manager currently not supported with spawn on macOS
-if sys.platform == "darwin":
-    from multiprocessing import set_start_method
-
-    set_start_method("fork", force=True)
-
 # from libensemble import logger
 # logger.set_level("DEBUG")  # For testing the test
 

--- a/libensemble/tests/functionality_tests/test_evaluate_existing_plus_gen.py
+++ b/libensemble/tests/functionality_tests/test_evaluate_existing_plus_gen.py
@@ -66,5 +66,5 @@ if __name__ == "__main__":
         assert np.array_equal(sampling.H0["x"][:50], sampling.H["x"][:50])
         assert np.all(sampling.H["sim_ended"])
         assert np.all(sampling.H["gen_worker"] == 0)
-        print("\nlibEnsemble correctly didn't add anything to initial sample")
+        print("\nlibEnsemble correctly appended to the initial sample via an additional gen.")
         sampling.save_output(__file__)

--- a/libensemble/tests/functionality_tests/test_evaluate_existing_plus_gen.py
+++ b/libensemble/tests/functionality_tests/test_evaluate_existing_plus_gen.py
@@ -1,5 +1,5 @@
 """
-Test libEnsemble's capability to evalute existing points and then generate
+Test libEnsemble's capability to evaluate existing points and then generate
 new samples via gen_on_manager.
 
 Execute via one of the following commands (e.g. 3 workers):

--- a/libensemble/tests/functionality_tests/test_evaluate_existing_plus_gen.py
+++ b/libensemble/tests/functionality_tests/test_evaluate_existing_plus_gen.py
@@ -1,0 +1,70 @@
+"""
+Test libEnsemble's capability to evalute existing points and then generate
+new samples via gen_on_manager.
+
+Execute via one of the following commands (e.g. 3 workers):
+   mpiexec -np 4 python test_evaluate_existing_sample.py
+   python test_evaluate_existing_sample.py --nworkers 3 --comms local
+   python test_evaluate_existing_sample.py --nworkers 3 --comms tcp
+
+The number of concurrent evaluations of the objective function will be 4-1=3.
+"""
+
+# Do not change these lines - they are parsed by run-tests.sh
+# TESTSUITE_COMMS: mpi local tcp
+# TESTSUITE_NPROCS: 2 4
+
+import numpy as np
+
+# Import libEnsemble items for this test
+from libensemble import Ensemble
+from libensemble.gen_funcs.sampling import latin_hypercube_sample as gen_f
+from libensemble.sim_funcs.six_hump_camel import six_hump_camel as sim_f
+from libensemble.specs import ExitCriteria, GenSpecs, SimSpecs
+from libensemble.tools import add_unique_random_streams
+
+
+def create_H0(persis_info, gen_specs, H0_size):
+    """Create an H0 for give_pregenerated_sim_work"""
+    # Manually creating H0
+    ub = gen_specs["user"]["ub"]
+    lb = gen_specs["user"]["lb"]
+    n = len(lb)
+    b = H0_size
+
+    H0 = np.zeros(b, dtype=[("x", float, 2), ("sim_id", int), ("sim_started", bool)])
+    H0["x"] = persis_info[0]["rand_stream"].uniform(lb, ub, (b, n))
+    H0["sim_id"] = range(b)
+    H0["sim_started"] = False
+    return H0
+
+
+# Main block is necessary only when using local comms with spawn start method (default on macOS and Windows).
+if __name__ == "__main__":
+
+    sampling = Ensemble(parse_args=True)
+    sampling.libE_specs.gen_on_manager = True
+    sampling.sim_specs = SimSpecs(sim_f=sim_f, inputs=["x"], out=[("f", float)])
+
+    gen_specs = {
+        "gen_f": gen_f,
+        "outputs": [("x", float, (2,))],
+        "user": {
+            "gen_batch_size": 50,
+            "lb": np.array([-3, -3]),
+            "ub": np.array([3, 3]),
+        },
+    }
+    sampling.gen_specs = GenSpecs(**gen_specs)
+    sampling.exit_criteria = ExitCriteria(sim_max=100)
+    sampling.persis_info = add_unique_random_streams({}, sampling.nworkers + 1)
+    sampling.H0 = create_H0(sampling.persis_info, gen_specs, 50)
+    sampling.run()
+
+    if sampling.is_manager:
+        assert len(sampling.H) == 2 * len(sampling.H0)
+        assert np.array_equal(sampling.H0["x"][:50], sampling.H["x"][:50])
+        assert np.all(sampling.H["sim_ended"])
+        assert np.all(sampling.H["gen_worker"] == 0)
+        print("\nlibEnsemble correctly didn't add anything to initial sample")
+        sampling.save_output(__file__)

--- a/libensemble/tests/functionality_tests/test_persistent_uniform_sampling.py
+++ b/libensemble/tests/functionality_tests/test_persistent_uniform_sampling.py
@@ -87,7 +87,7 @@ if __name__ == "__main__":
             sim_specs["in"] = ["x", "obj_component"]
             # sim_specs["out"] = [("f", float), ("grad", float, n)]
         elif run == 3:
-            libE_specs["manager_runs_additional_worker"] = True
+            libE_specs["gen_on_manager"] = True
 
         # Perform the run
         H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs, libE_specs)

--- a/libensemble/tests/functionality_tests/test_persistent_uniform_sampling.py
+++ b/libensemble/tests/functionality_tests/test_persistent_uniform_sampling.py
@@ -62,7 +62,7 @@ if __name__ == "__main__":
 
     libE_specs["kill_canceled_sims"] = False
 
-    for run in range(4):
+    for run in range(5):
         persis_info = add_unique_random_streams({}, nworkers + 1)
         for i in persis_info:
             persis_info[i]["get_grad"] = True
@@ -88,6 +88,9 @@ if __name__ == "__main__":
             # sim_specs["out"] = [("f", float), ("grad", float, n)]
         elif run == 3:
             libE_specs["gen_on_manager"] = True
+        elif run == 4:
+            libE_specs["gen_on_manager"] = False
+            libE_specs["gen_workers"] = [2]
 
         # Perform the run
         H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs, libE_specs)

--- a/libensemble/tests/regression_tests/test_evaluate_mixed_sample.py
+++ b/libensemble/tests/regression_tests/test_evaluate_mixed_sample.py
@@ -44,6 +44,7 @@ if __name__ == "__main__":
     H0["sim_ended"][:500] = True
 
     sampling = Ensemble(parse_args=True)
+    sampling.libE_specs.gen_on_manager = True
     sampling.H0 = H0
     sampling.sim_specs = SimSpecs(sim_f=sim_f, inputs=["x"], out=[("f", float)])
     sampling.alloc_specs = AllocSpecs(alloc_f=alloc_f)

--- a/libensemble/tests/unit_tests/test_allocation_funcs_and_support.py
+++ b/libensemble/tests/unit_tests/test_allocation_funcs_and_support.py
@@ -108,7 +108,7 @@ def test_als_worker_ids():
     W_ps = W.copy()
     W_ps["persis_state"] = np.array([EVAL_GEN_TAG, 0, 0, 0])
     als = AllocSupport(W_ps, True)
-    assert als.avail_worker_ids(persistent=True) == [
+    assert als.avail_worker_ids(persistent=EVAL_GEN_TAG) == [
         1
     ], "avail_worker_ids() didn't return expected persistent worker list."
 
@@ -116,7 +116,7 @@ def test_als_worker_ids():
     W_ar["active_recv"] = np.array([True, 0, 0, 0])
     W_ar["persis_state"] = np.array([EVAL_GEN_TAG, 0, 0, 0])
     als = AllocSupport(W_ar, True)
-    assert als.avail_worker_ids(persistent=True, active_recv=True) == [
+    assert als.avail_worker_ids(persistent=EVAL_GEN_TAG, active_recv=True) == [
         1
     ], "avail_worker_ids() didn't return expected persistent worker list."
 
@@ -138,7 +138,6 @@ def test_als_worker_ids():
 def test_als_evaluate_gens():
     W_gens = W.copy()
     W_gens["active"] = np.array([EVAL_GEN_TAG, 0, EVAL_GEN_TAG, 0])
-    W_gens["worker_type"] = np.array([EVAL_GEN_TAG, 0, EVAL_GEN_TAG, 0])
     als = AllocSupport(W_gens, True)
     assert als.count_gens() == 2, "count_gens() didn't return correct number of active generators"
 

--- a/libensemble/tests/unit_tests/test_allocation_funcs_and_support.py
+++ b/libensemble/tests/unit_tests/test_allocation_funcs_and_support.py
@@ -21,7 +21,7 @@ W = np.array(
     dtype=[
         ("worker_id", "<i8"),
         ("worker_type", "<i8"),
-        ("active", "?"),
+        ("active", "<i8"),
         ("persistent", "?"),
         ("active_recv", "?"),
         ("zero_resource_worker", "?"),

--- a/libensemble/tests/unit_tests/test_allocation_funcs_and_support.py
+++ b/libensemble/tests/unit_tests/test_allocation_funcs_and_support.py
@@ -18,12 +18,17 @@ libE_specs = {"comms": "local", "nworkers": 4}
 H0 = []
 
 W = np.array(
-    [(1, 0, 0, 0, 0, False), (2, 0, 0, 0, 0, False), (3, 0, 0, 0, 0, False), (4, 0, 0, 0, 0, False)],
+    [
+        (1, False, 0, 0, False, False),
+        (2, False, 0, 0, False, False),
+        (3, False, 0, 0, False, False),
+        (4, False, 0, 0, False, False),
+    ],
     dtype=[
         ("worker_id", "<i8"),
-        ("worker_type", "<i8"),
+        ("gen_worker", "?"),
         ("active", "<i8"),
-        ("persistent", "?"),
+        ("persis_state", "<i8"),
         ("active_recv", "?"),
         ("zero_resource_worker", "?"),
     ],
@@ -101,7 +106,7 @@ def test_als_worker_ids():
     assert als.avail_worker_ids() == [1, 2, 3, 4], "avail_worker_ids() didn't return expected available worker list."
 
     W_ps = W.copy()
-    W_ps["persistent"] = np.array([True, 0, 0, 0])
+    W_ps["persis_state"] = np.array([EVAL_GEN_TAG, 0, 0, 0])
     als = AllocSupport(W_ps, True)
     assert als.avail_worker_ids(persistent=True) == [
         1
@@ -109,7 +114,7 @@ def test_als_worker_ids():
 
     W_ar = W.copy()
     W_ar["active_recv"] = np.array([True, 0, 0, 0])
-    W_ar["persistent"] = np.array([True, 0, 0, 0])
+    W_ar["persis_state"] = np.array([EVAL_GEN_TAG, 0, 0, 0])
     als = AllocSupport(W_ar, True)
     assert als.avail_worker_ids(persistent=True, active_recv=True) == [
         1
@@ -139,7 +144,7 @@ def test_als_evaluate_gens():
 
     assert als.test_any_gen(), "test_any_gen() didn't return True on a generator worker being active."
 
-    W_gens["persistent"] = np.array([True, 0, 0, 0])
+    W_gens["persis_state"] = np.array([EVAL_GEN_TAG, 0, 0, 0])
 
     assert (
         als.count_persis_gens() == 1
@@ -166,7 +171,7 @@ def test_als_sim_work():
     ), "H_rows weren't assigned to libE_info correctly."
 
     W_ps = W.copy()
-    W_ps["persistent"] = np.array([True, 0, 0, 0])
+    W_ps["persis_state"] = np.array([EVAL_GEN_TAG, 0, 0, 0])
     W_ps["zero_resource_worker"] = np.array([True, 0, 0, 0])
     als = AllocSupport(_WorkerIndexer(W_ps, False), True)
     Work = {}
@@ -204,7 +209,7 @@ def test_als_gen_work():
     ), "H_rows weren't assigned to libE_info correctly."
 
     W_ps = W.copy()
-    W_ps["persistent"] = np.array([True, 0, 0, 0])
+    W_ps["persis_state"] = np.array([EVAL_GEN_TAG, 0, 0, 0])
     als = AllocSupport(_WorkerIndexer(W_ps, False), True)
     Work = {}
     Work[1] = als.gen_work(1, ["sim_id"], range(0, 5), persis_info[1], persistent=True)

--- a/libensemble/tests/unit_tests/test_allocation_funcs_and_support.py
+++ b/libensemble/tests/unit_tests/test_allocation_funcs_and_support.py
@@ -11,6 +11,7 @@ from libensemble.resources.scheduler import InsufficientResourcesError, Resource
 from libensemble.tools import add_unique_random_streams
 from libensemble.tools.alloc_support import AllocException, AllocSupport
 from libensemble.tools.fields_keys import libE_fields
+from libensemble.utils.misc import _WorkerIndexer
 
 al = {"alloc_f": give_sim_work_first}
 libE_specs = {"comms": "local", "nworkers": 4}
@@ -58,7 +59,7 @@ def test_decide_work_and_resources():
     libE_info = {"sim_max_given": False, "any_idle_workers": True, "use_resource_sets": False}
 
     # Don't give out work when all workers are active
-    W["active"] = True
+    W["active"] = 1
     Work, persis_info = al["alloc_f"](W, hist.H, sim_specs, gen_specs, al, {}, libE_info)
     assert len(Work) == 0
 
@@ -131,8 +132,8 @@ def test_als_worker_ids():
 
 def test_als_evaluate_gens():
     W_gens = W.copy()
-    W_gens["active"] = np.array([True, 0, True, 0])
-    W_gens["worker_type"] = np.array([2, 0, 2, 0])
+    W_gens["active"] = np.array([EVAL_GEN_TAG, 0, EVAL_GEN_TAG, 0])
+    W_gens["worker_type"] = np.array([EVAL_GEN_TAG, 0, EVAL_GEN_TAG, 0])
     als = AllocSupport(W_gens, True)
     assert als.count_gens() == 2, "count_gens() didn't return correct number of active generators"
 
@@ -166,7 +167,8 @@ def test_als_sim_work():
 
     W_ps = W.copy()
     W_ps["persistent"] = np.array([True, 0, 0, 0])
-    als = AllocSupport(W_ps, True)
+    W_ps["zero_resource_worker"] = np.array([True, 0, 0, 0])
+    als = AllocSupport(_WorkerIndexer(W_ps, False), True)
     Work = {}
     Work[1] = als.sim_work(1, H, ["x"], np.array([0, 1, 2, 3, 4]), persis_info[1], persistent=True)
 
@@ -203,7 +205,7 @@ def test_als_gen_work():
 
     W_ps = W.copy()
     W_ps["persistent"] = np.array([True, 0, 0, 0])
-    als = AllocSupport(W_ps, True)
+    als = AllocSupport(_WorkerIndexer(W_ps, False), True)
     Work = {}
     Work[1] = als.gen_work(1, ["sim_id"], range(0, 5), persis_info[1], persistent=True)
 

--- a/libensemble/tests/unit_tests/test_allocation_funcs_and_support.py
+++ b/libensemble/tests/unit_tests/test_allocation_funcs_and_support.py
@@ -17,12 +17,13 @@ libE_specs = {"comms": "local", "nworkers": 4}
 H0 = []
 
 W = np.array(
-    [(1, 0, 0, 0, False), (2, 0, 0, 0, False), (3, 0, 0, 0, False), (4, 0, 0, 0, False)],
+    [(1, 0, 0, 0, 0, False), (2, 0, 0, 0, 0, False), (3, 0, 0, 0, 0, False), (4, 0, 0, 0, 0, False)],
     dtype=[
         ("worker_id", "<i8"),
-        ("active", "<i8"),
-        ("persis_state", "<i8"),
-        ("active_recv", "<i8"),
+        ("worker_type", "<i8"),
+        ("active", "?"),
+        ("persistent", "?"),
+        ("active_recv", "?"),
         ("zero_resource_worker", "?"),
     ],
 )
@@ -57,7 +58,7 @@ def test_decide_work_and_resources():
     libE_info = {"sim_max_given": False, "any_idle_workers": True, "use_resource_sets": False}
 
     # Don't give out work when all workers are active
-    W["active"] = 1
+    W["active"] = True
     Work, persis_info = al["alloc_f"](W, hist.H, sim_specs, gen_specs, al, {}, libE_info)
     assert len(Work) == 0
 
@@ -99,17 +100,17 @@ def test_als_worker_ids():
     assert als.avail_worker_ids() == [1, 2, 3, 4], "avail_worker_ids() didn't return expected available worker list."
 
     W_ps = W.copy()
-    W_ps["persis_state"] = np.array([2, 0, 0, 0])
+    W_ps["persistent"] = np.array([True, 0, 0, 0])
     als = AllocSupport(W_ps, True)
-    assert als.avail_worker_ids(persistent=2) == [
+    assert als.avail_worker_ids(persistent=True) == [
         1
     ], "avail_worker_ids() didn't return expected persistent worker list."
 
     W_ar = W.copy()
-    W_ar["active_recv"] = np.array([1, 0, 0, 0])
-    W_ar["persis_state"] = np.array([2, 0, 0, 0])
+    W_ar["active_recv"] = np.array([True, 0, 0, 0])
+    W_ar["persistent"] = np.array([True, 0, 0, 0])
     als = AllocSupport(W_ar, True)
-    assert als.avail_worker_ids(persistent=2, active_recv=True) == [
+    assert als.avail_worker_ids(persistent=True, active_recv=True) == [
         1
     ], "avail_worker_ids() didn't return expected persistent worker list."
 
@@ -120,16 +121,8 @@ def test_als_worker_ids():
         flag = 0
     assert flag == 0, "AllocSupport didn't error on invalid options for avail_worker_ids()"
 
-    W_ar = W.copy()
-    W_ar["active_recv"] = np.array([1, 0, 0, 0])
-    W_ar["persis_state"] = np.array([2, 0, 0, 0])
-    als = AllocSupport(W_ar, True)
-    assert als.avail_worker_ids(persistent=EVAL_GEN_TAG, active_recv=True) == [
-        1
-    ], "avail_worker_ids() didn't return expected persistent worker list."
-
     W_zrw = W.copy()
-    W_zrw["zero_resource_worker"] = np.array([1, 0, 0, 0])
+    W_zrw["zero_resource_worker"] = np.array([True, 0, 0, 0])
     als = AllocSupport(W_zrw, True)
     assert als.avail_worker_ids(zero_resource_workers=True) == [
         1
@@ -138,13 +131,14 @@ def test_als_worker_ids():
 
 def test_als_evaluate_gens():
     W_gens = W.copy()
-    W_gens["active"] = np.array([2, 0, 2, 0])
+    W_gens["active"] = np.array([True, 0, True, 0])
+    W_gens["worker_type"] = np.array([2, 0, 2, 0])
     als = AllocSupport(W_gens, True)
     assert als.count_gens() == 2, "count_gens() didn't return correct number of active generators"
 
     assert als.test_any_gen(), "test_any_gen() didn't return True on a generator worker being active."
 
-    W_gens["persis_state"] = np.array([2, 0, 0, 0])
+    W_gens["persistent"] = np.array([True, 0, 0, 0])
 
     assert (
         als.count_persis_gens() == 1
@@ -171,7 +165,7 @@ def test_als_sim_work():
     ), "H_rows weren't assigned to libE_info correctly."
 
     W_ps = W.copy()
-    W_ps["persis_state"] = np.array([1, 0, 0, 0])
+    W_ps["persistent"] = np.array([True, 0, 0, 0])
     als = AllocSupport(W_ps, True)
     Work = {}
     Work[1] = als.sim_work(1, H, ["x"], np.array([0, 1, 2, 3, 4]), persis_info[1], persistent=True)
@@ -208,7 +202,7 @@ def test_als_gen_work():
     ), "H_rows weren't assigned to libE_info correctly."
 
     W_ps = W.copy()
-    W_ps["persis_state"] = np.array([2, 0, 0, 0])
+    W_ps["persistent"] = np.array([True, 0, 0, 0])
     als = AllocSupport(W_ps, True)
     Work = {}
     Work[1] = als.gen_work(1, ["sim_id"], range(0, 5), persis_info[1], persistent=True)

--- a/libensemble/tests/unit_tests/test_ensemble.py
+++ b/libensemble/tests/unit_tests/test_ensemble.py
@@ -3,6 +3,7 @@ import sys
 import numpy as np
 
 import libensemble.tests.unit_tests.setup as setup
+from libensemble.resources.platforms import PerlmutterGPU
 from libensemble.utils.misc import pydanticV1, specs_dump
 
 
@@ -166,6 +167,25 @@ def test_flakey_workflow():
     assert not flag, "should've caught input errors"
 
 
+def test_ensemble_specs_update_libE_specs():
+
+    from libensemble.ensemble import Ensemble
+    from libensemble.specs import LibeSpecs
+
+    platform_specs = PerlmutterGPU()
+
+    ensemble = Ensemble(
+        libE_specs=LibeSpecs(comms="local", nworkers=4),
+    )
+
+    ensemble.libE_specs = LibeSpecs(
+        num_resource_sets=ensemble.nworkers - 1,
+        resource_info={"gpus_on_node": 4},
+        use_workflow_dir=True,
+        platform_specs=platform_specs,
+    )
+
+
 if __name__ == "__main__":
     test_ensemble_init()
     test_ensemble_parse_args_false()
@@ -173,3 +193,4 @@ if __name__ == "__main__":
     test_bad_func_loads()
     test_full_workflow()
     test_flakey_workflow()
+    test_ensemble_specs_update_libE_specs()

--- a/libensemble/tests/unit_tests/test_ensemble.py
+++ b/libensemble/tests/unit_tests/test_ensemble.py
@@ -3,7 +3,6 @@ import sys
 import numpy as np
 
 import libensemble.tests.unit_tests.setup as setup
-from libensemble.resources.platforms import PerlmutterGPU
 from libensemble.utils.misc import pydanticV1, specs_dump
 
 
@@ -168,8 +167,9 @@ def test_flakey_workflow():
 
 
 def test_ensemble_specs_update_libE_specs():
-
+    """Test that libE_specs is updated as expected with .attribute setting"""
     from libensemble.ensemble import Ensemble
+    from libensemble.resources.platforms import PerlmutterGPU
     from libensemble.specs import LibeSpecs
 
     platform_specs = PerlmutterGPU()
@@ -184,6 +184,10 @@ def test_ensemble_specs_update_libE_specs():
         use_workflow_dir=True,
         platform_specs=platform_specs,
     )
+
+    assert ensemble.libE_specs.num_resource_sets == ensemble.nworkers - 1
+    assert len(str(ensemble.libE_specs.workflow_dir_path)) > 1
+    assert ensemble.libE_specs.platform_specs == specs_dump(platform_specs, exclude_none=True)
 
 
 if __name__ == "__main__":

--- a/libensemble/tools/alloc_support.py
+++ b/libensemble/tools/alloc_support.py
@@ -201,7 +201,7 @@ class AllocSupport:
         """Add rset_team to libE_info."""
         if self.manage_resources and not libE_info.get("rset_team"):
             num_rsets_req = 0
-            if self.W[wid - 1]["persis_state"]:
+            if self.W[wid]["persis_state"]:
                 # Even if empty list, non-None rset_team stops manager giving default resources
                 libE_info["rset_team"] = []
                 return
@@ -272,7 +272,7 @@ class AllocSupport:
         """
         self._update_rset_team(libE_info, wid)
 
-        if not self.W[wid - 1]["persis_state"]:
+        if not self.W[wid]["persis_state"]:
             AllocSupport.gen_counter += 1  # Count total gens
             libE_info["gen_count"] = AllocSupport.gen_counter
 

--- a/libensemble/tools/alloc_support.py
+++ b/libensemble/tools/alloc_support.py
@@ -153,11 +153,11 @@ class AllocSupport:
 
     def count_gens(self):
         """Returns the number of active generators."""
-        return sum(self.W["active"] & self.W["worker_type"] == EVAL_GEN_TAG)
+        return sum(self.W["active"] & (self.W["worker_type"] == EVAL_GEN_TAG))
 
     def test_any_gen(self):
         """Returns ``True`` if a generator worker is active."""
-        return any(self.W["active"] & self.W["worker_type"] == EVAL_GEN_TAG)
+        return any(self.W["active"] & (self.W["worker_type"] == EVAL_GEN_TAG))
 
     def count_persis_gens(self):
         """Return the number of active persistent generators."""

--- a/libensemble/tools/alloc_support.py
+++ b/libensemble/tools/alloc_support.py
@@ -201,7 +201,7 @@ class AllocSupport:
         """Add rset_team to libE_info."""
         if self.manage_resources and not libE_info.get("rset_team"):
             num_rsets_req = 0
-            if self.W[wid]["persis_state"]:
+            if self.W[wid - 1]["persis_state"]:
                 # Even if empty list, non-None rset_team stops manager giving default resources
                 libE_info["rset_team"] = []
                 return
@@ -272,7 +272,7 @@ class AllocSupport:
         """
         self._update_rset_team(libE_info, wid)
 
-        if not self.W[wid]["persis_state"]:
+        if not self.W[wid - 1]["persis_state"]:
             AllocSupport.gen_counter += 1  # Count total gens
             libE_info["gen_count"] = AllocSupport.gen_counter
 

--- a/libensemble/tools/alloc_support.py
+++ b/libensemble/tools/alloc_support.py
@@ -5,7 +5,7 @@ import numpy as np
 from libensemble.message_numbers import EVAL_GEN_TAG, EVAL_SIM_TAG
 from libensemble.resources.resources import Resources
 from libensemble.resources.scheduler import InsufficientFreeResources, InsufficientResourcesError, ResourceScheduler
-from libensemble.utils.misc import extract_H_ranges
+from libensemble.utils.misc import _WorkerIndexer, extract_H_ranges
 
 logger = logging.getLogger(__name__)
 # For debug messages - uncomment
@@ -47,7 +47,7 @@ class AllocSupport:
         :param user_resources: (Optional) A user supplied ``resources`` object.
         :param user_scheduler: (Optional) A user supplied ``user_scheduler`` object.
         """
-        self.W = W
+        self.W = _WorkerIndexer(W, libE_info.get("manager_runs_additional_worker", False))
         self.persis_info = persis_info
         self.manage_resources = manage_resources
         self.resources = user_resources or Resources.resources
@@ -221,7 +221,7 @@ class AllocSupport:
         """Add rset_team to libE_info."""
         if self.manage_resources and not libE_info.get("rset_team"):
             num_rsets_req = 0
-            if self.W[wid - 1]["persistent"]:
+            if self.W[wid]["persistent"]:
                 # Even if empty list, non-None rset_team stops manager giving default resources
                 libE_info["rset_team"] = []
                 return
@@ -292,7 +292,7 @@ class AllocSupport:
         """
         self._update_rset_team(libE_info, wid)
 
-        if not self.W[wid - 1]["persistent"]:
+        if not self.W[wid]["persistent"]:
             AllocSupport.gen_counter += 1  # Count total gens
             libE_info["gen_count"] = AllocSupport.gen_counter
 

--- a/libensemble/tools/alloc_support.py
+++ b/libensemble/tools/alloc_support.py
@@ -5,7 +5,7 @@ import numpy as np
 from libensemble.message_numbers import EVAL_GEN_TAG, EVAL_SIM_TAG
 from libensemble.resources.resources import Resources
 from libensemble.resources.scheduler import InsufficientFreeResources, InsufficientResourcesError, ResourceScheduler
-from libensemble.utils.misc import _WorkerIndexer, extract_H_ranges
+from libensemble.utils.misc import extract_H_ranges
 
 logger = logging.getLogger(__name__)
 # For debug messages - uncomment
@@ -47,7 +47,7 @@ class AllocSupport:
         :param user_resources: (Optional) A user supplied ``resources`` object.
         :param user_scheduler: (Optional) A user supplied ``user_scheduler`` object.
         """
-        self.W = _WorkerIndexer(W, libE_info.get("manager_runs_additional_worker", False))
+        self.W = W
         self.persis_info = persis_info
         self.manage_resources = manage_resources
         self.resources = user_resources or Resources.resources

--- a/libensemble/tools/alloc_support.py
+++ b/libensemble/tools/alloc_support.py
@@ -93,7 +93,7 @@ class AllocSupport:
         :param persistent: (Optional) Int. Only return workers with given ``persis_state`` (1=sim, 2=gen).
         :param active_recv: (Optional) Boolean. Only return workers with given active_recv state.
         :param zero_resource_workers: (Optional) Boolean. Only return workers that require no resources.
-        :param gen_workers: (Optional) Boolean. If True, return gen-only workers and manager's ID.
+        :param gen_workers: (Optional) Boolean. If True, return gen-only workers.
         :returns: List of worker IDs.
 
         If there are no zero resource workers defined, then the ``zero_resource_workers`` argument will

--- a/libensemble/tools/alloc_support.py
+++ b/libensemble/tools/alloc_support.py
@@ -100,6 +100,9 @@ class AllocSupport:
         be ignored.
         """
 
+        if persistent == EVAL_GEN_TAG:  # backwards compatibility
+            return self.avail_gen_worker_ids(persistent, active_recv, zero_resource_workers)
+
         # For abbrev.
         def fltr_persis():
             return wrk["persistent"] == persistent

--- a/libensemble/tools/alloc_support.py
+++ b/libensemble/tools/alloc_support.py
@@ -102,10 +102,7 @@ class AllocSupport:
 
         # For abbrev.
         def fltr_persis():
-            if persistent:
-                return wrk["persistent"]
-            else:
-                return True
+            return wrk["persistent"] == persistent
 
         def fltr_zrw():
             # If none exist or you did not ask for zrw then return True
@@ -160,11 +157,11 @@ class AllocSupport:
 
     def test_any_gen(self):
         """Returns ``True`` if a generator worker is active."""
-        return any(self.W["active"] == EVAL_GEN_TAG)
+        return any(self.W["active"] & self.W["worker_type"] == EVAL_GEN_TAG)
 
     def count_persis_gens(self):
         """Return the number of active persistent generators."""
-        return sum(self.W["persistent"] == EVAL_GEN_TAG)
+        return sum((self.W["persistent"]) & (self.W["worker_type"] == EVAL_GEN_TAG))
 
     def _req_resources_sim(self, libE_info, user_params, H, H_rows):
         """Determine required resources for a sim work unit"""

--- a/libensemble/tools/alloc_support.py
+++ b/libensemble/tools/alloc_support.py
@@ -87,25 +87,24 @@ class AllocSupport:
             rset_team = self.sched.assign_resources(rsets_req, use_gpus, user_params)
         return rset_team
 
-    def avail_worker_ids(self, persistent=False, active_recv=False, zero_resource_workers=None, worker_type=None):
+    def avail_worker_ids(self, persistent=None, active_recv=False, zero_resource_workers=None, gen_workers=False):
         """Returns available workers as a list of IDs, filtered by the given options.
 
         :param persistent: (Optional) Int. Only return workers with given ``persis_state`` (1=sim, 2=gen).
         :param active_recv: (Optional) Boolean. Only return workers with given active_recv state.
         :param zero_resource_workers: (Optional) Boolean. Only return workers that require no resources.
-        :param worker_type: (Optional) Int. Only return workers with given ``worker_type`` (1=sim, 2=gen).
+        :param gen_workers: (Optional) Boolean. If True, return gen-only workers and manager's ID.
         :returns: List of worker IDs.
 
         If there are no zero resource workers defined, then the ``zero_resource_workers`` argument will
         be ignored.
         """
 
-        if persistent == EVAL_GEN_TAG:  # backwards compatibility
-            return self.avail_gen_worker_ids(persistent, active_recv, zero_resource_workers)
-
         # For abbrev.
         def fltr_persis():
-            return wrk["persistent"] == persistent
+            if persistent is None:
+                return True
+            return wrk["persis_state"] == persistent
 
         def fltr_zrw():
             # If none exist or you did not ask for zrw then return True
@@ -119,11 +118,9 @@ class AllocSupport:
             else:
                 return wrk["active"] == 0
 
-        def fltr_worker_type():
-            if worker_type == EVAL_SIM_TAG:
-                return wrk["worker_type"] != EVAL_GEN_TAG  # only workers not given gen work *yet*
-            elif worker_type == EVAL_GEN_TAG:
-                return wrk["worker_type"] == EVAL_GEN_TAG  # explicitly want gen_workers
+        def fltr_gen_workers():
+            if gen_workers:
+                return wrk["gen_worker"]
             else:
                 return True
 
@@ -134,39 +131,21 @@ class AllocSupport:
         no_zrw = not any(self.W["zero_resource_worker"])
         wrks = []
         for wrk in self.W:
-            if fltr_recving() and fltr_persis() and fltr_zrw() and fltr_worker_type():
+            if fltr_recving() and fltr_persis() and fltr_zrw() and fltr_gen_workers():
                 wrks.append(wrk["worker_id"])
         return wrks
 
-    def avail_gen_worker_ids(self, persistent=False, active_recv=False, zero_resource_workers=None):
-        """Returns available generator workers as a list of IDs."""
-        return self.avail_worker_ids(
-            persistent=persistent,
-            active_recv=active_recv,
-            zero_resource_workers=zero_resource_workers,
-            worker_type=EVAL_GEN_TAG,
-        )
-
-    def avail_sim_worker_ids(self, persistent=False, active_recv=False, zero_resource_workers=None):
-        """Returns available non-generator workers as a list of IDs."""
-        return self.avail_worker_ids(
-            persistent=persistent,
-            active_recv=active_recv,
-            zero_resource_workers=zero_resource_workers,
-            worker_type=EVAL_SIM_TAG,
-        )
-
     def count_gens(self):
         """Returns the number of active generators."""
-        return sum((self.W["active"] == EVAL_GEN_TAG) & (self.W["worker_type"] == EVAL_GEN_TAG))
+        return sum((self.W["active"] == EVAL_GEN_TAG))
 
     def test_any_gen(self):
         """Returns ``True`` if a generator worker is active."""
-        return any((self.W["active"] == EVAL_GEN_TAG) & (self.W["worker_type"] == EVAL_GEN_TAG))
+        return any((self.W["active"] == EVAL_GEN_TAG))
 
     def count_persis_gens(self):
         """Return the number of active persistent generators."""
-        return sum((self.W["persistent"]) & (self.W["worker_type"] == EVAL_GEN_TAG))
+        return sum(self.W["persis_state"] == EVAL_GEN_TAG)
 
     def _req_resources_sim(self, libE_info, user_params, H, H_rows):
         """Determine required resources for a sim work unit"""
@@ -223,7 +202,7 @@ class AllocSupport:
         """Add rset_team to libE_info."""
         if self.manage_resources and not libE_info.get("rset_team"):
             num_rsets_req = 0
-            if self.W[wid]["persistent"]:
+            if self.W[wid]["persis_state"]:
                 # Even if empty list, non-None rset_team stops manager giving default resources
                 libE_info["rset_team"] = []
                 return
@@ -294,7 +273,7 @@ class AllocSupport:
         """
         self._update_rset_team(libE_info, wid)
 
-        if not self.W[wid]["persistent"]:
+        if not self.W[wid]["persis_state"]:
             AllocSupport.gen_counter += 1  # Count total gens
             libE_info["gen_count"] = AllocSupport.gen_counter
 

--- a/libensemble/tools/alloc_support.py
+++ b/libensemble/tools/alloc_support.py
@@ -117,7 +117,7 @@ class AllocSupport:
             if active_recv:
                 return wrk["active_recv"]
             else:
-                return not wrk["active"]
+                return wrk["active"] == 0
 
         def fltr_worker_type():
             if worker_type == EVAL_SIM_TAG:
@@ -158,11 +158,11 @@ class AllocSupport:
 
     def count_gens(self):
         """Returns the number of active generators."""
-        return sum(self.W["active"] & (self.W["worker_type"] == EVAL_GEN_TAG))
+        return sum((self.W["active"] == EVAL_GEN_TAG) & (self.W["worker_type"] == EVAL_GEN_TAG))
 
     def test_any_gen(self):
         """Returns ``True`` if a generator worker is active."""
-        return any(self.W["active"] & (self.W["worker_type"] == EVAL_GEN_TAG))
+        return any((self.W["active"] == EVAL_GEN_TAG) & (self.W["worker_type"] == EVAL_GEN_TAG))
 
     def count_persis_gens(self):
         """Return the number of active persistent generators."""

--- a/libensemble/tools/alloc_support.py
+++ b/libensemble/tools/alloc_support.py
@@ -120,8 +120,10 @@ class AllocSupport:
                 return not wrk["active"]
 
         def fltr_worker_type():
-            if worker_type:
-                return wrk["worker_type"] == worker_type
+            if worker_type == EVAL_SIM_TAG:
+                return wrk["worker_type"] != EVAL_GEN_TAG  # only workers not given gen work *yet*
+            elif worker_type == EVAL_GEN_TAG:
+                return wrk["worker_type"] == EVAL_GEN_TAG  # explicitly want gen_workers
             else:
                 return True
 
@@ -146,7 +148,7 @@ class AllocSupport:
         )
 
     def avail_sim_worker_ids(self, persistent=False, active_recv=False, zero_resource_workers=None):
-        """Returns available generator workers as a list of IDs."""
+        """Returns available non-generator workers as a list of IDs."""
         return self.avail_worker_ids(
             persistent=persistent,
             active_recv=active_recv,

--- a/libensemble/utils/misc.py
+++ b/libensemble/utils/misc.py
@@ -33,6 +33,27 @@ def extract_H_ranges(Work: dict) -> str:
         return "_".join(ranges)
 
 
+class _WorkerIndexer:
+    def __init__(self, iterable: list, additional_worker=False):
+        self.iterable = iterable
+        self.additional_worker = additional_worker
+
+    def __getitem__(self, key):
+        if self.additional_worker or isinstance(key, str):
+            return self.iterable[key]
+        else:
+            return self.iterable[key - 1]
+
+    def __setitem__(self, key, value):
+        self.iterable[key] = value
+
+    def __len__(self):
+        return len(self.iterable)
+
+    def __iter__(self):
+        return iter(self.iterable)
+
+
 def specs_dump(specs, **kwargs):
     if pydanticV1:
         return specs.dict(**kwargs)

--- a/libensemble/utils/runners.py
+++ b/libensemble/utils/runners.py
@@ -62,8 +62,8 @@ class GlobusComputeRunner(Runner):
         libE_info["comm"] = None  # 'comm' object not pickle-able
         Worker._set_executor(0, None)  # ditto for executor
 
-        fargs = self._truncate_args(calc_in, persis_info, libE_info)
-        task_fut = self.globus_compute_executor.submit_to_registered_function(self.globus_compute_fid, fargs)
+        args = self._truncate_args(calc_in, persis_info, libE_info)
+        task_fut = self.globus_compute_executor.submit_to_registered_function(self.globus_compute_fid, args)
         return task_fut.result()
 
     def shutdown(self) -> None:
@@ -76,8 +76,8 @@ class ThreadRunner(Runner):
         self.thread_handle = None
 
     def _result(self, calc_in: npt.NDArray, persis_info: dict, libE_info: dict) -> (npt.NDArray, dict, Optional[int]):
-        fargs = self._truncate_args(calc_in, persis_info, libE_info)
-        self.thread_handle = QCommThread(self.f, None, *fargs, ufunc=True)
+        args = self._truncate_args(calc_in, persis_info, libE_info)
+        self.thread_handle = QCommThread(self.f, None, *args, user_function=True)
         self.thread_handle.run()
         return self.thread_handle.result()
 

--- a/libensemble/worker.py
+++ b/libensemble/worker.py
@@ -415,4 +415,4 @@ class Worker:
             self.gen_runner.shutdown()
             self.sim_runner.shutdown()
             self.EnsembleDirectory.copy_back()
-            Executor.executor.comm = None
+            Executor.executor.comm = None  # so Executor can be pickled upon further libE calls

--- a/libensemble/worker.py
+++ b/libensemble/worker.py
@@ -415,4 +415,5 @@ class Worker:
             self.gen_runner.shutdown()
             self.sim_runner.shutdown()
             self.EnsembleDirectory.copy_back()
-            Executor.executor.comm = None  # so Executor can be pickled upon further libE calls
+            if Executor.executor is not None:
+                Executor.executor.comm = None  # so Executor can be pickled upon further libE calls

--- a/libensemble/worker.py
+++ b/libensemble/worker.py
@@ -415,3 +415,4 @@ class Worker:
             self.gen_runner.shutdown()
             self.sim_runner.shutdown()
             self.EnsembleDirectory.copy_back()
+            Executor.executor.comm = None


### PR DESCRIPTION
Addresses #1166 

# User - Manager runs local worker on thread - Gen Worker 0

The manager can start an additional worker _thread_ with the worker ID 0. 

This worker is, via `W["gen_worker"] = True`, and filtering options, made to run gens only.

Tentative interface: `libE_specs["gen_on_manager"] = True`

# Internal - Refactor runners.py

Largely refactors utils/runners.py so additional "Runners" for user functions can be more easily developed/extended.

GlobusComputeRunner and ThreadRunner inherit from Runner.

Runner inspects the contents of the input sim/gen specs and instantiates the correct subclass on the left-hand-side:

```
>>> sim_specs = {... , "globus_compute_endpoint": "1234}
>>> runner = Runner(sim_specs)
>>> runner
<libensemble.utils.runners.GlobusComputeRunner object at 0x1490ec190>
>>> runner = Runner({"sim_f": print})
>>> runner
<libensemble.utils.runners.Runner object at 0x104e024d0>
```

# Internal -  _WorkerIndexer class for indexing into worker arrays

# Internal - Workers can be assigned gen_worker.
