### PR TITLE
gpCAM grid method without pairwise distance matrix

### DIFF
--- a/libensemble/gen_funcs/persistent_gpCAM.py
+++ b/libensemble/gen_funcs/persistent_gpCAM.py
@@ -170,8 +170,12 @@ def persistent_gpCAM_simple(H_in, persis_info, gen_specs, libE_info):
         tag, Work, calc_in = ps.send_recv(H_o)
 
         if calc_in is not None:
+            y_new = np.atleast_2d(calc_in["f"]).T
+            nan_indices = [i for i, fval in enumerate(y_new) if np.isnan(fval)]
+            x_new = np.delete(x_new, nan_indices, axis=0)
+            y_new = np.delete(y_new, nan_indices, axis=0)
             all_x = np.vstack((all_x, x_new))
-            all_y = np.vstack((all_y, np.atleast_2d(calc_in["f"]).T))
+            all_y = np.vstack((all_y, y_new))
 
     # If final points are sent with PERSIS_STOP, update model and get final var_vals
     if calc_in is not None:

--- a/libensemble/gen_funcs/persistent_gpCAM.py
+++ b/libensemble/gen_funcs/persistent_gpCAM.py
@@ -83,7 +83,7 @@ def _update_gp_and_eval_var(all_x, all_y, x_for_var, test_points, persis_info):
     points in x_for_var. If we have test points, calculate mean square error
     at those points.
     """
-    my_gp2S = GP(all_x, all_y, noise_variances=1e-8 * np.ones(len(all_y)))
+    my_gp2S = GP(all_x, all_y, noise_variances=1e-12 * np.ones(len(all_y)))
     my_gp2S.train()
 
     # Obtain covariance in groups to prevent memory overload.


### PR DESCRIPTION
An attempt to implement the gpCAM with grid method without constructing the huge pairwise distance matrix. 

The points are compared for distance only against points already added to the eligible points list. 

At five dimensions we still run into memory problems when call my_gp2S.posterior_covariance which constructs it's own pairwise distance matrix, so these are now handled in groups. 

NaNs returned from simulations are removed from points before updating the GP.

A test point file can be provided (can be a history file from previous run), and mean squared error is taken at those points each step.

