### PR TITLE
Fixes/from 112 optimas

### DIFF
--- a/libensemble/executors/executor.py
+++ b/libensemble/executors/executor.py
@@ -569,8 +569,8 @@ class Executor:
         self, task: Task, timeout: Optional[int] = None, delay: float = 0.1, poll_manager: bool = False
     ) -> int:
         """Optional, blocking, generic task status polling loop. Operates until the task
-        finishes, times out, or is Optionally killed via a manager signal. On completion, returns a
-        presumptive :ref:`calc_status<funcguides-calcstatus>` integer. Potentially useful
+        finishes, times out, or is optionally killed via a manager signal. On completion, returns a
+        presumptive :ref:`calc_status<funcguides-calcstatus>` integer. Useful
         for running an application via the Executor until it stops without monitoring
         its intermediate output.
 
@@ -676,7 +676,7 @@ class Executor:
         stdout: Optional[str] = None,
         stderr: Optional[str] = None,
         dry_run: Optional[bool] = False,
-        wait_on_start: Optional[bool | int] = False,
+        wait_on_start: Optional[Union[bool, int]] = False,
         env_script: Optional[str] = None,
     ) -> Task:
         """Create a new task and run as a local serial subprocess.

--- a/libensemble/executors/executor.py
+++ b/libensemble/executors/executor.py
@@ -676,7 +676,7 @@ class Executor:
         stdout: Optional[str] = None,
         stderr: Optional[str] = None,
         dry_run: Optional[bool] = False,
-        wait_on_start: Optional[bool] = False,
+        wait_on_start: Optional[bool | int] = False,
         env_script: Optional[str] = None,
     ) -> Task:
         """Create a new task and run as a local serial subprocess.
@@ -707,9 +707,10 @@ class Executor:
             Whether this is a dry_run - no task will be launched; instead
             runline is printed to logger (at INFO level)
 
-        wait_on_start: bool, Optional
+        wait_on_start: bool or int, Optional
             Whether to wait for task to be polled as RUNNING (or other
-            active/end state) before continuing
+            active/end state) before continuing. If an integer N is supplied,
+            wait at most N seconds.
 
         env_script: str, Optional
             The full path of a shell script to set up the environment for the
@@ -762,7 +763,10 @@ class Executor:
                     start_new_session=False,
                 )
             if wait_on_start:
-                self._wait_on_start(task, 0)  # No fail time as no re-starts in-place
+                if isinstance(wait_on_start, int):
+                    self._wait_on_start(task, wait_on_start)
+                else:
+                    self._wait_on_start(task, 0)
 
             if not task.timer.timing and not task.finished:
                 task.timer.start()

--- a/libensemble/executors/mpi_executor.py
+++ b/libensemble/executors/mpi_executor.py
@@ -157,12 +157,13 @@ class MPIExecutor(Executor):
                     )
             except Exception as e:
                 logger.warning(f"task {task.name} submit command failed on try {retry_count} with error {e}")
-                task.poll()
+                task.state = "FAILED"
                 retry = True
                 retry_count += 1
             else:
                 if wait_on_start:
                     self._wait_on_start(task, self.fail_time)
+                task.poll()
 
                 if task.state == "FAILED":
                     logger.warning(

--- a/libensemble/executors/mpi_executor.py
+++ b/libensemble/executors/mpi_executor.py
@@ -157,6 +157,7 @@ class MPIExecutor(Executor):
                     )
             except Exception as e:
                 logger.warning(f"task {task.name} submit command failed on try {retry_count} with error {e}")
+                task.poll()
                 retry = True
                 retry_count += 1
             else:

--- a/libensemble/tests/unit_tests/test_executor.py
+++ b/libensemble/tests/unit_tests/test_executor.py
@@ -281,13 +281,16 @@ def test_launch_wait_on_start():
     exctr = Executor.executor
     cores = NCORES
     args_for_sim = "sleep 0.2"
-    task = exctr.submit(calc_type="sim", num_procs=cores, app_args=args_for_sim, wait_on_start=True)
-    assert task.state not in NOT_STARTED_STATES, "Task should not be in a NOT_STARTED state. State: " + str(task.state)
-    exctr.poll(task)
-    if not task.finished:
-        task = polling_loop(exctr, task)
-    assert task.finished, "task.finished should be True. Returned " + str(task.finished)
-    assert task.state == "FINISHED", "task.state should be FINISHED. Returned " + str(task.state)
+    for value in [True, 1]:
+        task = exctr.submit(calc_type="sim", num_procs=cores, app_args=args_for_sim, wait_on_start=value)
+        assert task.state not in NOT_STARTED_STATES, "Task should not be in a NOT_STARTED state. State: " + str(
+            task.state
+        )
+        exctr.poll(task)
+        if not task.finished:
+            task = polling_loop(exctr, task)
+        assert task.finished, "task.finished should be True. Returned " + str(task.finished)
+        assert task.state == "FINISHED", "task.state should be FINISHED. Returned " + str(task.state)
 
 
 def test_kill_on_file():
@@ -651,7 +654,7 @@ def test_retries_launch_fail():
     cores = NCORES
     args_for_sim = "sleep 0"
     task = exctr.submit(calc_type="sim", num_procs=cores, app_args=args_for_sim)
-    assert task.state == "CREATED", "task.state should be CREATED. Returned " + str(task.state)
+    assert task.state == "FAILED", "task.state should be FAILED. Returned " + str(task.state)
     assert exctr.mpi_runner_obj.subgroup_launch, "subgroup_launch should be True"
     assert task.run_attempts == 5, "task.run_attempts should be 5. Returned " + str(task.run_attempts)
 


### PR DESCRIPTION
- `wait_on_start=N`: N seconds of waiting before continuing
- Upon exception, `task.state = "FAILED"`