### PR TITLE
Just letting the  package handle code spellcheck

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,0 @@
-[codespell]
-skip = _typos.toml,*.so,*.npy,*.mod,*.pyc,*.pickle,.git,*.png,*.xml,*.bib,lapack.f,test_allocation_funcs_and_support.py
-quiet-level = 1
-ignore-words=.spell

--- a/.spell
+++ b/.spell
@@ -1,7 +1,0 @@
-parameterizes
-datas
-apoints
-numer
-hist
-inout
-slac


### PR DESCRIPTION
Code is being checked by `typos`. Documentation by `sphinxcontrib-spelling`. Should we drop `codespell` for now?