### PR TITLE
Formatting changes to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,21 +104,8 @@ Resources
     doi     = {10.1109/tpds.2021.3082815}
   }
 
-.. _Community Examples repository: https://github.com/Libensemble/libe-community-examples
-.. _conda-forge: https://conda-forge.org/
-.. _Contributions: https://github.com/Libensemble/libensemble/blob/main/CONTRIBUTING.rst
-.. _docs: https://libensemble.readthedocs.io/en/main/advanced_installation.html
-.. _GitHub: https://github.com/Libensemble/libensemble
-.. _libEnsemble mailing list: https://lists.mcs.anl.gov/mailman/listinfo/libensemble
-.. _libEnsemble Slack page: https://libensemble.slack.com
-.. _MPICH: http://www.mpich.org/
-.. _mpmath: http://mpmath.org/
-.. _PyPI: https://pypi.org
-.. _Quickstart: https://libensemble.readthedocs.io/en/main/introduction.html
-.. _ReadtheDocs: http://libensemble.readthedocs.org/
-
 .. |libE_logo| image:: https://raw.githubusercontent.com/Libensemble/libensemble/main/docs/images/libE_logo.png
-   :align: center
+   :align: middle
    :alt: libEnsemble
 .. |PyPI| image:: https://img.shields.io/pypi/v/libensemble.svg?color=blue
    :target: https://pypi.org/project/libensemble
@@ -139,3 +126,16 @@ Resources
 .. |JOSS| image:: https://joss.theoj.org/papers/10.21105/joss.06031/status.svg
    :target: https://doi.org/10.21105/joss.06031
    :alt: JOSS Status
+
+.. _Community Examples repository: https://github.com/Libensemble/libe-community-examples
+.. _conda-forge: https://conda-forge.org/
+.. _Contributions: https://github.com/Libensemble/libensemble/blob/main/CONTRIBUTING.rst
+.. _docs: https://libensemble.readthedocs.io/en/main/advanced_installation.html
+.. _GitHub: https://github.com/Libensemble/libensemble
+.. _libEnsemble mailing list: https://lists.mcs.anl.gov/mailman/listinfo/libensemble
+.. _libEnsemble Slack page: https://libensemble.slack.com
+.. _MPICH: http://www.mpich.org/
+.. _mpmath: http://mpmath.org/
+.. _PyPI: https://pypi.org
+.. _Quickstart: https://libensemble.readthedocs.io/en/main/introduction.html
+.. _ReadtheDocs: http://libensemble.readthedocs.org/

--- a/README.rst
+++ b/README.rst
@@ -2,38 +2,29 @@
    :align: center
    :alt: libEnsemble
 
-|
+|PyPI| |Conda| |Spack|
 
-.. image:: https://img.shields.io/pypi/v/libensemble.svg?color=blue
+|Tests| |Coverage| |Docs| |Style| |JOSS|
+
+.. |PyPI| image:: https://img.shields.io/pypi/v/libensemble.svg?color=blue
    :target: https://pypi.org/project/libensemble
-
-.. image:: https://img.shields.io/conda/v/conda-forge/libensemble?color=blue
+.. |Conda| image:: https://img.shields.io/conda/v/conda-forge/libensemble?color=blue
    :target: https://anaconda.org/conda-forge/libensemble
-
-.. image:: https://img.shields.io/spack/v/py-libensemble?color=blue
+.. |Spack| image:: https://img.shields.io/spack/v/py-libensemble?color=blue
    :target: https://packages.spack.io/package.html?name=py-libensemble
-
-|
-
-.. image:: https://github.com/Libensemble/libensemble/actions/workflows/extra.yml/badge.svg?branch=main
+.. |Tests| image:: https://github.com/Libensemble/libensemble/actions/workflows/extra.yml/badge.svg?branch=main
    :target: https://github.com/Libensemble/libensemble/actions
-
-.. image:: https://codecov.io/github/Libensemble/libensemble/graph/badge.svg
+.. |Coverage| image:: https://codecov.io/github/Libensemble/libensemble/graph/badge.svg
    :target: https://codecov.io/github/Libensemble/libensemble
-
-.. image:: https://readthedocs.org/projects/libensemble/badge/?maxAge=2592000
+.. |Docs| image:: https://readthedocs.org/projects/libensemble/badge/?maxAge=2592000
    :target: https://libensemble.readthedocs.org/en/latest/
    :alt: Documentation Status
-
-.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
+.. |Style| image:: https://img.shields.io/badge/code%20style-black-000000.svg
    :target: https://github.com/psf/black
    :alt: Code style: black
-
-.. image:: https://joss.theoj.org/papers/10.21105/joss.06031/status.svg
+.. |JOSS| image:: https://joss.theoj.org/papers/10.21105/joss.06031/status.svg
    :target: https://doi.org/10.21105/joss.06031
    :alt: JOSS Status
-
-|
 
 .. after_badges_rst_tag
 

--- a/README.rst
+++ b/README.rst
@@ -1,30 +1,8 @@
-.. image:: https://raw.githubusercontent.com/Libensemble/libensemble/main/docs/images/libE_logo.png
-   :align: center
-   :alt: libEnsemble
+|libE_logo|
 
 |PyPI| |Conda| |Spack|
 
 |Tests| |Coverage| |Docs| |Style| |JOSS|
-
-.. |PyPI| image:: https://img.shields.io/pypi/v/libensemble.svg?color=blue
-   :target: https://pypi.org/project/libensemble
-.. |Conda| image:: https://img.shields.io/conda/v/conda-forge/libensemble?color=blue
-   :target: https://anaconda.org/conda-forge/libensemble
-.. |Spack| image:: https://img.shields.io/spack/v/py-libensemble?color=blue
-   :target: https://packages.spack.io/package.html?name=py-libensemble
-.. |Tests| image:: https://github.com/Libensemble/libensemble/actions/workflows/extra.yml/badge.svg?branch=main
-   :target: https://github.com/Libensemble/libensemble/actions
-.. |Coverage| image:: https://codecov.io/github/Libensemble/libensemble/graph/badge.svg
-   :target: https://codecov.io/github/Libensemble/libensemble
-.. |Docs| image:: https://readthedocs.org/projects/libensemble/badge/?maxAge=2592000
-   :target: https://libensemble.readthedocs.org/en/latest/
-   :alt: Documentation Status
-.. |Style| image:: https://img.shields.io/badge/code%20style-black-000000.svg
-   :target: https://github.com/psf/black
-   :alt: Code style: black
-.. |JOSS| image:: https://joss.theoj.org/papers/10.21105/joss.06031/status.svg
-   :target: https://doi.org/10.21105/joss.06031
-   :alt: JOSS Status
 
 .. after_badges_rst_tag
 
@@ -138,3 +116,26 @@ Resources
 .. _PyPI: https://pypi.org
 .. _Quickstart: https://libensemble.readthedocs.io/en/main/introduction.html
 .. _ReadtheDocs: http://libensemble.readthedocs.org/
+
+.. |libE_logo| image:: https://raw.githubusercontent.com/Libensemble/libensemble/main/docs/images/libE_logo.png
+   :align: center
+   :alt: libEnsemble
+.. |PyPI| image:: https://img.shields.io/pypi/v/libensemble.svg?color=blue
+   :target: https://pypi.org/project/libensemble
+.. |Conda| image:: https://img.shields.io/conda/v/conda-forge/libensemble?color=blue
+   :target: https://anaconda.org/conda-forge/libensemble
+.. |Spack| image:: https://img.shields.io/spack/v/py-libensemble?color=blue
+   :target: https://packages.spack.io/package.html?name=py-libensemble
+.. |Tests| image:: https://github.com/Libensemble/libensemble/actions/workflows/extra.yml/badge.svg?branch=main
+   :target: https://github.com/Libensemble/libensemble/actions
+.. |Coverage| image:: https://codecov.io/github/Libensemble/libensemble/graph/badge.svg
+   :target: https://codecov.io/github/Libensemble/libensemble
+.. |Docs| image:: https://readthedocs.org/projects/libensemble/badge/?maxAge=2592000
+   :target: https://libensemble.readthedocs.org/en/latest/
+   :alt: Documentation Status
+.. |Style| image:: https://img.shields.io/badge/code%20style-black-000000.svg
+   :target: https://github.com/psf/black
+   :alt: Code style: black
+.. |JOSS| image:: https://joss.theoj.org/papers/10.21105/joss.06031/status.svg
+   :target: https://doi.org/10.21105/joss.06031
+   :alt: JOSS Status


### PR DESCRIPTION
Following display issues with README (a [known issue](https://github.com/orgs/community/discussions/86715))
- Badges each on own line.
- Code blocks render incorrectly.

This will likely resolve itself, but experimenting with use of [substitutions](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#substitution-definitions) for badges. Is it safe to then move details to bottom (despite `after_badges_rst_tag`).


