### PR TITLE
No longer using deprecated in1d method

### DIFF
--- a/libensemble/alloc_funcs/fast_alloc_and_pausing.py
+++ b/libensemble/alloc_funcs/fast_alloc_and_pausing.py
@@ -100,7 +100,7 @@ def give_sim_work_first(W, H, sim_specs, gen_specs, alloc_specs, persis_info, li
 
             if not pt_ids_to_pause.issubset(persis_info["already_paused"]):
                 persis_info["already_paused"].update(pt_ids_to_pause)
-                sim_ids_to_remove = np.in1d(H["pt_id"], list(pt_ids_to_pause))
+                sim_ids_to_remove = np.isin(H["pt_id"], list(pt_ids_to_pause))
                 H["paused"][sim_ids_to_remove] = True
 
                 persis_info["need_to_give"] = persis_info["need_to_give"].difference(np.where(sim_ids_to_remove)[0])

--- a/libensemble/history.py
+++ b/libensemble/history.py
@@ -236,7 +236,7 @@ class History:
 
             # Ensure there aren't any gaps in the generated sim_id values:
             assert np.all(
-                np.in1d(np.arange(self.index, np.max(D["sim_id"]) + 1), D["sim_id"])
+                np.isin(np.arange(self.index, np.max(D["sim_id"]) + 1), D["sim_id"])
             ), "The generator function has produced sim_ids that are not in order."
 
             num_new = len(np.setdiff1d(D["sim_id"], self.H["sim_id"]))


### PR DESCRIPTION
https://numpy.org/doc/stable/reference/generated/numpy.in1d.html is being removed in numpy 2.0. It seems as if `isin` works the same.