### PR TITLE
Try install from conda-forge::gcc_linux-64

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -83,7 +83,7 @@ jobs:
 
         - name: Install Ubuntu compilers
           if: matrix.os == 'ubuntu-latest'
-          run: conda install gcc_linux-64
+          run: conda install conda-forge::gcc_linux-64
 
         # Roundabout solution on macos for proper linking with mpicc
         - name: Install macOS compilers

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -63,19 +63,6 @@ jobs:
             channel-priority: flexible
             auto-update-conda: true
 
-        - uses: actions/cache/restore@v4
-          name: Restore cached dependencies
-          id: cache
-          if: matrix.os == 'ubuntu-latest'
-          with:
-            path: |
-              /home/runner/.local
-              /usr/share/miniconda3/envs/condaenv
-              /usr/share/miniconda3/bin
-              /usr/share/miniconda3/lib
-              /usr/share/miniconda3/include
-            key: libe-${{ github.ref_name }}-${{ matrix.python-version }}-${{ matrix.comms-type }}-${{ matrix.pydantic-version }}-basic
-
         - name: Force-update certifi
           run: |
             python --version
@@ -114,18 +101,6 @@ jobs:
             python -m pip install --upgrade pip
             pip install mpmath matplotlib
             conda install numpy nlopt scipy
-
-        - uses: actions/cache/save@v4
-          name: Save dependencies to cache
-          if: matrix.os == 'ubuntu-latest'
-          with:
-            path: |
-              /home/runner/.local
-              /usr/share/miniconda3/envs/condaenv
-              /usr/share/miniconda3/bin
-              /usr/share/miniconda3/lib
-              /usr/share/miniconda3/include
-            key: libe-${{ github.ref_name }}-${{ matrix.python-version }}-${{ matrix.comms-type }}
 
         - name: Install libEnsemble, flake8
           run: |

--- a/.github/workflows/extra.yml
+++ b/.github/workflows/extra.yml
@@ -88,7 +88,7 @@ jobs:
 
         - name: Install Ubuntu compilers
           if: matrix.os == 'ubuntu-latest'
-          run: conda install gcc_linux-64
+          run: conda install conda-forge::gcc_linux-64
 
         # Roundabout solution on macos for proper linking with mpicc
         - name: Install macOS compilers


### PR DESCRIPTION
Seems to pick up `gcc_linux-64` from ctng-compiler-activation-feedstock you need:

    conda install conda-forge::gcc_linux-64

even if conda-forge is priority channel.

Re:
https://github.com/conda-forge/ctng-compiler-activation-feedstock/issues/122 (and 123)
https://github.com/conda-forge/mpich-feedstock/issues/98


