### PR TITLE
Fixing broken link

### DIFF
--- a/docs/FAQ.rst
+++ b/docs/FAQ.rst
@@ -305,7 +305,7 @@ macOS and Windows Errors
 
 .. _Installing PETSc On Microsoft Windows: https://petsc.org/release/install/windows/#recommended-installation-methods
 .. _option to srun: https://docs.nersc.gov/systems/perlmutter/running-jobs/#single-gpu-tasks-in-parallel
-.. _Perlmutter: https://docs.nersc.gov/systems/perlmutter
+.. _Perlmutter: https://docs.nersc.gov/systems/perlmutter/architecture/
 .. _Python multiprocessing docs: https://docs.python.org/3/library/multiprocessing.html
 .. _SDF: https://sdf.slac.stanford.edu/public/doc/#/?id=what-is-the-sdf
 .. _Support: https://libensemble.readthedocs.io/en/main/introduction.html#resources

--- a/docs/nitpicky
+++ b/docs/nitpicky
@@ -43,6 +43,7 @@ py:class libensemble.resources.platforms.Aurora
 py:class libensemble.resources.platforms.GenericROCm
 py:class libensemble.resources.platforms.Crusher
 py:class libensemble.resources.platforms.Frontier
+py:class libensemble.resources.platforms.Perlmutter
 py:class libensemble.resources.platforms.PerlmutterCPU
 py:class libensemble.resources.platforms.PerlmutterGPU
 py:class libensemble.resources.platforms.Polaris

--- a/docs/platforms/perlmutter.rst
+++ b/docs/platforms/perlmutter.rst
@@ -190,7 +190,7 @@ See the NERSC Perlmutter_ docs for more information about Perlmutter.
 .. _mpi4py: https://mpi4py.readthedocs.io/en/stable/
 .. _NERSC: https://www.nersc.gov/
 .. _option to srun: https://docs.nersc.gov/systems/perlmutter/running-jobs/#single-gpu-tasks-in-parallel
-.. _Perlmutter: https://docs.nersc.gov/systems/perlmutter/
+.. _Perlmutter: https://docs.nersc.gov/systems/perlmutter/architecture/
 .. _Python on Perlmutter: https://docs.nersc.gov/development/languages/python/using-python-perlmutter/
 .. _Slurm: https://slurm.schedmd.com/
 .. _video: https://www.youtube.com/watch?v=Av8ctYph7-Y


### PR DESCRIPTION
When building docs locally, I get an error:

`libensemble/libensemble/resources/platforms.py:docstring of libensemble.resources.platforms.Known_platforms.perlmutter:1: WARNING: py:class reference target not found: libensemble.resources.platforms.Perlmutter [ref.class]`

I was hoping that fixing the broken URL would resolve this. It doesn't. 