### PR TITLE
Refactor/pydantic adjusts

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -18,18 +18,18 @@ jobs:
                 os: [ubuntu-latest]
                 mpi-version: [mpich]
                 python-version: [3.9, "3.10", "3.11", "3.12"]
-                pydantic-version: ["2.8.2"]
+                pydantic-version: ["2.9.0"]
                 comms-type: [m, l]
                 include:
                     - os: macos-latest
                       python-version: "3.11"
                       mpi-version: mpich
-                      pydantic-version: "2.8.2"
+                      pydantic-version: "2.9.0"
                       comms-type: m
                     - os: macos-latest
                       python-version: "3.11"
                       mpi-version: mpich
-                      pydantic-version: "2.8.2"
+                      pydantic-version: "2.9.0"
                       comms-type: l
                     - os: ubuntu-latest
                       mpi-version: mpich

--- a/.github/workflows/extra.yml
+++ b/.github/workflows/extra.yml
@@ -12,27 +12,27 @@ jobs:
                 os: [ubuntu-latest]
                 mpi-version: [mpich]
                 python-version: [3.9, "3.10", "3.11", "3.12"]
-                pydantic-version: ["2.8.2"]
+                pydantic-version: ["2.9.0"]
                 comms-type: [m, l]
                 include:
                     - os: macos-latest
                       python-version: 3.11
                       mpi-version: mpich
-                      pydantic-version: "2.8.2"
+                      pydantic-version: "2.9.0"
                       comms-type: m
                     - os: macos-latest
                       python-version: 3.11
                       mpi-version: mpich
-                      pydantic-version: "2.8.2"
+                      pydantic-version: "2.9.0"
                       comms-type: l
                     - os: ubuntu-latest
                       python-version: "3.10"
                       mpi-version: mpich
-                      pydantic-version: "2.8.2"
+                      pydantic-version: "2.9.0"
                       comms-type: t
                     - os: ubuntu-latest
                       mpi-version: "openmpi"
-                      pydantic-version: "2.8.2"
+                      pydantic-version: "2.9.0"
                       python-version: "3.12"
                       comms-type: l
                     - os: ubuntu-latest
@@ -143,7 +143,7 @@ jobs:
             rm ./libensemble/tests/regression_tests/test_persistent_surmise_killsims.py
 
         - name: Install redis/proxystore on Pydantic 2
-          if: matrix.pydantic-version == '2.8.2'
+          if: matrix.pydantic-version == '2.9.0'
           run: |
             pip install redis
             pip install proxystore==0.7.0
@@ -153,8 +153,8 @@ jobs:
           run: |
             rm ./libensemble/tests/regression_tests/test_proxystore_integration.py
 
-        - name: Remove Balsam/Globus-compute tests on Pydantic 2
-          if: matrix.pydantic-version == '2.8.2'
+        - name: Remove Balsam tests on Pydantic 2
+          if: matrix.pydantic-version == '2.9.0'
           run: |
             rm ./libensemble/tests/unit_tests/test_ufunc_runners.py
             rm ./libensemble/tests/unit_tests/test_executor_balsam.py

--- a/libensemble/__init__.py
+++ b/libensemble/__init__.py
@@ -10,5 +10,6 @@ __author__ = "Jeffrey Larson, Stephen Hudson, Stefan M. Wild, David Bindel and J
 __credits__ = "Argonne National Laboratory"
 
 from libensemble import logger
+from libensemble.utils import pydantic_bindings
 
 from .ensemble import Ensemble

--- a/libensemble/resources/platforms.py
+++ b/libensemble/resources/platforms.py
@@ -13,9 +13,8 @@ import os
 import subprocess
 from typing import Optional
 
-from pydantic import BaseModel
-
 from libensemble.utils.misc import specs_dump
+from libensemble.utils.pydantic_modules import BaseModel
 
 logger = logging.getLogger(__name__)
 # To change logging level for just this module

--- a/libensemble/specs.py
+++ b/libensemble/specs.py
@@ -2,10 +2,9 @@ import random
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Tuple, Union
 
-from pydantic import BaseModel, Field
-
 from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.resources.platforms import Platform
+from libensemble.utils.pydantic_modules import BaseModel, Field
 
 __all__ = ["SimSpecs", "GenSpecs", "AllocSpecs", "ExitCriteria", "LibeSpecs", "_EnsembleSpecs"]
 

--- a/libensemble/tests/unit_tests/test_ensemble.py
+++ b/libensemble/tests/unit_tests/test_ensemble.py
@@ -3,7 +3,8 @@ import sys
 import numpy as np
 
 import libensemble.tests.unit_tests.setup as setup
-from libensemble.utils.misc import pydanticV1, specs_dump
+from libensemble.utils.misc import specs_dump
+from libensemble.utils.pydantic_modules import ValidationError
 
 
 def test_ensemble_init():
@@ -127,10 +128,6 @@ def test_full_workflow():
 
 def test_flakey_workflow():
     """Test initializing a workflow via Specs and Ensemble.run()"""
-    if pydanticV1:
-        from pydantic.error_wrappers import ValidationError
-    else:
-        from pydantic import ValidationError
 
     from libensemble.ensemble import Ensemble
     from libensemble.gen_funcs.sampling import latin_hypercube_sample

--- a/libensemble/tests/unit_tests/test_models.py
+++ b/libensemble/tests/unit_tests/test_models.py
@@ -2,12 +2,8 @@ import numpy as np
 
 import libensemble.tests.unit_tests.setup as setup
 from libensemble.specs import ExitCriteria, GenSpecs, LibeSpecs, SimSpecs, _EnsembleSpecs
-from libensemble.utils.misc import pydanticV1, specs_dump
-
-if pydanticV1:
-    from pydantic.error_wrappers import ValidationError
-else:
-    from pydantic import ValidationError
+from libensemble.utils.misc import specs_dump
+from libensemble.utils.pydantic_modules import ValidationError
 
 
 class Fake_MPI:
@@ -51,10 +47,7 @@ def test_sim_gen_alloc_exit_specs_invalid():
     }
 
     try:
-        if pydanticV1:
-            SimSpecs.parse_obj(bad_specs)
-        else:
-            SimSpecs.model_validate(bad_specs)
+        SimSpecs.parse_obj(bad_specs)
         flag = 0
     except ValidationError as e:
         assert len(e.errors()) > 1, "SimSpecs model should have detected multiple errors in specs"
@@ -62,10 +55,7 @@ def test_sim_gen_alloc_exit_specs_invalid():
     assert flag, "SimSpecs didn't raise ValidationError on invalid specs"
 
     try:
-        if pydanticV1:
-            GenSpecs.parse_obj(bad_specs)
-        else:
-            GenSpecs.model_validate(bad_specs)
+        GenSpecs.parse_obj(bad_specs)
         flag = 0
     except ValidationError as e:
         assert len(e.errors()) > 1, "Should've detected multiple errors in specs"
@@ -75,10 +65,7 @@ def test_sim_gen_alloc_exit_specs_invalid():
     bad_ec = {"stop_vals": 0.5}
 
     try:
-        if pydanticV1:
-            ExitCriteria.parse_obj(bad_ec)
-        else:
-            ExitCriteria.model_validate(bad_ec)
+        ExitCriteria.parse_obj(bad_ec)
         flag = 0
     except ValidationError:
         flag = 1
@@ -88,41 +75,26 @@ def test_sim_gen_alloc_exit_specs_invalid():
 def test_libe_specs():
     sim_specs, gen_specs, exit_criteria = setup.make_criteria_and_specs_0()
     libE_specs = {"mpi_comm": Fake_MPI(), "comms": "mpi"}
-    if pydanticV1:
-        ls = LibeSpecs.parse_obj(libE_specs)
-    else:
-        ls = LibeSpecs.model_validate(libE_specs)
+    ls = LibeSpecs.parse_obj(libE_specs)
 
     libE_specs["sim_input_dir"] = "./simdir"
     libE_specs["sim_dir_copy_files"] = ["./simdir"]
-    if pydanticV1:
-        ls = LibeSpecs.parse_obj(libE_specs)
-    else:
-        ls = LibeSpecs.model_validate(libE_specs)
+    ls = LibeSpecs.parse_obj(libE_specs)
 
     libE_specs = {"comms": "tcp", "nworkers": 4}
 
-    if pydanticV1:
-        ls = LibeSpecs.parse_obj(libE_specs)
-    else:
-        ls = LibeSpecs.model_validate(libE_specs)
+    ls = LibeSpecs.parse_obj(libE_specs)
     assert ls.disable_resource_manager, "resource manager should be disabled when using tcp comms"
 
     libE_specs = {"comms": "tcp", "workers": ["hello.host"]}
-    if pydanticV1:
-        ls = LibeSpecs.parse_obj(libE_specs)
-    else:
-        ls = LibeSpecs.model_validate(libE_specs)
+    ls = LibeSpecs.parse_obj(libE_specs)
 
 
 def test_libe_specs_invalid():
     bad_specs = {"comms": "local", "zero_resource_workers": 2, "sim_input_dirs": ["obj"]}
 
     try:
-        if pydanticV1:
-            LibeSpecs.parse_obj(bad_specs)
-        else:
-            LibeSpecs.model_validate(bad_specs)
+        LibeSpecs.parse_obj(bad_specs)
         flag = 0
     except ValidationError:
         flag = 1

--- a/libensemble/utils/misc.py
+++ b/libensemble/utils/misc.py
@@ -9,12 +9,6 @@ import pydantic
 
 pydantic_version = pydantic.__version__[0]
 
-pydanticV1 = pydantic_version == "1"
-pydanticV2 = pydantic_version == "2"
-
-if not pydanticV1 and not pydanticV2:
-    raise ModuleNotFoundError("Pydantic not installed or current version not supported. Install v1 or v2.")
-
 
 def extract_H_ranges(Work: dict) -> str:
     """Convert received H_rows into ranges for labeling"""
@@ -55,24 +49,12 @@ class _WorkerIndexer:
 
 
 def specs_dump(specs, **kwargs):
-    if pydanticV1:
-        return specs.dict(**kwargs)
-    else:
-        return specs.model_dump(**kwargs)
+    return specs.dict(**kwargs)
 
 
 def specs_checker_getattr(obj, key, default=None):
-    if pydanticV1:  # dict
-        return obj.get(key, default)
-    else:  # actual obj
-        try:
-            return getattr(obj, key)
-        except AttributeError:
-            return default
+    return obj.get(key, default)
 
 
 def specs_checker_setattr(obj, key, value):
-    if pydanticV1:  # dict
-        obj[key] = value
-    else:  # actual obj
-        obj.__dict__[key] = value
+    obj[key] = value

--- a/libensemble/utils/pydantic_modules.py
+++ b/libensemble/utils/pydantic_modules.py
@@ -1,0 +1,5 @@
+# Thanks globus-compute !
+try:
+    from pydantic.v1 import *  # noqa: F401 F403
+except ImportError:
+    from pydantic import *  # type: ignore # noqa: F401 F403

--- a/libensemble/utils/validators.py
+++ b/libensemble/utils/validators.py
@@ -5,7 +5,7 @@ from typing import Callable
 import numpy as np
 
 from libensemble.resources.platforms import Platform
-from libensemble.utils.misc import pydanticV1
+from libensemble.utils.pydantic_modules import root_validator, validator
 from libensemble.utils.specs_checkers import (
     _check_any_workers_and_disable_rm_if_tcp,
     _check_exit_criteria,
@@ -103,190 +103,111 @@ def check_mpi_runner_type(cls, value):
     return value
 
 
-if pydanticV1:
-    from pydantic import root_validator, validator
+# SPECS VALIDATORS #####
 
-    # SPECS VALIDATORS #####
+check_valid_out = validator("outputs", pre=True)(check_valid_out)
+check_valid_in = validator("inputs", "persis_in", pre=True)(check_valid_in)
+check_valid_comms_type = validator("comms")(check_valid_comms_type)
+set_platform_specs_to_class = validator("platform_specs")(set_platform_specs_to_class)
+check_input_dir_exists = validator("sim_input_dir", "gen_input_dir")(check_input_dir_exists)
+check_inputs_exist = validator(
+    "sim_dir_copy_files", "sim_dir_symlink_files", "gen_dir_copy_files", "gen_dir_symlink_files"
+)(check_inputs_exist)
+check_gpu_setting_type = validator("gpu_setting_type")(check_gpu_setting_type)
+check_mpi_runner_type = validator("mpi_runner")(check_mpi_runner_type)
 
-    check_valid_out = validator("outputs", pre=True)(check_valid_out)
-    check_valid_in = validator("inputs", "persis_in", pre=True)(check_valid_in)
-    check_valid_comms_type = validator("comms")(check_valid_comms_type)
-    set_platform_specs_to_class = validator("platform_specs")(set_platform_specs_to_class)
-    check_input_dir_exists = validator("sim_input_dir", "gen_input_dir")(check_input_dir_exists)
-    check_inputs_exist = validator(
-        "sim_dir_copy_files", "sim_dir_symlink_files", "gen_dir_copy_files", "gen_dir_symlink_files"
-    )(check_inputs_exist)
-    check_gpu_setting_type = validator("gpu_setting_type")(check_gpu_setting_type)
-    check_mpi_runner_type = validator("mpi_runner")(check_mpi_runner_type)
 
-    @root_validator
-    def check_any_workers_and_disable_rm_if_tcp(cls, values):
-        return _check_any_workers_and_disable_rm_if_tcp(values)
+@root_validator
+def check_any_workers_and_disable_rm_if_tcp(cls, values):
+    return _check_any_workers_and_disable_rm_if_tcp(values)
 
-    @root_validator(pre=True)
-    def set_default_comms(cls, values):
-        return default_comms(values)
 
-    @root_validator(pre=True)
-    def enable_save_H_when_every_K(cls, values):
-        if "save_H_on_completion" not in values and (
-            values.get("save_every_k_sims", 0) > 0 or values.get("save_every_k_gens", 0) > 0
-        ):
-            values["save_H_on_completion"] = True
-        return values
+@root_validator(pre=True)
+def set_default_comms(cls, values):
+    return default_comms(values)
 
-    @root_validator
-    def set_workflow_dir(cls, values):
-        return _check_set_workflow_dir(values)
 
-    @root_validator
-    def set_calc_dirs_on_input_dir(cls, values):
-        return _check_set_calc_dirs_on_input_dir(values)
+@root_validator(pre=True)
+def enable_save_H_when_every_K(cls, values):
+    if "save_H_on_completion" not in values and (
+        values.get("save_every_k_sims", 0) > 0 or values.get("save_every_k_gens", 0) > 0
+    ):
+        values["save_H_on_completion"] = True
+    return values
 
-    @root_validator
-    def check_exit_criteria(cls, values):
-        return _check_exit_criteria(values)
 
-    @root_validator
-    def check_output_fields(cls, values):
-        return _check_output_fields(values)
+@root_validator
+def set_workflow_dir(cls, values):
+    return _check_set_workflow_dir(values)
 
-    @root_validator
-    def check_H0(cls, values):
-        return _check_H0(values)
 
-    @root_validator
-    def check_provided_ufuncs(cls, values):
-        sim_specs = values.get("sim_specs")
-        assert hasattr(sim_specs, "sim_f"), "Simulation function not provided to SimSpecs."
-        assert isinstance(sim_specs.sim_f, Callable), "Simulation function is not callable."
+@root_validator
+def set_calc_dirs_on_input_dir(cls, values):
+    return _check_set_calc_dirs_on_input_dir(values)
 
-        if values.get("alloc_specs").alloc_f.__name__ != "give_pregenerated_sim_work":
-            gen_specs = values.get("gen_specs")
-            assert hasattr(gen_specs, "gen_f"), "Generator function not provided to GenSpecs."
-            assert isinstance(gen_specs.gen_f, Callable), "Generator function is not callable."
 
-        return values
+@root_validator
+def check_exit_criteria(cls, values):
+    return _check_exit_criteria(values)
 
-    @root_validator
-    def simf_set_in_out_from_attrs(cls, values):
-        if not values.get("sim_f"):
-            from libensemble.sim_funcs.simple_sim import norm_eval
 
-            values["sim_f"] = norm_eval
-        if hasattr(values.get("sim_f"), "inputs") and not values.get("inputs"):
-            values["inputs"] = values.get("sim_f").inputs
-        if hasattr(values.get("sim_f"), "outputs") and not values.get("outputs"):
-            values["outputs"] = values.get("sim_f").outputs
-        if hasattr(values.get("sim_f"), "persis_in") and not values.get("persis_in"):
-            values["persis_in"] = values.get("sim_f").persis_in
-        return values
+@root_validator
+def check_output_fields(cls, values):
+    return _check_output_fields(values)
 
-    @root_validator
-    def genf_set_in_out_from_attrs(cls, values):
-        if not values.get("gen_f"):
-            from libensemble.gen_funcs.sampling import latin_hypercube_sample
 
-            values["gen_f"] = latin_hypercube_sample
-        if hasattr(values.get("gen_f"), "inputs") and not values.get("inputs"):
-            values["inputs"] = values.get("gen_f").inputs
-        if hasattr(values.get("gen_f"), "outputs") and not values.get("outputs"):
-            values["outputs"] = values.get("gen_f").outputs
-        if hasattr(values.get("gen_f"), "persis_in") and not values.get("persis_in"):
-            values["persis_in"] = values.get("gen_f").persis_in
-        return values
+@root_validator
+def check_H0(cls, values):
+    return _check_H0(values)
 
-    # RESOURCES VALIDATORS #####
 
-    @root_validator
-    def check_logical_cores(cls, values):
-        return _check_logical_cores(values)
+@root_validator
+def check_provided_ufuncs(cls, values):
+    sim_specs = values.get("sim_specs")
+    assert hasattr(sim_specs, "sim_f"), "Simulation function not provided to SimSpecs."
+    assert isinstance(sim_specs.sim_f, Callable), "Simulation function is not callable."
 
-else:
-    from pydantic import field_validator, model_validator
+    if values.get("alloc_specs").alloc_f.__name__ != "give_pregenerated_sim_work":
+        gen_specs = values.get("gen_specs")
+        assert hasattr(gen_specs, "gen_f"), "Generator function not provided to GenSpecs."
+        assert isinstance(gen_specs.gen_f, Callable), "Generator function is not callable."
 
-    # SPECS VALIDATORS #####
+    return values
 
-    check_valid_out = field_validator("outputs")(classmethod(check_valid_out))
-    check_valid_in = field_validator("inputs", "persis_in")(classmethod(check_valid_in))
-    check_valid_comms_type = field_validator("comms")(classmethod(check_valid_comms_type))
-    set_platform_specs_to_class = field_validator("platform_specs")(classmethod(set_platform_specs_to_class))
-    check_input_dir_exists = field_validator("sim_input_dir", "gen_input_dir")(classmethod(check_input_dir_exists))
-    check_inputs_exist = field_validator(
-        "sim_dir_copy_files", "sim_dir_symlink_files", "gen_dir_copy_files", "gen_dir_symlink_files"
-    )(classmethod(check_inputs_exist))
-    check_gpu_setting_type = field_validator("gpu_setting_type")(classmethod(check_gpu_setting_type))
-    check_mpi_runner_type = field_validator("mpi_runner")(classmethod(check_mpi_runner_type))
 
-    @model_validator(mode="after")
-    def check_any_workers_and_disable_rm_if_tcp(self):
-        return _check_any_workers_and_disable_rm_if_tcp(self)
+@root_validator
+def simf_set_in_out_from_attrs(cls, values):
+    if not values.get("sim_f"):
+        from libensemble.sim_funcs.simple_sim import norm_eval
 
-    @model_validator(mode="before")
-    def set_default_comms(cls, values):
-        return default_comms(values)
+        values["sim_f"] = norm_eval
+    if hasattr(values.get("sim_f"), "inputs") and not values.get("inputs"):
+        values["inputs"] = values.get("sim_f").inputs
+    if hasattr(values.get("sim_f"), "outputs") and not values.get("outputs"):
+        values["outputs"] = values.get("sim_f").outputs
+    if hasattr(values.get("sim_f"), "persis_in") and not values.get("persis_in"):
+        values["persis_in"] = values.get("sim_f").persis_in
+    return values
 
-    @model_validator(mode="after")
-    def enable_save_H_when_every_K(self):
-        if not self.__dict__.get("save_H_on_completion") and (
-            self.__dict__.get("save_every_k_sims", 0) > 0 or self.__dict__.get("save_every_k_gens", 0) > 0
-        ):
-            self.__dict__["save_H_on_completion"] = True
-        return self
 
-    @model_validator(mode="after")
-    def set_workflow_dir(self):
-        return _check_set_workflow_dir(self)
+@root_validator
+def genf_set_in_out_from_attrs(cls, values):
+    if not values.get("gen_f"):
+        from libensemble.gen_funcs.sampling import latin_hypercube_sample
 
-    @model_validator(mode="after")
-    def set_calc_dirs_on_input_dir(self):
-        return _check_set_calc_dirs_on_input_dir(self)
+        values["gen_f"] = latin_hypercube_sample
+    if hasattr(values.get("gen_f"), "inputs") and not values.get("inputs"):
+        values["inputs"] = values.get("gen_f").inputs
+    if hasattr(values.get("gen_f"), "outputs") and not values.get("outputs"):
+        values["outputs"] = values.get("gen_f").outputs
+    if hasattr(values.get("gen_f"), "persis_in") and not values.get("persis_in"):
+        values["persis_in"] = values.get("gen_f").persis_in
+    return values
 
-    @model_validator(mode="after")
-    def check_exit_criteria(self):
-        return _check_exit_criteria(self)
 
-    @model_validator(mode="after")
-    def check_output_fields(self):
-        return _check_output_fields(self)
+# RESOURCES VALIDATORS #####
 
-    @model_validator(mode="after")
-    def check_H0(self):
-        return _check_H0(self)
 
-    @model_validator(mode="after")
-    def check_provided_ufuncs(self):
-        assert hasattr(self.sim_specs, "sim_f"), "Simulation function not provided to SimSpecs."
-        assert isinstance(self.sim_specs.sim_f, Callable), "Simulation function is not callable."
-
-        if self.alloc_specs.alloc_f.__name__ != "give_pregenerated_sim_work":
-            assert hasattr(self.gen_specs, "gen_f"), "Generator function not provided to GenSpecs."
-            assert isinstance(self.gen_specs.gen_f, Callable), "Generator function is not callable."
-
-        return self
-
-    @model_validator(mode="after")
-    def simf_set_in_out_from_attrs(self):
-        if hasattr(self.__dict__.get("sim_f"), "inputs") and not self.__dict__.get("inputs"):
-            self.__dict__["inputs"] = self.__dict__.get("sim_f").inputs
-        if hasattr(self.__dict__.get("sim_f"), "outputs") and not self.__dict__.get("outputs"):
-            self.__dict__["outputs"] = self.__dict__.get("sim_f").outputs
-        if hasattr(self.__dict__.get("sim_f"), "persis_in") and not self.__dict__.get("persis_in"):
-            self.__dict__["persis_in"] = self.__dict__.get("sim_f").persis_in
-        return self
-
-    @model_validator(mode="after")
-    def genf_set_in_out_from_attrs(self):
-        if hasattr(self.__dict__.get("gen_f"), "inputs") and not self.__dict__.get("inputs"):
-            self.__dict__["inputs"] = self.__dict__.get("gen_f").inputs
-        if hasattr(self.__dict__.get("gen_f"), "outputs") and not self.__dict__.get("outputs"):
-            self.__dict__["outputs"] = self.__dict__.get("gen_f").outputs
-        if hasattr(self.__dict__.get("gen_f"), "persis_in") and not self.__dict__.get("persis_in"):
-            self.__dict__["persis_in"] = self.__dict__.get("gen_f").persis_in
-        return self
-
-    # RESOURCES VALIDATORS #####
-
-    @model_validator(mode="after")
-    def check_logical_cores(self):
-        return _check_logical_cores(self)
+@root_validator
+def check_logical_cores(cls, values):
+    return _check_logical_cores(values)

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
         "libensemble.tests.unit_tests",
         "libensemble.tests.regression_tests",
     ],
-    install_requires=["numpy>=1.21", "psutil>=5.9.4", "pydantic>=1.10", "tomli>=1.2.1", "pyyaml>=6.0"],
+    install_requires=["numpy>=1.21", "psutil>=5.9.4", "pydantic>=1.10.17", "tomli>=1.2.1", "pyyaml>=6.0"],
     # numpy - oldest working version. psutil - oldest working version.
     # pyyaml - oldest working version.
     # If run tests through setup.py - downloads these but does not install


### PR DESCRIPTION
Pydantic v2 _and_ v1.10.17 have a `pydantic.v1` compatibility namespace/module that we can import everything we need from. This means that we only need a single interface (unfortunately, the old one) to be compatible with both versions.

This is much cleaner, but I wouldn't be surprised if there's a slight performance drawback if the validation in the `v1` module only occurs in python instead of rust.