### PR TITLE
First attempt at allowing decorating of objects with e.g. ``@output_data(["x"])``

### DIFF
--- a/libensemble/gen_classes/sampling.py
+++ b/libensemble/gen_classes/sampling.py
@@ -3,6 +3,7 @@
 import numpy as np
 
 from libensemble.generators import Generator, LibensembleGenerator
+from libensemble.specs import output_data
 
 __all__ = [
     "UniformSample",
@@ -23,6 +24,7 @@ class SampleBase(LibensembleGenerator):
         assert isinstance(self.ub, np.ndarray), "ub must be a numpy array"
 
 
+@output_data(["x"])
 class UniformSample(SampleBase):
     """
     This generator returns ``gen_specs["initial_batch_size"]`` uniformly
@@ -47,6 +49,7 @@ class UniformSample(SampleBase):
 # List of dictionaries format for ask (constructor currently using numpy still)
 # Mostly standard generator interface for libE generators will use the ask/tell wrappers
 # to the classes above. This is for testing a function written directly with that interface.
+@output_data(["x0", "x1", "xn", "..."])
 class UniformSampleDicts(Generator):
     """
     This generator returns ``gen_specs["initial_batch_size"]`` uniformly
@@ -60,11 +63,15 @@ class UniformSampleDicts(Generator):
         self.persis_info = persis_info
         self._get_user_params(self.gen_specs["user"])
 
+    # TODO: flatten this
     def ask(self, n_trials):
         H_o = []
         for _ in range(n_trials):
             # using same rand number stream
             trial = {"x": self.persis_info["rand_stream"].uniform(self.lb, self.ub, self.n)}
+            import ipdb
+
+            ipdb.set_trace()
             H_o.append(trial)
         return H_o
 

--- a/libensemble/specs.py
+++ b/libensemble/specs.py
@@ -621,6 +621,9 @@ def output_data(fields: List[Union[Tuple[str, Any], Tuple[str, Any, Union[int, T
             H_o = np.zeros(1, dtype=sim_specs["out"])
             H_o["f"] = np.linalg.norm(x)
             return H_o, persis_info
+
+    Devs: Optionally, specify only a list of field names. This will have no effect on ``.outputs``, but
+    those fields will render in the docs.
     """
 
     def decorator(func):

--- a/libensemble/utils/validators.py
+++ b/libensemble/utils/validators.py
@@ -265,9 +265,18 @@ else:
 
     @model_validator(mode="after")
     def simf_set_in_out_from_attrs(self):
+        """
+        Set inputs and outputs, if the user function has those attributes and we haven't set them in specs.
+        For outputs, only if the contents are dtype-like.
+        """
+        # a list-of-fields attribute for outputs is useful for docs, but not for initializing an array
         if hasattr(self.__dict__.get("sim_f"), "inputs") and not self.__dict__.get("inputs"):
             self.__dict__["inputs"] = self.__dict__.get("sim_f").inputs
-        if hasattr(self.__dict__.get("sim_f"), "outputs") and not self.__dict__.get("outputs"):
+        if (
+            hasattr(self.__dict__.get("sim_f"), "outputs")
+            and not self.__dict__.get("outputs")
+            and isinstance(self.__dict__.get("sim_f").outputs[0], tuple)
+        ):
             self.__dict__["outputs"] = self.__dict__.get("sim_f").outputs
         if hasattr(self.__dict__.get("sim_f"), "persis_in") and not self.__dict__.get("persis_in"):
             self.__dict__["persis_in"] = self.__dict__.get("sim_f").persis_in
@@ -275,9 +284,18 @@ else:
 
     @model_validator(mode="after")
     def genf_set_in_out_from_attrs(self):
+        """
+        Set inputs and outputs, if the user function has those attributes and we haven't set them in specs.
+        For outputs, only if the contents are dtype-like.
+        """
+        # a list-of-fields attribute for outputs is useful for docs, but not for initializing an array
         if hasattr(self.__dict__.get("gen_f"), "inputs") and not self.__dict__.get("inputs"):
             self.__dict__["inputs"] = self.__dict__.get("gen_f").inputs
-        if hasattr(self.__dict__.get("gen_f"), "outputs") and not self.__dict__.get("outputs"):
+        if (
+            hasattr(self.__dict__.get("gen_f"), "outputs")
+            and not self.__dict__.get("outputs")
+            and isinstance(self.__dict__.get("gen_f").outputs[0], tuple)
+        ):
             self.__dict__["outputs"] = self.__dict__.get("gen_f").outputs
         if hasattr(self.__dict__.get("gen_f"), "persis_in") and not self.__dict__.get("persis_in"):
             self.__dict__["persis_in"] = self.__dict__.get("gen_f").persis_in


### PR DESCRIPTION
So these fields show up in docs, but won't affect gen_specs