### PR TITLE
NLopt isn't stopping as soon as before.

### DIFF
--- a/libensemble/tests/regression_tests/test_persistent_aposmm_with_grad.py
+++ b/libensemble/tests/regression_tests/test_persistent_aposmm_with_grad.py
@@ -76,7 +76,7 @@ if __name__ == "__main__":
             "initial_sample_size": 0,  # Don't need to do evaluations because the sampling already done below
             "localopt_method": "LD_MMA",
             "rk_const": 0.5 * ((gamma(1 + (n / 2)) * 5) ** (1 / n)) / sqrt(pi),
-            "stop_after_k_minima": 25,
+            "stop_after_k_minima": 15,
             "xtol_rel": 1e-6,
             "ftol_rel": 1e-6,
             "max_active_runs": 6,


### PR DESCRIPTION
One of many features of APOSMM being tested by this test was the ability to stop after k local minima have been identified. 

This was set to 25 before and was sufficient to find all 6 local minima in less than 1000 sim evals.

Due to updates to NLopt, this is no longer the case: 1000 evals are surpassed before 25 minima are found.

Decreasing the 25 to 15 fixes the issue, and also still finds all 6 of the 6-hump-camel minima. 