### PR TITLE
Fix wait_on_start type-instance condition checking to use fail_time w…

### DIFF
--- a/libensemble/executors/executor.py
+++ b/libensemble/executors/executor.py
@@ -687,7 +687,7 @@ class Executor:
         stdout: Optional[str] = None,
         stderr: Optional[str] = None,
         dry_run: Optional[bool] = False,
-        wait_on_start: Optional[Union[bool, int]] = False,
+        wait_on_start: Optional[bool] = False,
         env_script: Optional[str] = None,
     ) -> Task:
         """Create a new task and run as a local serial subprocess.
@@ -718,7 +718,7 @@ class Executor:
             Whether this is a dry_run - no task will be launched; instead
             runline is printed to logger (at INFO level)
 
-        wait_on_start: bool or int, Optional
+        wait_on_start: bool, Optional
             Whether to wait for task to be polled as RUNNING (or other
             active/end state) before continuing. If an integer N is supplied,
             wait at most N seconds.

--- a/libensemble/executors/mpi_executor.py
+++ b/libensemble/executors/mpi_executor.py
@@ -164,10 +164,11 @@ class MPIExecutor(Executor):
                 task.finished = True
                 retry = True
                 retry_count += 1
-            else:
-                if wait_on_start:
-                    wait_time = wait_on_start if isinstance(wait_on_start, int) else self.fail_time
-                    self._wait_on_start(task, wait_time)
+            else:  # *actually* got True
+                if (wait_on_start == 1) and isinstance(wait_on_start, bool):
+                    self._wait_on_start(task, self.fail_time)
+                elif isinstance(wait_on_start, int):  # got another integer. False is fine: zero wait-time
+                    self._wait_on_start(task, wait_on_start)
                 task.poll()
 
                 if task.state == "FAILED":

--- a/libensemble/executors/mpi_executor.py
+++ b/libensemble/executors/mpi_executor.py
@@ -138,7 +138,7 @@ class MPIExecutor(Executor):
         self.resources = resources
 
     def _launch_with_retries(
-        self, task: Task, subgroup_launch: bool, wait_on_start: Union[bool, int], run_cmd: List[str], use_shell: bool
+        self, task: Task, subgroup_launch: bool, wait_on_start: bool, run_cmd: List[str], use_shell: bool
     ) -> None:
         """Launch task with retry mechanism"""
         retry_count = 0
@@ -164,11 +164,9 @@ class MPIExecutor(Executor):
                 task.finished = True
                 retry = True
                 retry_count += 1
-            else:  # *actually* got True
-                if (wait_on_start == 1) and isinstance(wait_on_start, bool):
+            else:
+                if wait_on_start:
                     self._wait_on_start(task, self.fail_time)
-                elif isinstance(wait_on_start, int):  # got another integer. False is fine: zero wait-time
-                    self._wait_on_start(task, wait_on_start)
                 task.poll()
 
                 if task.state == "FAILED":
@@ -201,7 +199,7 @@ class MPIExecutor(Executor):
         stage_inout: Optional[str] = None,
         hyperthreads: Optional[bool] = False,
         dry_run: Optional[bool] = False,
-        wait_on_start: Optional[Union[bool, int]] = False,
+        wait_on_start: Optional[bool] = False,
         extra_args: Optional[str] = None,
         auto_assign_gpus: Optional[bool] = False,
         match_procs_to_gpus: Optional[bool] = False,
@@ -261,10 +259,9 @@ class MPIExecutor(Executor):
             Whether this is a dry_run - no task will be launched; instead
             runline is printed to logger (at INFO level)
 
-        wait_on_start: bool or int, Optional
+        wait_on_start: bool, Optional
             Whether to wait for task to be polled as RUNNING (or other
-            active/end state) before continuing. If an integer N is supplied,
-            wait at most N seconds.
+            active/end state) before continuing.
 
         extra_args: str, Optional
             Additional command line arguments to supply to MPI runner. If

--- a/libensemble/tests/unit_tests/test_executor.py
+++ b/libensemble/tests/unit_tests/test_executor.py
@@ -306,7 +306,7 @@ def test_launch_wait_on_start():
     exctr = Executor.executor
     cores = NCORES
     args_for_sim = "sleep 0.2"
-    for value in [False, True, 1, 2, 3, "dontfail"]:
+    for value in [False, True]:
         task = exctr.submit(calc_type="sim", num_procs=cores, app_args=args_for_sim, wait_on_start=value)
         assert task.state not in NOT_STARTED_STATES, "Task should not be in a NOT_STARTED state. State: " + str(
             task.state
@@ -737,7 +737,7 @@ def test_retries_run_fail():
     exctr.retry_delay_incr = 0.05
     cores = NCORES
     args_for_sim = "sleep 0 Fail"
-    task = exctr.submit(calc_type="sim", num_procs=cores, app_args=args_for_sim, wait_on_start=3)
+    task = exctr.submit(calc_type="sim", num_procs=cores, app_args=args_for_sim, wait_on_start=True)
     assert task.state == "FAILED", "task.state should be FAILED. Returned " + str(task.state)
     assert task.run_attempts == 5, "task.run_attempts should be 5. Returned " + str(task.run_attempts)
 

--- a/libensemble/tests/unit_tests/test_executor.py
+++ b/libensemble/tests/unit_tests/test_executor.py
@@ -51,9 +51,9 @@ def setup_module(module):
 
         mpi4py.rc.initialize = False
     try:
-        print(f"setup_module module:{module.__name__}")
+        print(f"setup_module module: {module.__name__}")
     except AttributeError:
-        print(f"setup_module (direct run) module:{module}")
+        print(f"setup_module (direct run) module: {module}")
     if Executor.executor is not None:
         del Executor.executor
         Executor.executor = None
@@ -61,7 +61,7 @@ def setup_module(module):
 
 
 def setup_function(function):
-    print(f"setup_function function:{function.__name__}")
+    print(f"setup_function function: {function.__name__}")
     if Executor.executor is not None:
         del Executor.executor
         Executor.executor = None
@@ -69,9 +69,9 @@ def setup_function(function):
 
 def teardown_module(module):
     try:
-        print(f"teardown_module module:{module.__name__}")
+        print(f"teardown_module module: {module.__name__}")
     except AttributeError:
-        print(f"teardown_module (direct run) module:{module}")
+        print(f"teardown_module (direct run) module: {module}")
     if Executor.executor is not None:
         del Executor.executor
         Executor.executor = None
@@ -306,7 +306,7 @@ def test_launch_wait_on_start():
     exctr = Executor.executor
     cores = NCORES
     args_for_sim = "sleep 0.2"
-    for value in [True, 1]:
+    for value in [False, True, 1, 2, 3]:
         task = exctr.submit(calc_type="sim", num_procs=cores, app_args=args_for_sim, wait_on_start=value)
         assert task.state not in NOT_STARTED_STATES, "Task should not be in a NOT_STARTED state. State: " + str(
             task.state

--- a/libensemble/tests/unit_tests/test_executor.py
+++ b/libensemble/tests/unit_tests/test_executor.py
@@ -306,7 +306,7 @@ def test_launch_wait_on_start():
     exctr = Executor.executor
     cores = NCORES
     args_for_sim = "sleep 0.2"
-    for value in [False, True, 1, 2, 3]:
+    for value in [False, True, 1, 2, 3, "dontfail"]:
         task = exctr.submit(calc_type="sim", num_procs=cores, app_args=args_for_sim, wait_on_start=value)
         assert task.state not in NOT_STARTED_STATES, "Task should not be in a NOT_STARTED state. State: " + str(
             task.state


### PR DESCRIPTION
Addresses #1468.

Basically `True` and `False` got interpreted as `0` and `1`, valid integers for `wait_on_start`,
meaning the `Executor.fail_time` attribute never got used.

Now we use that attribute if we _actually_ got `True`. Any other integer >1 means we wait for that time. `False` being `0` should simply mean we don't wait.

Thanks @cchall!