### PR TITLE
Logging updates

### DIFF
--- a/docs/history_output_logging.rst
+++ b/docs/history_output_logging.rst
@@ -37,7 +37,7 @@ Logger Configuration
 ~~~~~~~~~~~~~~~~~~~~
 
 The libEnsemble logger uses the following logging levels
-(``VDEBUG``, ``DEBUG``, ``INFO``, ``WARNING``, ``MANAGER_WARNING`` ``ERROR``, ``CRITICAL``)
+(``VDEBUG``, ``DEBUG``, ``INFO``, ``WARNING``, ``MANAGER_WARNING``, ``ERROR``, ``CRITICAL``)
 
 The default level is ``INFO``, which includes information about how tasks are submitted
 and when tasks are killed. To gain additional diagnostics, including communication

--- a/docs/history_output_logging.rst
+++ b/docs/history_output_logging.rst
@@ -36,13 +36,15 @@ Two other libEnsemble files produced by default:
 Logger Configuration
 ~~~~~~~~~~~~~~~~~~~~
 
-The libEnsemble logger uses the standard Python logging levels (``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``, ``CRITICAL``)
-plus one additional custom level (``MANAGER_WARNING``) between ``WARNING`` and ``ERROR``.
+The libEnsemble logger uses the following logging levels
+(``VDEBUG``, ``DEBUG``, ``INFO``, ``WARNING``, ``MANAGER_WARNING`` ``ERROR``, ``CRITICAL``)
 
 The default level is ``INFO``, which includes information about how tasks are submitted
-and when tasks are killed. To gain additional diagnostics, set the logging level
-to ``DEBUG``. libEnsemble writes to ``ensemble.log`` by default. A log
-file name can also be supplied.
+and when tasks are killed. To gain additional diagnostics, including communication
+tracking, set the logging level to ``DEBUG``. In rare cases, the ``VDEBUG`` level may
+be useful, which also tracks log messages.
+
+libEnsemble writes to ``ensemble.log`` by default. A log file name can also be supplied.
 
 To change the logging level to ``DEBUG``::
 

--- a/libensemble/logger.py
+++ b/libensemble/logger.py
@@ -8,9 +8,11 @@ MANAGER_WARNING = 35
 logging.addLevelName(MANAGER_WARNING, "MANAGER_WARNING")
 logging.MANAGER_WARNING = MANAGER_WARNING
 
+
 def manager_warning(self, message: str, *args, **kwargs) -> None:
     if self.isEnabledFor(MANAGER_WARNING):
         self._log(MANAGER_WARNING, message, args, **kwargs)
+
 
 logging.Logger.manager_warning = manager_warning
 
@@ -18,9 +20,11 @@ VDEBUG = 5
 logging.addLevelName(VDEBUG, "VDEBUG")
 logging.VDEBUG = VDEBUG
 
+
 def vdebug(self, message, *args, **kwargs):
     if self.isEnabledFor(VDEBUG):
         self._log(VDEBUG, message, args, **kwargs)
+
 
 logging.Logger.vdebug = vdebug
 

--- a/libensemble/logger.py
+++ b/libensemble/logger.py
@@ -8,13 +8,22 @@ MANAGER_WARNING = 35
 logging.addLevelName(MANAGER_WARNING, "MANAGER_WARNING")
 logging.MANAGER_WARNING = MANAGER_WARNING
 
-
 def manager_warning(self, message: str, *args, **kwargs) -> None:
     if self.isEnabledFor(MANAGER_WARNING):
         self._log(MANAGER_WARNING, message, args, **kwargs)
 
-
 logging.Logger.manager_warning = manager_warning
+
+VDEBUG = 5
+logging.addLevelName(VDEBUG, "VDEBUG")
+logging.VDEBUG = VDEBUG
+
+def vdebug(self, message, *args, **kwargs):
+    if self.isEnabledFor(VDEBUG):
+        self._log(VDEBUG, message, args, **kwargs)
+
+logging.Logger.vdebug = vdebug
+
 LogConfig(__package__)
 
 

--- a/libensemble/manager.py
+++ b/libensemble/manager.py
@@ -532,7 +532,7 @@ class Manager:
                 self._kill_workers()
                 raise WorkerException(f"Received error message from worker {w}", D_recv.msg, D_recv.exc)
         elif isinstance(D_recv, logging.LogRecord):
-            logger.debug(f"Manager received a log message from worker {w}")
+            logger.vdebug(f"Manager received a log message from worker {w}")
             logging.getLogger(D_recv.name).handle(D_recv)
         else:
             logger.debug(f"Manager received data message from worker {w}")

--- a/libensemble/manager.py
+++ b/libensemble/manager.py
@@ -678,7 +678,7 @@ class Manager:
 
     def run(self, persis_info: dict) -> (dict, int, int):
         """Runs the manager"""
-        logger.info(f"Manager initiated on node {socket.gethostname()}")
+        logger.debug(f"Manager initiated on node {socket.gethostname()}")
         logger.info(f"Manager exit_criteria: {self.exit_criteria}")
 
         # Continue receiving and giving until termination test is satisfied

--- a/libensemble/resources/scheduler.py
+++ b/libensemble/resources/scheduler.py
@@ -296,15 +296,9 @@ class ResourceScheduler:
         return slots_avail_by_group
 
     def calc_req_split(self, rsets_req, max_grpsize, num_groups, extend):
-        if self.resources.even_groups:  # This is total group sizes even (not available sizes)
-            rsets_req, num_groups_req, rsets_per_group = self.calc_rsets_even_grps(
-                rsets_req, max_grpsize, num_groups, extend
-            )
-        else:
-            logger.warning("Uneven groups - but using even groups function")
-            rsets_req, num_groups_req, rsets_per_group = self.calc_rsets_even_grps(
-                rsets_req, max_grpsize, num_groups, extend
-            )
+        rsets_req, num_groups_req, rsets_per_group = self.calc_rsets_even_grps(
+            rsets_req, max_grpsize, num_groups, extend
+        )
         return rsets_req, num_groups_req, rsets_per_group
 
     def calc_rsets_even_grps(self, rsets_req, max_grpsize, max_groups, extend):

--- a/libensemble/tests/unit_tests_logger/test_logger.py
+++ b/libensemble/tests/unit_tests_logger/test_logger.py
@@ -19,6 +19,10 @@ def test_set_log_level():
     level = logger.get_level()
     assert level == 10, "Log level should be 10. Found: " + str(level)
 
+    logger.set_level("VDEBUG")
+    level = logger.get_level()
+    assert level == 5, "Log level should be 5. Found: " + str(level)
+
     logger.set_level("WARNING")
     level = logger.get_level()
     assert level == 30, "Log level should be 30. Found: " + str(level)

--- a/libensemble/tests/unit_tests_logger/test_logger.py
+++ b/libensemble/tests/unit_tests_logger/test_logger.py
@@ -5,6 +5,7 @@ Unit test of libensemble log functions.
 """
 import logging
 import os
+import pytest
 
 from libensemble import logger
 from libensemble.comms.logs import LogConfig
@@ -57,8 +58,8 @@ def test_set_filename():
 
     assert os.path.isfile(alt_name), "Expected creation of file" + str(alt_name)
     with open(alt_name, "r") as f:
-        line = f.readline()
-        assert "Cannot set filename after loggers initialized" in line
+        file_content = f.read()
+        assert "Cannot set filename after loggers initialized" in file_content
     try:
         os.remove(alt_name)
     except PermissionError:  # windows only
@@ -108,9 +109,25 @@ def test_set_stderr_level():
     stderr_level = logger.get_stderr_level()
     assert stderr_level == 40, "Log level should be 40. Found: " + str(stderr_level)
 
-    logger.set_level("ERROR")
+
+def test_custom_log_levels():
+    from libensemble.comms.logs import manager_logging_config
+
+    manager_logging_config()
     logger_test = logging.getLogger("libensemble")
+    logger.set_level("ERROR")
     logger_test.manager_warning("This test message should not log")
+    logger.set_level("DEBUG")
+    logger_test.vdebug("This test message should not log")
+    logger.set_level("VDEBUG")
+    logger_test.manager_warning("This manager_warning message should log")
+    logger_test.vdebug("This vdebug message should log")
+
+    with open(LogConfig.config.filename, 'r') as f:
+        file_content = f.read()
+        assert "This manager_warning message should log" in file_content
+        assert "This vdebug message should log" in file_content
+        assert "This test message should not log" not in file_content
 
 
 # Need setup/teardown here to kill loggers if running file without pytest
@@ -118,7 +135,4 @@ def test_set_stderr_level():
 # Partial solution: either rename the file so it is the first unit test, or
 #   move this unit test to its own directory.
 if __name__ == "__main__":
-    test_set_log_level()
-    test_set_filename()
-    test_set_directory()
-    test_set_stderr_level()
+    pytest.main([__file__])

--- a/libensemble/tests/unit_tests_logger/test_logger.py
+++ b/libensemble/tests/unit_tests_logger/test_logger.py
@@ -15,13 +15,13 @@ def test_set_log_level():
     level = logger.get_level()
     assert level == 20, "Log level should be 20. Found: " + str(level)
 
-    logger.set_level("DEBUG")
-    level = logger.get_level()
-    assert level == 10, "Log level should be 10. Found: " + str(level)
-
     logger.set_level("VDEBUG")
     level = logger.get_level()
     assert level == 5, "Log level should be 5. Found: " + str(level)
+
+    logger.set_level("DEBUG")
+    level = logger.get_level()
+    assert level == 10, "Log level should be 10. Found: " + str(level)
 
     logger.set_level("WARNING")
     level = logger.get_level()
@@ -83,6 +83,10 @@ def test_set_directory(tmp_path):
 def test_set_stderr_level():
     stderr_level = logger.get_stderr_level()
     assert stderr_level == 35, "Default stderr copying level is 35, found " + str(stderr_level)
+
+    logger.set_stderr_level("VDEBUG")
+    stderr_level = logger.get_stderr_level()
+    assert stderr_level == 5, "Log level should be 5. Found: " + str(stderr_level)
 
     logger.set_stderr_level("DEBUG")
     stderr_level = logger.get_stderr_level()

--- a/libensemble/worker.py
+++ b/libensemble/worker.py
@@ -364,7 +364,7 @@ class Worker:
             return None
 
         # Otherwise, send a calc result back to manager
-        logger.debug(f"Sending to Manager with status {calc_status}")
+        logger.debug(f"Sending data to Manager with status {calc_status}")
         return {
             "calc_out": calc_out,
             "persis_info": persis_info,

--- a/libensemble/worker.py
+++ b/libensemble/worker.py
@@ -376,7 +376,7 @@ class Worker:
     def run(self) -> None:
         """Runs the main worker loop."""
         try:
-            logger.info(f"Worker {self.workerID} initiated on node {socket.gethostname()}")
+            logger.debug(f"Worker {self.workerID} initiated on node {socket.gethostname()}")
 
             for worker_iter in count(start=1):
                 logger.debug(f"Iteration {worker_iter}")

--- a/libensemble/worker.py
+++ b/libensemble/worker.py
@@ -376,7 +376,10 @@ class Worker:
     def run(self) -> None:
         """Runs the main worker loop."""
         try:
-            logger.debug(f"Worker {self.workerID} initiated on node {socket.gethostname()}")
+            if self.libE_specs["comms"] in ["local", "threads"]:
+                logger.debug(f"Worker {self.workerID} initiated")
+            else:
+                logger.debug(f"Worker {self.workerID} initiated on node {socket.gethostname()}")
 
             for worker_iter in count(start=1):
                 logger.debug(f"Iteration {worker_iter}")


### PR DESCRIPTION
Showing worker node with local comms can confuse users.

Only show worker node in the log when running in a distributed mode (e.g., MPI comms).

Also only report manager/worker initialization with debug logging.

This also adds a `VDEBUG` logging level for logging of communicating log messages, as this is rarely needed and is very verbose.

Removes unhelpful Uneven groups warning