### PR TITLE
Reduce dependabot commits via grouping and lowering frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,17 +10,30 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly # Reduced frequency
     target-branch: "develop"
+    groups:
+      actions-updates:
+        patterns:
+          - "actions/*"
 
   - package-ecosystem: pip
     directory: /
     schedule:
-      interval: daily
+      interval: weekly # Reduced frequency
     target-branch: "develop"
+    groups:
+      python-updates:
+        patterns:
+          - "*"
 
   - package-ecosystem: gitsubmodule
     directory: /
     schedule:
-      interval: daily
+      interval: weekly # Reduced frequency
     target-branch: "develop"
+    groups:
+      submodule-updates:
+        patterns:
+          - "*"
+


### PR DESCRIPTION
Dependabot is swamping developer commits.

