### PR TITLE
Return None from persistent gens

### DIFF
--- a/libensemble/gen_funcs/persistent_ax_multitask.py
+++ b/libensemble/gen_funcs/persistent_ax_multitask.py
@@ -305,7 +305,7 @@ def persistent_gp_mt_ax_gen_f(H, persis_info, gen_specs, libE_info):
         # Increase iteration counter.
         model_iteration += 1
 
-    return [], persis_info, FINISHED_PERSISTENT_GEN_TAG
+    return None, persis_info, FINISHED_PERSISTENT_GEN_TAG
 
 
 class AxRunner(Runner):

--- a/libensemble/gen_funcs/persistent_gpCAM.py
+++ b/libensemble/gen_funcs/persistent_gpCAM.py
@@ -212,7 +212,7 @@ def persistent_gpCAM_simple(H_in, persis_info, gen_specs, libE_info):
                 x_for_var = persis_info["rand_stream"].uniform(lb, ub, (10 * batch_size, n))
             var_vals = _eval_var(my_gp, all_x, all_y, x_for_var, test_points, persis_info)
 
-    return H_o, persis_info, FINISHED_PERSISTENT_GEN_TAG
+    return None, persis_info, FINISHED_PERSISTENT_GEN_TAG
 
 
 def persistent_gpCAM_ask_tell(H_in, persis_info, gen_specs, libE_info):
@@ -264,4 +264,4 @@ def persistent_gpCAM_ask_tell(H_in, persis_info, gen_specs, libE_info):
 
         tag, Work, calc_in = ps.send_recv(H_o)
 
-    return H_o, persis_info, FINISHED_PERSISTENT_GEN_TAG
+    return None, persis_info, FINISHED_PERSISTENT_GEN_TAG

--- a/libensemble/gen_funcs/persistent_inverse_bayes.py
+++ b/libensemble/gen_funcs/persistent_inverse_bayes.py
@@ -3,6 +3,10 @@ import numpy as np
 from libensemble.message_numbers import EVAL_GEN_TAG, FINISHED_PERSISTENT_GEN_TAG, PERSIS_STOP, STOP_TAG
 from libensemble.tools.persistent_support import PersistentSupport
 
+__all__ = [
+    "persistent_updater_after_likelihood",
+]
+
 
 def persistent_updater_after_likelihood(H, persis_info, gen_specs, libE_info):
     """ """
@@ -36,4 +40,4 @@ def persistent_updater_after_likelihood(H, persis_info, gen_specs, libE_info):
         if calc_in is not None:
             w = H_o["prior"] + calc_in["like"] - H_o["prop"]
 
-    return H_o, persis_info, FINISHED_PERSISTENT_GEN_TAG
+    return None, persis_info, FINISHED_PERSISTENT_GEN_TAG

--- a/libensemble/gen_funcs/persistent_sampling.py
+++ b/libensemble/gen_funcs/persistent_sampling.py
@@ -60,7 +60,7 @@ def persistent_uniform(_, persis_info, gen_specs, libE_info):
         if hasattr(calc_in, "__len__"):
             b = len(calc_in)
 
-    return H_o, persis_info, FINISHED_PERSISTENT_GEN_TAG
+    return None, persis_info, FINISHED_PERSISTENT_GEN_TAG
 
 
 def persistent_uniform_final_update(_, persis_info, gen_specs, libE_info):
@@ -163,7 +163,7 @@ def persistent_request_shutdown(_, persis_info, gen_specs, libE_info):
             print("Reached threshold.", f_count, flush=True)
             break  # End the persistent gen
 
-    return H_o, persis_info, FINISHED_PERSISTENT_GEN_TAG
+    return None, persis_info, FINISHED_PERSISTENT_GEN_TAG
 
 
 def uniform_nonblocking(_, persis_info, gen_specs, libE_info):
@@ -197,7 +197,7 @@ def uniform_nonblocking(_, persis_info, gen_specs, libE_info):
         if hasattr(calc_in, "__len__"):
             b = len(calc_in)
 
-    return H_o, persis_info, FINISHED_PERSISTENT_GEN_TAG
+    return None, persis_info, FINISHED_PERSISTENT_GEN_TAG
 
 
 def batched_history_matching(_, persis_info, gen_specs, libE_info):
@@ -243,7 +243,7 @@ def batched_history_matching(_, persis_info, gen_specs, libE_info):
             mu = np.mean(H_o["x"][best_inds], axis=0)
             Sigma = np.cov(H_o["x"][best_inds].T)
 
-    return H_o, persis_info, FINISHED_PERSISTENT_GEN_TAG
+    return None, persis_info, FINISHED_PERSISTENT_GEN_TAG
 
 
 def persistent_uniform_with_cancellations(_, persis_info, gen_specs, libE_info):
@@ -272,4 +272,4 @@ def persistent_uniform_with_cancellations(_, persis_info, gen_specs, libE_info):
             cancel_from += b
             ps.request_cancel_sim_ids(cancel_ids)
 
-    return H_o, persis_info, FINISHED_PERSISTENT_GEN_TAG
+    return None, persis_info, FINISHED_PERSISTENT_GEN_TAG

--- a/libensemble/gen_funcs/persistent_sampling_var_resources.py
+++ b/libensemble/gen_funcs/persistent_sampling_var_resources.py
@@ -58,7 +58,7 @@ def uniform_sample(_, persis_info, gen_specs, libE_info):
         if hasattr(calc_in, "__len__"):
             b = len(calc_in)
 
-    return H_o, persis_info, FINISHED_PERSISTENT_GEN_TAG
+    return None, persis_info, FINISHED_PERSISTENT_GEN_TAG
 
 
 def uniform_sample_with_var_gpus(_, persis_info, gen_specs, libE_info):
@@ -99,7 +99,7 @@ def uniform_sample_with_var_gpus(_, persis_info, gen_specs, libE_info):
         if hasattr(calc_in, "__len__"):
             b = len(calc_in)
 
-    return H_o, persis_info, FINISHED_PERSISTENT_GEN_TAG
+    return None, persis_info, FINISHED_PERSISTENT_GEN_TAG
 
 
 def uniform_sample_with_procs_gpus(_, persis_info, gen_specs, libE_info):
@@ -128,7 +128,7 @@ def uniform_sample_with_procs_gpus(_, persis_info, gen_specs, libE_info):
         if hasattr(calc_in, "__len__"):
             b = len(calc_in)
 
-    return H_o, persis_info, FINISHED_PERSISTENT_GEN_TAG
+    return None, persis_info, FINISHED_PERSISTENT_GEN_TAG
 
 
 def uniform_sample_with_var_priorities(_, persis_info, gen_specs, libE_info):
@@ -163,7 +163,7 @@ def uniform_sample_with_var_priorities(_, persis_info, gen_specs, libE_info):
 
         tag, Work, calc_in = ps.send_recv(H_o)
 
-    return H_o, persis_info, FINISHED_PERSISTENT_GEN_TAG
+    return None, persis_info, FINISHED_PERSISTENT_GEN_TAG
 
 
 def uniform_sample_diff_simulations(_, persis_info, gen_specs, libE_info):
@@ -197,7 +197,7 @@ def uniform_sample_diff_simulations(_, persis_info, gen_specs, libE_info):
         if hasattr(calc_in, "__len__"):
             b = len(calc_in)
 
-    return H_o, persis_info, FINISHED_PERSISTENT_GEN_TAG
+    return None, persis_info, FINISHED_PERSISTENT_GEN_TAG
 
 
 def uniform_sample_with_sim_gen_resources(_, persis_info, gen_specs, libE_info):
@@ -245,4 +245,4 @@ def uniform_sample_with_sim_gen_resources(_, persis_info, gen_specs, libE_info):
         if hasattr(calc_in, "__len__"):
             b = len(calc_in)
 
-    return H_o, persis_info, FINISHED_PERSISTENT_GEN_TAG
+    return None, persis_info, FINISHED_PERSISTENT_GEN_TAG

--- a/libensemble/gen_funcs/persistent_tasmanian.py
+++ b/libensemble/gen_funcs/persistent_tasmanian.py
@@ -10,6 +10,11 @@ from libensemble.message_numbers import EVAL_GEN_TAG, FINISHED_PERSISTENT_GEN_TA
 from libensemble.tools import parse_args
 from libensemble.tools.persistent_support import PersistentSupport
 
+__all__ = [
+    "sparse_grid_batched",
+    "sparse_grid_async",
+]
+
 
 def lex_le(x, y, tol=1e-12):
     """
@@ -195,7 +200,7 @@ def sparse_grid_batched(H, persis_info, gen_specs, libE_info):
             assert "sCriteria" in U
             grid.setSurplusRefinement(U["fTolerance"], U["iOutput"], U["sCriteria"])
 
-    return H0, persis_info, FINISHED_PERSISTENT_GEN_TAG
+    return None, persis_info, FINISHED_PERSISTENT_GEN_TAG
 
 
 def sparse_grid_async(H, persis_info, gen_specs, libE_info):
@@ -283,7 +288,7 @@ def sparse_grid_async(H, persis_info, gen_specs, libE_info):
         else:
             tag, Work, calc_in = ps.recv()
 
-    return [], persis_info, FINISHED_PERSISTENT_GEN_TAG
+    return None, persis_info, FINISHED_PERSISTENT_GEN_TAG
 
 
 def get_sparse_grid_specs(user_specs, sim_f, num_dims, num_outputs=1, mode="batched"):


### PR DESCRIPTION
- [x] What about APOSMM and fd_param_finder?

### Explanation

Look at this code, which is typical for our persistent gens.

```python

    while tag not in [STOP_TAG, PERSIS_STOP]:
        H_o = np.zeros(b, dtype=gen_specs["out"])
        H_o["x"] = persis_info["rand_stream"].uniform(lb, ub, (b, n))
        tag, Work, calc_in = ps.send_recv(H_o)


    return H_o, persis_info, FINISHED_PERSISTENT_GEN_TAG

```

H_o is sent to the manager in `ps.send_recv(H_o)`. Then at end those points are returned (again). They get added twice - the manager will give new sim_ids. We decided to ignore the return H_o unless `use_persis_return_gen` is set, in order to prevent that. Also, bear in mind, users will have used these as templates to their own gens. 

We should make our gens end with 

`return None, persis_info, FINISHED_PERSISTENT_GEN_TAG`

unless we do something after the loop and actually make a different H_o.

The same should be done in community examples.

We can do this with the intent to drop  `use_persis_return_gen` once this is normalized.