### PR TITLE
Very thin wrapper for local History arrays

### DIFF
--- a/libensemble/array.py
+++ b/libensemble/array.py
@@ -1,0 +1,25 @@
+import numpy as np
+
+
+class Array:
+    def __init__(self, size, specs):
+        self.size = size
+        self.specs = specs
+        self.dtype = self.specs["out"]
+        self.data = np.zeros(size, dtype=self.dtype)
+
+    def __setitem__(self, name, value):
+        self.data[name] = value
+
+    def __getitem__(self, name):
+        return self.data[name]
+
+    @property
+    def fields(self):
+        return self.data.dtype.fields
+
+    def grow(self, size: int):
+        self.data = np.append(self.data, np.zeros(size, dtype=self.dtype))
+
+    def reset(self):
+        self.data = np.zeros(self.size, dtype=self.dtype)

--- a/libensemble/gen_funcs/persistent_sampling.py
+++ b/libensemble/gen_funcs/persistent_sampling.py
@@ -44,19 +44,22 @@ def persistent_uniform(_, persis_info, gen_specs, libE_info):
         `test_persistent_uniform_sampling_async.py <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/functionality_tests/test_persistent_uniform_sampling_async.py>`_
     """  # noqa
 
+    from libensemble.array import Array
+
     b, n, lb, ub = _get_user_params(gen_specs["user"])
     ps = PersistentSupport(libE_info, EVAL_GEN_TAG)
 
     # Send batches until manager sends stop tag
     tag = None
+    H_o = Array(b, gen_specs)
     while tag not in [STOP_TAG, PERSIS_STOP]:
-        H_o = np.zeros(b, dtype=gen_specs["out"])
+        H_o.reset()
         H_o["x"] = persis_info["rand_stream"].uniform(lb, ub, (b, n))
-        if "obj_component" in H_o.dtype.fields:
+        if "obj_component" in H_o.fields:
             H_o["obj_component"] = persis_info["rand_stream"].integers(
                 low=0, high=gen_specs["user"]["num_components"], size=b
             )
-        tag, Work, calc_in = ps.send_recv(H_o)
+        tag, Work, calc_in = ps.send_recv(H_o.data)
         if hasattr(calc_in, "__len__"):
             b = len(calc_in)
 


### PR DESCRIPTION
The following line is used within most persistent functions:

`H_o = np.zeros(b, dtype=gen_specs["out"])`

Of course requiring `import numpy as np` for *every* function.

---

The following is also common:

```python

H_initial = np.zeros(b, dtype=gen_specs["out"])
ps.send(H_initial)
while True:
   H_subsequent = np.zeros(b, dtype=gen_specs["out"])
   H_subsequent["x"] = new_data()
   ...
```

simplified somewhat to:

```python

H = Array(b, gen_specs)
ps.send(H.data)
while True:
   H.reset()
   H["x"] = new_data()
   ...
```

---

We can always add additional methods.


