### PR TITLE
Swap default alloc_f to only_persistent_gens

### DIFF
--- a/docs/data_structures/alloc_specs.rst
+++ b/docs/data_structures/alloc_specs.rst
@@ -19,7 +19,7 @@ Can be constructed and passed to libEnsemble as a Python class or a dictionary.
   * libEnsemble uses the following defaults if the user doesn't provide their own ``alloc_specs``:
 
   ..  literalinclude:: ../../libensemble/specs.py
-      :start-at: alloc_f: Callable = give_sim_work_first
+      :start-at: alloc_f: Callable = start_only_persistent
       :end-before: end_alloc_tag
       :caption: Default settings for alloc_specs
 

--- a/docs/examples/alloc_funcs.rst
+++ b/docs/examples/alloc_funcs.rst
@@ -10,13 +10,30 @@ Many users use these unmodified.
 .. IMPORTANT::
   See the API for allocation functions :ref:`here<api_alloc_f>`.
 
-.. note::
-   The default allocation function (for non-persistent generators) is :ref:`give_sim_work_first<gswf_label>`.
+  **The default allocation function changed in libEnsemble v2.0 from `give_sim_work_first` to `start_only_persistent `.**
 
-   The most commonly used (for persistent generators) is :ref:`start_only_persistent<start_only_persistent_label>`.
+.. note::
+
+   The default allocation function for persistent generators is :ref:`start_only_persistent<start_only_persistent_label>`.
+
+   The most commonly used allocation function for non-persistent generators is :ref:`give_sim_work_first<gswf_label>`.
 
 .. role:: underline
     :class: underline
+
+.. _start_only_persistent_label:
+
+start_only_persistent
+---------------------
+.. automodule:: start_only_persistent
+  :members:
+  :undoc-members:
+
+.. dropdown:: :underline:`start_only_persistent.py`
+
+   .. literalinclude:: ../../libensemble/alloc_funcs/start_only_persistent.py
+      :language: python
+      :linenos:
 
 .. _gswf_label:
 
@@ -41,20 +58,6 @@ fast_alloc
 .. dropdown:: :underline:`fast_alloc.py`
 
    .. literalinclude:: ../../libensemble/alloc_funcs/fast_alloc.py
-      :language: python
-      :linenos:
-
-.. _start_only_persistent_label:
-
-start_only_persistent
----------------------
-.. automodule:: start_only_persistent
-  :members:
-  :undoc-members:
-
-.. dropdown:: :underline:`start_only_persistent.py`
-
-   .. literalinclude:: ../../libensemble/alloc_funcs/start_only_persistent.py
       :language: python
       :linenos:
 

--- a/docs/function_guides/allocator.rst
+++ b/docs/function_guides/allocator.rst
@@ -128,8 +128,8 @@ The remaining values above are useful for efficient filtering of H values
 
 Descriptions of included allocation functions can be found :doc:`here<../examples/alloc_funcs>`.
 The default allocation function is
-``give_sim_work_first``. During its worker ID loop, it checks if there's unallocated
+``start_only_persistent``. During its worker ID loop, it checks if there's unallocated
 work and assigns simulations for that work. Otherwise, it initializes
 generators for up to ``"num_active_gens"`` instances. Other settings like
 ``batch_mode`` are also supported. See
-:ref:`here<gswf_label>` for more information about ``give_sim_work_first``.
+:ref:`here<start_only_persistent_label>` for more information.

--- a/libensemble/specs.py
+++ b/libensemble/specs.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pydantic
 from pydantic import BaseModel, Field
 
-from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
+from libensemble.alloc_funcs.start_only_persistent import only_persistent_gens
 
 __all__ = ["SimSpecs", "GenSpecs", "AllocSpecs", "ExitCriteria", "LibeSpecs", "_EnsembleSpecs"]
 
@@ -126,10 +126,14 @@ class AllocSpecs(BaseModel):
     Specifications for configuring an Allocation Function.
     """
 
-    alloc_f: object = give_sim_work_first
+    alloc_f: object = only_persistent_gens
     """
     Python function matching the ``alloc_f`` interface. Decides when simulator and generator functions
     should be called, and with what resources and parameters.
+
+    .. note::
+        For libEnsemble v2.0, the default allocation function is now ``only_persistent_gens``, instead
+        of ``give_sim_work_first``.
     """
 
     user: dict | None = {"num_active_gens": 1}

--- a/libensemble/tests/functionality_tests/1d_sampling.json
+++ b/libensemble/tests/functionality_tests/1d_sampling.json
@@ -28,5 +28,8 @@
     "user": {
       "gen_batch_size": 500
     }
+  },
+  "alloc_specs": {
+    "alloc_f": "libensemble.alloc_funcs.give_sim_work_first.give_sim_work_first"
   }
 }

--- a/libensemble/tests/functionality_tests/1d_sampling.toml
+++ b/libensemble/tests/functionality_tests/1d_sampling.toml
@@ -20,3 +20,6 @@
       size = 1
   [gen_specs.user]
     gen_batch_size = 500
+
+[alloc_specs]
+  alloc_f = "libensemble.alloc_funcs.give_sim_work_first.give_sim_work_first"

--- a/libensemble/tests/functionality_tests/1d_sampling.yaml
+++ b/libensemble/tests/functionality_tests/1d_sampling.yaml
@@ -22,3 +22,6 @@ gen_specs:
             size: 1
     user:
         gen_batch_size: 500
+
+alloc_specs:
+    alloc_f: libensemble.alloc_funcs.give_sim_work_first.give_sim_work_first

--- a/libensemble/tests/functionality_tests/test_1d_sampling_no_comms_given.py
+++ b/libensemble/tests/functionality_tests/test_1d_sampling_no_comms_given.py
@@ -17,11 +17,12 @@ The number of concurrent evaluations of the objective function will be 4-1=3.
 import numpy as np
 
 from libensemble import Ensemble
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.gen_funcs.sampling import latin_hypercube_sample as gen_f
 
 # Import libEnsemble items for this test
 from libensemble.sim_funcs.simple_sim import norm_eval as sim_f
-from libensemble.specs import ExitCriteria, GenSpecs, LibeSpecs, SimSpecs
+from libensemble.specs import AllocSpecs, ExitCriteria, GenSpecs, LibeSpecs, SimSpecs
 from libensemble.tools import check_npy_file_exists
 
 # Main block is necessary only when using local comms with spawn start method (default on macOS and Windows).
@@ -55,6 +56,7 @@ if __name__ == "__main__":
     )
 
     sampling.add_random_streams()
+    sampling.alloc_specs = AllocSpecs(alloc_f=give_sim_work_first)
     H, persis_info, flag = sampling.run()
 
     if sampling.is_manager:

--- a/libensemble/tests/functionality_tests/test_1d_sampling_with_profile.py
+++ b/libensemble/tests/functionality_tests/test_1d_sampling_with_profile.py
@@ -19,6 +19,7 @@ import time
 
 import numpy as np
 
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.gen_funcs.sampling import latin_hypercube_sample as gen_f
 from libensemble.libE import libE
 from libensemble.sim_funcs.simple_sim import norm_eval as sim_f
@@ -50,10 +51,16 @@ if __name__ == "__main__":
 
     persis_info = add_unique_random_streams({}, nworkers + 1)
 
+    alloc_specs = {
+        "alloc_f": give_sim_work_first,
+    }
+
     exit_criteria = {"sim_max": 501}
 
     # Perform the run
-    H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
+    H, persis_info, flag = libE(
+        sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs=alloc_specs, libE_specs=libE_specs
+    )
 
     if is_manager:
         assert len(H) >= 501

--- a/libensemble/tests/functionality_tests/test_1d_splitcomm.py
+++ b/libensemble/tests/functionality_tests/test_1d_splitcomm.py
@@ -15,6 +15,7 @@ The number of concurrent evaluations of the objective function will be 4-1=3.
 
 import numpy as np
 
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.gen_funcs.sampling import latin_hypercube_sample as gen_f
 
 # Import libEnsemble items for this test
@@ -51,12 +52,18 @@ if __name__ == "__main__":
         },
     }
 
+    alloc_specs = {
+        "alloc_f": give_sim_work_first,
+    }
+
     persis_info = add_unique_random_streams({}, nworkers + 1, seed=1234)
 
     exit_criteria = {"gen_max": 501}
 
     # Perform the run
-    H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
+    H, persis_info, flag = libE(
+        sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs=alloc_specs, libE_specs=libE_specs
+    )
 
     if is_manager:
         assert len(H) >= 501

--- a/libensemble/tests/functionality_tests/test_1d_subcomm.py
+++ b/libensemble/tests/functionality_tests/test_1d_subcomm.py
@@ -15,6 +15,7 @@ The number of concurrent evaluations of the objective function will be 4-1=3.
 
 import numpy as np
 
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.gen_funcs.sampling import latin_hypercube_sample as gen_f
 
 # Import libEnsemble items for this test
@@ -55,12 +56,18 @@ if __name__ == "__main__":
         },
     }
 
+    alloc_specs = {
+        "alloc_f": give_sim_work_first,
+    }
+
     persis_info = add_unique_random_streams({}, nworkers + 1, seed=1234)
 
     exit_criteria = {"gen_max": 501}
 
     # Perform the run
-    H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
+    H, persis_info, flag = libE(
+        sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs=alloc_specs, libE_specs=libE_specs
+    )
 
     if is_manager:
         assert len(H) >= 501

--- a/libensemble/tests/functionality_tests/test_1d_super_simple.py
+++ b/libensemble/tests/functionality_tests/test_1d_super_simple.py
@@ -15,6 +15,7 @@ The number of concurrent evaluations of the objective function will be 4-1=3.
 
 import numpy as np
 
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.gen_funcs.sampling import latin_hypercube_sample as gen_f
 
 # Import libEnsemble items for this test
@@ -55,7 +56,13 @@ if __name__ == "__main__":
 
     exit_criteria = {"gen_max": 501}
 
-    H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
+    alloc_specs = {
+        "alloc_f": give_sim_work_first,
+    }
+
+    H, persis_info, flag = libE(
+        sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs=alloc_specs, libE_specs=libE_specs
+    )
 
     if is_manager:
         assert len(H) >= 501

--- a/libensemble/tests/functionality_tests/test_1d_uniform_sampling_with_comm_dup.py
+++ b/libensemble/tests/functionality_tests/test_1d_uniform_sampling_with_comm_dup.py
@@ -19,6 +19,7 @@ import sys
 
 import numpy as np
 
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
 
 # Import libEnsemble items for this test
@@ -62,8 +63,12 @@ if __name__ == "__main__":
 
     exit_criteria = {"gen_max": 501}
 
+    alloc_specs = {
+        "alloc_f": give_sim_work_first,
+    }
+
     # Perform the run
-    H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info)
+    H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs=alloc_specs)
 
     if is_manager:
         # assert libE_specs["comms"] == "mpi", "MPI default comms should be set"

--- a/libensemble/tests/functionality_tests/test_calc_exception.py
+++ b/libensemble/tests/functionality_tests/test_calc_exception.py
@@ -13,6 +13,7 @@ Execute via one of the following commands (e.g. 3 workers):
 
 import numpy as np
 
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
 from libensemble.libE import libE
 from libensemble.manager import LoggedException
@@ -47,6 +48,10 @@ if __name__ == "__main__":
 
     persis_info = add_unique_random_streams({}, nworkers + 1)
 
+    alloc_specs = {
+        "alloc_f": give_sim_work_first,
+    }
+
     exit_criteria = {"wallclock_max": 10}
 
     libE_specs["abort_on_exception"] = False
@@ -54,7 +59,9 @@ if __name__ == "__main__":
     # Perform the run
     return_flag = 1
     try:
-        H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
+        H, persis_info, flag = libE(
+            sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs=alloc_specs, libE_specs=libE_specs
+        )
     except LoggedException as e:
         print(f"Caught deliberate exception: {e}")
         return_flag = 0

--- a/libensemble/tests/functionality_tests/test_comms.py
+++ b/libensemble/tests/functionality_tests/test_comms.py
@@ -16,6 +16,7 @@ The number of concurrent evaluations of the objective function will be N-1.
 
 import numpy as np
 
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.executors.mpi_executor import MPIExecutor  # Only used to get workerID in float_x1000
 from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
 
@@ -55,8 +56,14 @@ if __name__ == "__main__":
 
     exit_criteria = {"sim_max": sim_max, "wallclock_max": 300}
 
+    alloc_specs = {
+        "alloc_f": give_sim_work_first,
+    }
+
     # Perform the run
-    H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
+    H, persis_info, flag = libE(
+        sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs=alloc_specs, libE_specs=libE_specs
+    )
 
     if is_manager:
         assert flag == 0

--- a/libensemble/tests/functionality_tests/test_evaluate_existing_plus_gen.py
+++ b/libensemble/tests/functionality_tests/test_evaluate_existing_plus_gen.py
@@ -18,9 +18,10 @@ import numpy as np
 
 # Import libEnsemble items for this test
 from libensemble import Ensemble
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.gen_funcs.sampling import latin_hypercube_sample as gen_f
 from libensemble.sim_funcs.six_hump_camel import six_hump_camel as sim_f
-from libensemble.specs import ExitCriteria, GenSpecs, SimSpecs
+from libensemble.specs import AllocSpecs, ExitCriteria, GenSpecs, SimSpecs
 from libensemble.tools import add_unique_random_streams
 
 
@@ -59,6 +60,7 @@ if __name__ == "__main__":
     sampling.exit_criteria = ExitCriteria(sim_max=100)
     sampling.persis_info = add_unique_random_streams({}, sampling.nworkers + 1)
     sampling.H0 = create_H0(sampling.persis_info, gen_specs, 50)
+    sampling.alloc_specs = AllocSpecs(alloc_f=give_sim_work_first)
     sampling.run()
 
     if sampling.is_manager:

--- a/libensemble/tests/functionality_tests/test_executor_hworld_pass_fail.py
+++ b/libensemble/tests/functionality_tests/test_executor_hworld_pass_fail.py
@@ -15,6 +15,7 @@ import os
 import numpy as np
 
 import libensemble.sim_funcs.six_hump_camel as six_hump_camel
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.executors.mpi_executor import MPIExecutor
 from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
 from libensemble.libE import libE
@@ -88,8 +89,12 @@ if __name__ == "__main__":
     # num sim_ended_count conditions in executor_hworld
     exit_criteria = {"sim_max": nworkers * 5}
 
+    alloc_specs = {
+        "alloc_f": give_sim_work_first,
+    }
+
     # Perform the run
-    H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
+    H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs, libE_specs=libE_specs)
 
     if is_manager:
         print("\nChecking expected task status against Workers ...\n")

--- a/libensemble/tests/functionality_tests/test_executor_hworld_timeout.py
+++ b/libensemble/tests/functionality_tests/test_executor_hworld_timeout.py
@@ -15,6 +15,7 @@ import os
 import numpy as np
 
 import libensemble.sim_funcs.six_hump_camel as six_hump_camel
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.executors.mpi_executor import MPIExecutor
 from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
 
@@ -85,6 +86,10 @@ if __name__ == "__main__":
         },
     }
 
+    alloc_specs = {
+        "alloc_f": give_sim_work_first,
+    }
+
     persis_info = add_unique_random_streams({}, nworkers + 1)
 
     exit_criteria = {"wallclock_max": 10}
@@ -97,7 +102,9 @@ if __name__ == "__main__":
 
     for i in range(iterations):
         # Perform the run
-        H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
+        H, persis_info, flag = libE(
+            sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs, libE_specs=libE_specs
+        )
 
         if is_manager:
             print("\nChecking expected task status against Workers ...\n")

--- a/libensemble/tests/functionality_tests/test_executor_simple.py
+++ b/libensemble/tests/functionality_tests/test_executor_simple.py
@@ -12,6 +12,7 @@ The number of concurrent evaluations of the objective function will be 4-1=3.
 import numpy as np
 
 import libensemble.sim_funcs.six_hump_camel as six_hump_camel
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.executors.mpi_executor import MPIExecutor
 from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
 from libensemble.libE import libE
@@ -61,8 +62,12 @@ if __name__ == "__main__":
     # num sim_ended_count conditions in executor_hworld
     exit_criteria = {"sim_max": nworkers * 5}
 
+    alloc_specs = {
+        "alloc_f": give_sim_work_first,
+    }
+
     # Perform the run
-    H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
+    H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs, libE_specs=libE_specs)
 
     if is_manager:
         print("\nChecking expected task status against Workers ...\n")

--- a/libensemble/tests/functionality_tests/test_local_sine_tutorial.py
+++ b/libensemble/tests/functionality_tests/test_local_sine_tutorial.py
@@ -3,7 +3,8 @@ from sine_gen import gen_random_sample
 from sine_sim import sim_find_sine
 
 from libensemble import Ensemble
-from libensemble.specs import ExitCriteria, GenSpecs, LibeSpecs, SimSpecs
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
+from libensemble.specs import AllocSpecs, ExitCriteria, GenSpecs, LibeSpecs, SimSpecs
 
 if __name__ == "__main__":  # Python-quirk required on macOS and windows
     libE_specs = LibeSpecs(nworkers=4, comms="local")
@@ -27,6 +28,7 @@ if __name__ == "__main__":  # Python-quirk required on macOS and windows
     exit_criteria = ExitCriteria(sim_max=80)  # Stop libEnsemble after 80 simulations
 
     ensemble = Ensemble(sim_specs, gen_specs, exit_criteria, libE_specs)
+    ensemble.alloc_specs = AllocSpecs(alloc_f=give_sim_work_first)
     ensemble.add_random_streams()  # setup the random streams unique to each worker
     ensemble.run()  # start the ensemble. Blocks until completion.
 

--- a/libensemble/tests/functionality_tests/test_local_sine_tutorial_2.py
+++ b/libensemble/tests/functionality_tests/test_local_sine_tutorial_2.py
@@ -3,7 +3,8 @@ from sine_gen import gen_random_sample
 from sine_sim import sim_find_sine
 
 from libensemble import Ensemble
-from libensemble.specs import ExitCriteria, GenSpecs, LibeSpecs, SimSpecs
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
+from libensemble.specs import AllocSpecs, ExitCriteria, GenSpecs, LibeSpecs, SimSpecs
 
 if __name__ == "__main__":
     libE_specs = LibeSpecs(nworkers=4, comms="local")
@@ -24,9 +25,11 @@ if __name__ == "__main__":
         out=[("y", float)],  # sim_f output. "y" = sine("x")
     )
 
+    alloc_specs = AllocSpecs(alloc_f=give_sim_work_first)
+
     exit_criteria = ExitCriteria(gen_max=160)
 
-    ensemble = Ensemble(sim_specs, gen_specs, exit_criteria, libE_specs)
+    ensemble = Ensemble(sim_specs, gen_specs, exit_criteria, libE_specs, alloc_specs)
     ensemble.add_random_streams()
     ensemble.run()
 

--- a/libensemble/tests/functionality_tests/test_local_sine_tutorial_3.py
+++ b/libensemble/tests/functionality_tests/test_local_sine_tutorial_3.py
@@ -3,7 +3,8 @@ from sine_gen import gen_random_sample
 from sine_sim import sim_find_sine
 
 from libensemble import Ensemble
-from libensemble.specs import ExitCriteria, GenSpecs, SimSpecs
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
+from libensemble.specs import AllocSpecs, ExitCriteria, GenSpecs, SimSpecs
 
 if __name__ == "__main__":  # Python-quirk required on macOS and windows
     # libE_specs = LibeSpecs(nworkers=4, comms="local")
@@ -26,8 +27,10 @@ if __name__ == "__main__":  # Python-quirk required on macOS and windows
 
     exit_criteria = ExitCriteria(sim_max=80)  # Stop libEnsemble after 80 simulations
 
+    alloc_specs = AllocSpecs(alloc_f=give_sim_work_first)
+
     # replace libE_specs with parse_args=True. Detects MPI runtime
-    ensemble = Ensemble(sim_specs, gen_specs, exit_criteria, parse_args=True)
+    ensemble = Ensemble(sim_specs, gen_specs, exit_criteria, alloc_specs=alloc_specs, parse_args=True)
 
     ensemble.add_random_streams()
     ensemble.run()  # start the ensemble. Blocks until completion.

--- a/libensemble/tests/functionality_tests/test_mpi_runners.py
+++ b/libensemble/tests/functionality_tests/test_mpi_runners.py
@@ -12,6 +12,7 @@ The number of concurrent evaluations of the objective function will be 4-1=3.
 import numpy as np
 
 from libensemble import logger
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.executors.mpi_executor import MPIExecutor
 from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
 from libensemble.libE import libE
@@ -233,8 +234,10 @@ if __name__ == "__main__":
             "tests": test_list,
         }
 
+        alloc_specs = {"alloc_f": give_sim_work_first}
+
         # Perform the run
-        H, pinfo, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
+        H, pinfo, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs, libE_specs=libE_specs)
 
     # for run_set in ['mpich', 'openmpi', 'aprun', 'srun', 'jsrun', 'rename_mpich', 'custom']:
     for run_set in ["mpich", "aprun", "srun", "jsrun", "rename_mpich", "custom"]:

--- a/libensemble/tests/functionality_tests/test_mpi_runners_subnode.py
+++ b/libensemble/tests/functionality_tests/test_mpi_runners_subnode.py
@@ -16,6 +16,7 @@ import sys
 import numpy as np
 
 from libensemble import logger
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.executors.mpi_executor import MPIExecutor
 from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
 from libensemble.libE import libE
@@ -91,6 +92,8 @@ if __name__ == "__main__":
         },
     }
 
+    alloc_specs = {"alloc_f": give_sim_work_first}
+
     persis_info = add_unique_random_streams({}, nworkers + 1)
     exit_criteria = {"sim_max": (nsim_workers) * rounds}
 
@@ -118,6 +121,6 @@ if __name__ == "__main__":
     }
 
     # Perform the run
-    H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
+    H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs, libE_specs=libE_specs)
 
     # All asserts are in sim func

--- a/libensemble/tests/functionality_tests/test_mpi_runners_subnode_uneven.py
+++ b/libensemble/tests/functionality_tests/test_mpi_runners_subnode_uneven.py
@@ -14,6 +14,7 @@ import sys
 import numpy as np
 
 from libensemble import logger
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.executors.mpi_executor import MPIExecutor
 from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
 from libensemble.libE import libE
@@ -92,6 +93,8 @@ if __name__ == "__main__":
         },
     }
 
+    alloc_specs = {"alloc_f": give_sim_work_first}
+
     persis_info = add_unique_random_streams({}, nworkers + 1)
     exit_criteria = {"sim_max": (nsim_workers) * rounds}
 
@@ -137,6 +140,6 @@ if __name__ == "__main__":
     }
 
     # Perform the run
-    H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
+    H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs, libE_specs=libE_specs)
 
     # All asserts are in sim func

--- a/libensemble/tests/functionality_tests/test_mpi_runners_supernode_uneven.py
+++ b/libensemble/tests/functionality_tests/test_mpi_runners_supernode_uneven.py
@@ -11,6 +11,7 @@ Execute via one of the following commands (e.g. 5 workers):
 import numpy as np
 
 from libensemble import logger
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.executors.mpi_executor import MPIExecutor
 from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
 from libensemble.libE import libE
@@ -131,7 +132,9 @@ if __name__ == "__main__":
         "expect": exp_list,
     }
 
+    alloc_specs = {"alloc_f": give_sim_work_first}
+
     # Perform the run
-    H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
+    H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs, libE_specs=libE_specs)
 
     # All asserts are in sim func

--- a/libensemble/tests/functionality_tests/test_mpi_runners_zrw_subnode_uneven.py
+++ b/libensemble/tests/functionality_tests/test_mpi_runners_zrw_subnode_uneven.py
@@ -21,7 +21,6 @@ import sys
 import numpy as np
 
 from libensemble import logger
-from libensemble.alloc_funcs.start_only_persistent import only_persistent_gens as alloc_f
 from libensemble.executors.mpi_executor import MPIExecutor
 from libensemble.gen_funcs.persistent_sampling import persistent_uniform as gen_f
 from libensemble.libE import libE
@@ -100,7 +99,6 @@ if __name__ == "__main__":
         },
     }
 
-    alloc_specs = {"alloc_f": alloc_f}
     exit_criteria = {"sim_max": (nsim_workers) * rounds}
 
     test_list_base = [
@@ -161,5 +159,5 @@ if __name__ == "__main__":
             persis_info = add_unique_random_streams({}, nworkers + 1)
 
         # Perform the run
-        H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs, libE_specs)
+        H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
         # Run-line asserts are in sim func

--- a/libensemble/tests/functionality_tests/test_mpi_runners_zrw_supernode_uneven.py
+++ b/libensemble/tests/functionality_tests/test_mpi_runners_zrw_supernode_uneven.py
@@ -11,7 +11,6 @@ Execute via one of the following commands (e.g. 6 workers - one is zero resource
 import numpy as np
 
 from libensemble import logger
-from libensemble.alloc_funcs.start_only_persistent import only_persistent_gens as alloc_f
 from libensemble.executors.mpi_executor import MPIExecutor
 from libensemble.gen_funcs.persistent_sampling import persistent_uniform as gen_f
 from libensemble.libE import libE
@@ -86,7 +85,6 @@ if __name__ == "__main__":
         },
     }
 
-    alloc_specs = {"alloc_f": alloc_f}
     persis_info = add_unique_random_streams({}, nworkers + 1)
     exit_criteria = {"sim_max": (nsim_workers) * rounds}
 
@@ -139,6 +137,6 @@ if __name__ == "__main__":
     }
 
     # Perform the run
-    H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs, libE_specs)
+    H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
 
     # All asserts are in sim func

--- a/libensemble/tests/functionality_tests/test_mpi_warning.py
+++ b/libensemble/tests/functionality_tests/test_mpi_warning.py
@@ -17,11 +17,12 @@ import time
 import numpy as np
 
 from libensemble import Ensemble, logger
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.gen_funcs.sampling import latin_hypercube_sample as gen_f
 
 # Import libEnsemble items for this test
 from libensemble.sim_funcs.simple_sim import norm_eval as sim_f
-from libensemble.specs import ExitCriteria, GenSpecs, SimSpecs
+from libensemble.specs import AllocSpecs, ExitCriteria, GenSpecs, SimSpecs
 
 # Main block is necessary only when using local comms with spawn start method (default on macOS and Windows).
 if __name__ == "__main__":
@@ -41,6 +42,7 @@ if __name__ == "__main__":
             "ub": np.array([3, 2]),
         },
     )
+    sampling.alloc_specs = AllocSpecs(alloc_f=give_sim_work_first)
 
     sampling.exit_criteria = ExitCriteria(sim_max=100)
     sampling.add_random_streams()

--- a/libensemble/tests/functionality_tests/test_new_field.py
+++ b/libensemble/tests/functionality_tests/test_new_field.py
@@ -15,6 +15,7 @@ The number of concurrent evaluations of the objective function will be 4-1=3.
 
 import numpy as np
 
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.gen_funcs.sampling import latin_hypercube_sample as gen_f
 
 # Import libEnsemble items for this test
@@ -48,11 +49,17 @@ if __name__ == "__main__":
         },
     }
 
+    alloc_specs = {
+        "alloc_f": give_sim_work_first,
+    }
+
     persis_info = add_unique_random_streams({}, nworkers + 1, seed=1234)
 
     exit_criteria = {"gen_max": 501}
 
-    H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
+    H, persis_info, flag = libE(
+        sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs=alloc_specs, libE_specs=libE_specs
+    )
 
     if is_manager:
         assert len(H) >= 501

--- a/libensemble/tests/functionality_tests/test_persistent_uniform_sampling.py
+++ b/libensemble/tests/functionality_tests/test_persistent_uniform_sampling.py
@@ -20,7 +20,6 @@ import sys
 
 import numpy as np
 
-from libensemble.alloc_funcs.start_only_persistent import only_persistent_gens as alloc_f
 from libensemble.gen_funcs.persistent_sampling import batched_history_matching as gen_f2
 from libensemble.gen_funcs.persistent_sampling import persistent_uniform as gen_f1
 
@@ -55,8 +54,6 @@ if __name__ == "__main__":
             "ub": np.array([3, 2]),
         },
     }
-
-    alloc_specs = {"alloc_f": alloc_f}
 
     exit_criteria = {"gen_max": num_batches * batch, "wallclock_max": 300}
 
@@ -93,7 +90,7 @@ if __name__ == "__main__":
             libE_specs["gen_workers"] = [2]
 
         # Perform the run
-        H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs, libE_specs)
+        H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
 
         if is_manager:
             assert len(np.unique(H["gen_ended_time"])) == num_batches

--- a/libensemble/tests/functionality_tests/test_persistent_uniform_sampling_nonblocking.py
+++ b/libensemble/tests/functionality_tests/test_persistent_uniform_sampling_nonblocking.py
@@ -20,7 +20,6 @@ import sys
 
 import numpy as np
 
-from libensemble.alloc_funcs.start_only_persistent import only_persistent_gens as alloc_f
 from libensemble.gen_funcs.persistent_sampling import uniform_nonblocking as gen_f
 
 # Import libEnsemble items for this test
@@ -53,8 +52,6 @@ if __name__ == "__main__":
         },
     }
 
-    alloc_specs = {"alloc_f": alloc_f}
-
     persis_info = add_unique_random_streams({}, nworkers + 1)
     for i in persis_info:
         persis_info[i]["get_grad"] = True
@@ -62,7 +59,7 @@ if __name__ == "__main__":
     exit_criteria = {"gen_max": 40, "wallclock_max": 300}
 
     # Perform the run
-    H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs, libE_specs)
+    H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
 
     if is_manager:
         assert len(np.unique(H["gen_ended_time"])) == 2

--- a/libensemble/tests/functionality_tests/test_persistent_uniform_sampling_running_mean.py
+++ b/libensemble/tests/functionality_tests/test_persistent_uniform_sampling_running_mean.py
@@ -20,7 +20,6 @@ import sys
 
 import numpy as np
 
-from libensemble.alloc_funcs.start_only_persistent import only_persistent_gens as alloc_f
 from libensemble.gen_funcs.persistent_sampling import persistent_uniform_final_update as gen_f
 from libensemble.libE import libE
 from libensemble.sim_funcs.six_hump_camel import six_hump_camel_simple as sim_f
@@ -57,8 +56,6 @@ if __name__ == "__main__":
         },
     }
 
-    alloc_specs = {"alloc_f": alloc_f}
-
     sim_max = 120
     exit_criteria = {"sim_max": sim_max}
     libE_specs["final_gen_send"] = True
@@ -72,7 +69,7 @@ if __name__ == "__main__":
             }
 
         persis_info = add_unique_random_streams({}, nworkers + 1)
-        H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs, libE_specs)
+        H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
 
         if is_manager:
             # Check that last saved history agrees with returned history.

--- a/libensemble/tests/functionality_tests/test_sim_dirs_per_calc.py
+++ b/libensemble/tests/functionality_tests/test_sim_dirs_per_calc.py
@@ -18,6 +18,7 @@ import os
 
 import numpy as np
 
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
 from libensemble.libE import libE
 from libensemble.tests.regression_tests.support import write_sim_func as sim_f
@@ -61,11 +62,17 @@ if __name__ == "__main__":
         },
     }
 
+    alloc_specs = {
+        "alloc_f": give_sim_work_first,
+    }
+
     persis_info = add_unique_random_streams({}, nworkers + 1)
 
     exit_criteria = {"sim_max": 21}
 
-    H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
+    H, persis_info, flag = libE(
+        sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs=alloc_specs, libE_specs=libE_specs
+    )
 
     if is_manager:
         assert os.path.isdir(c_ensemble), f"Ensemble directory {c_ensemble} not created."

--- a/libensemble/tests/functionality_tests/test_sim_dirs_per_worker.py
+++ b/libensemble/tests/functionality_tests/test_sim_dirs_per_worker.py
@@ -18,6 +18,7 @@ import os
 
 import numpy as np
 
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
 from libensemble.libE import libE
 from libensemble.tests.regression_tests.support import write_sim_func as sim_f
@@ -60,11 +61,17 @@ if __name__ == "__main__":
         },
     }
 
+    alloc_specs = {
+        "alloc_f": give_sim_work_first,
+    }
+
     persis_info = add_unique_random_streams({}, nworkers + 1)
 
     exit_criteria = {"sim_max": 21}
 
-    H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
+    H, persis_info, flag = libE(
+        sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs=alloc_specs, libE_specs=libE_specs
+    )
 
     if is_manager:
         assert os.path.isdir(w_ensemble), f"Ensemble directory {w_ensemble} not created."

--- a/libensemble/tests/functionality_tests/test_sim_dirs_with_exception.py
+++ b/libensemble/tests/functionality_tests/test_sim_dirs_with_exception.py
@@ -18,6 +18,7 @@ import os
 
 import numpy as np
 
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
 from libensemble.libE import libE
 from libensemble.manager import LoggedException
@@ -53,13 +54,19 @@ if __name__ == "__main__":
         },
     }
 
+    alloc_specs = {
+        "alloc_f": give_sim_work_first,
+    }
+
     persis_info = add_unique_random_streams({}, nworkers + 1)
 
     exit_criteria = {"sim_max": 21}
 
     return_flag = 1
     try:
-        H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
+        H, persis_info, flag = libE(
+            sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs, libE_specs=libE_specs
+        )
     except LoggedException as e:
         print(f"Caught deliberate exception: {e}")
         return_flag = 0

--- a/libensemble/tests/functionality_tests/test_sim_dirs_with_gen_dirs.py
+++ b/libensemble/tests/functionality_tests/test_sim_dirs_with_gen_dirs.py
@@ -18,6 +18,7 @@ import os
 
 import numpy as np
 
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.libE import libE
 from libensemble.tests.regression_tests.support import write_sim_func as sim_f
 from libensemble.tests.regression_tests.support import write_uniform_gen_func as gen_f
@@ -76,7 +77,13 @@ if __name__ == "__main__":
 
     exit_criteria = {"sim_max": 20}
 
-    H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
+    alloc_specs = {
+        "alloc_f": give_sim_work_first,
+    }
+
+    H, persis_info, flag = libE(
+        sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs=alloc_specs, libE_specs=libE_specs
+    )
 
     def check_copied(type):
         input_copied = []

--- a/libensemble/tests/functionality_tests/test_sim_input_dir_option.py
+++ b/libensemble/tests/functionality_tests/test_sim_input_dir_option.py
@@ -18,6 +18,7 @@ import os
 
 import numpy as np
 
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
 from libensemble.libE import libE
 from libensemble.tests.regression_tests.support import write_sim_func as sim_f
@@ -60,7 +61,13 @@ if __name__ == "__main__":
 
     exit_criteria = {"sim_max": 21}
 
-    H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
+    alloc_specs = {
+        "alloc_f": give_sim_work_first,
+    }
+
+    H, persis_info, flag = libE(
+        sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs=alloc_specs, libE_specs=libE_specs
+    )
 
     if is_manager:
         assert os.path.isdir(o_ensemble), f"Ensemble directory {o_ensemble} not created."

--- a/libensemble/tests/functionality_tests/test_uniform_sampling.py
+++ b/libensemble/tests/functionality_tests/test_uniform_sampling.py
@@ -19,6 +19,7 @@ import os
 
 import numpy as np
 
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.gen_funcs.sampling import uniform_random_sample
 
 # Import libEnsemble items for this test
@@ -59,6 +60,10 @@ if __name__ == "__main__":
 
     exit_criteria = {"gen_max": 501, "wallclock_max": 300}
 
+    alloc_specs = {
+        "alloc_f": give_sim_work_first,
+    }
+
     for run in range(2):
         if run == 1:
             # Test running a mock sim using previous history file
@@ -67,7 +72,9 @@ if __name__ == "__main__":
             sim_specs["user"] = {"history_file": hfile}
 
         # Perform the run
-        H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
+        H, persis_info, flag = libE(
+            sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs, libE_specs=libE_specs
+        )
 
         if is_manager:
             assert flag == 0

--- a/libensemble/tests/functionality_tests/test_worker_exceptions.py
+++ b/libensemble/tests/functionality_tests/test_worker_exceptions.py
@@ -16,6 +16,7 @@ The number of concurrent evaluations of the objective function will be 4-1=3.
 
 import numpy as np
 
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
 from libensemble.libE import libE
 from libensemble.manager import LoggedException
@@ -52,10 +53,16 @@ if __name__ == "__main__":
     # Tell libEnsemble when to stop
     exit_criteria = {"wallclock_max": 10}
 
+    alloc_specs = {
+        "alloc_f": give_sim_work_first,
+    }
+
     # Perform the run
     return_flag = 1
     try:
-        H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
+        H, persis_info, flag = libE(
+            sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs=alloc_specs, libE_specs=libE_specs
+        )
     except LoggedException as e:
         print(f"Caught deliberate exception: {e}")
         return_flag = 0

--- a/libensemble/tests/functionality_tests/test_workflow_dir.py
+++ b/libensemble/tests/functionality_tests/test_workflow_dir.py
@@ -18,6 +18,7 @@ import os
 
 import numpy as np
 
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.gen_funcs.sampling import uniform_random_sample as gen_f
 from libensemble.libE import libE
 from libensemble.tests.regression_tests.support import write_sim_func as sim_f
@@ -58,6 +59,10 @@ if __name__ == "__main__":
         },
     }
 
+    alloc_specs = {
+        "alloc_f": give_sim_work_first,
+    }
+
     persis_info = add_unique_random_streams({}, nworkers + 1)
 
     exit_criteria = {"sim_max": 21}
@@ -70,7 +75,9 @@ if __name__ == "__main__":
             "./test_workflow" + str(i) + "_nworkers" + str(nworkers) + "_comms-" + libE_specs["comms"]
         )
 
-        H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
+        H, persis_info, flag = libE(
+            sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs=alloc_specs, libE_specs=libE_specs
+        )
 
         assert os.path.isdir(libE_specs["workflow_dir_path"]), "workflow_dir not created"
         assert all(

--- a/libensemble/tests/regression_tests/test_1d_sampling.py
+++ b/libensemble/tests/regression_tests/test_1d_sampling.py
@@ -16,11 +16,12 @@ The number of concurrent evaluations of the objective function will be 4-1=3.
 import numpy as np
 
 from libensemble import Ensemble
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.gen_funcs.sampling import latin_hypercube_sample as gen_f
 
 # Import libEnsemble items for this test
 from libensemble.sim_funcs.simple_sim import norm_eval as sim_f
-from libensemble.specs import ExitCriteria, GenSpecs, LibeSpecs, SimSpecs
+from libensemble.specs import AllocSpecs, ExitCriteria, GenSpecs, LibeSpecs, SimSpecs
 from libensemble.tools import add_unique_random_streams
 
 # Main block is necessary only when using local comms with spawn start method (default on macOS and Windows).
@@ -39,6 +40,7 @@ if __name__ == "__main__":
     )
 
     sampling.persis_info = add_unique_random_streams({}, sampling.nworkers + 1)
+    sampling.alloc_specs = AllocSpecs(alloc_f=give_sim_work_first)
     sampling.exit_criteria = ExitCriteria(sim_max=500)
 
     sampling.run()

--- a/libensemble/tests/regression_tests/test_1d_sampling.py
+++ b/libensemble/tests/regression_tests/test_1d_sampling.py
@@ -16,12 +16,11 @@ The number of concurrent evaluations of the objective function will be 4-1=3.
 import numpy as np
 
 from libensemble import Ensemble
-from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
-from libensemble.gen_funcs.sampling import latin_hypercube_sample as gen_f
+from libensemble.gen_funcs.persistent_sampling import persistent_uniform
 
 # Import libEnsemble items for this test
 from libensemble.sim_funcs.simple_sim import norm_eval as sim_f
-from libensemble.specs import AllocSpecs, ExitCriteria, GenSpecs, LibeSpecs, SimSpecs
+from libensemble.specs import ExitCriteria, GenSpecs, LibeSpecs, SimSpecs
 from libensemble.tools import add_unique_random_streams
 
 # Main block is necessary only when using local comms with spawn start method (default on macOS and Windows).
@@ -30,17 +29,16 @@ if __name__ == "__main__":
     sampling.libE_specs = LibeSpecs(save_every_k_gens=300, safe_mode=False, disable_log_files=True)
     sampling.sim_specs = SimSpecs(sim_f=sim_f)
     sampling.gen_specs = GenSpecs(
-        gen_f=gen_f,
+        gen_f=persistent_uniform,
         outputs=[("x", float, (1,))],
         user={
-            "gen_batch_size": 100,
+            "initial_batch_size": 100,
             "lb": np.array([-3]),
             "ub": np.array([3]),
         },
     )
 
     sampling.persis_info = add_unique_random_streams({}, sampling.nworkers + 1)
-    sampling.alloc_specs = AllocSpecs(alloc_f=give_sim_work_first)
     sampling.exit_criteria = ExitCriteria(sim_max=500)
 
     sampling.run()

--- a/libensemble/tests/regression_tests/test_2d_sampling.py
+++ b/libensemble/tests/regression_tests/test_2d_sampling.py
@@ -16,11 +16,12 @@ The number of concurrent evaluations of the objective function will be 4-1=3.
 import numpy as np
 
 from libensemble import Ensemble
+from libensemble.alloc_funcs.give_sim_work_first import give_sim_work_first
 from libensemble.gen_funcs.sampling import latin_hypercube_sample as gen_f
 
 # Import libEnsemble items for this test
 from libensemble.sim_funcs.simple_sim import norm_eval as sim_f
-from libensemble.specs import ExitCriteria, GenSpecs, LibeSpecs, SimSpecs
+from libensemble.specs import AllocSpecs, ExitCriteria, GenSpecs, LibeSpecs, SimSpecs
 
 # Main block is necessary only when using local comms with spawn start method (default on macOS and Windows).
 if __name__ == "__main__":
@@ -36,6 +37,8 @@ if __name__ == "__main__":
             "ub": np.array([3, 2]),
         },
     )
+
+    sampling.alloc_specs = AllocSpecs(alloc_f=give_sim_work_first)
 
     sampling.exit_criteria = ExitCriteria(sim_max=200)
     sampling.add_random_streams()

--- a/libensemble/tests/regression_tests/test_gpCAM.py
+++ b/libensemble/tests/regression_tests/test_gpCAM.py
@@ -28,7 +28,6 @@ import warnings
 
 import numpy as np
 
-from libensemble.alloc_funcs.start_only_persistent import only_persistent_gens as alloc_f
 from libensemble.gen_funcs.persistent_gpCAM import persistent_gpCAM, persistent_gpCAM_covar
 
 # Import libEnsemble items for this test
@@ -67,8 +66,6 @@ if __name__ == "__main__":
         },
     }
 
-    alloc_specs = {"alloc_f": alloc_f}
-
     for inst in range(3):
         if inst == 0:
             gen_specs["gen_f"] = persistent_gpCAM_covar
@@ -91,7 +88,7 @@ if __name__ == "__main__":
         persis_info = add_unique_random_streams({}, nworkers + 1)
 
         # Perform the run
-        H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs, libE_specs)
+        H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
 
         if is_manager:
             assert len(np.unique(H["gen_ended_time"])) == num_batches

--- a/libensemble/tests/regression_tests/test_persistent_tasmanian.py
+++ b/libensemble/tests/regression_tests/test_persistent_tasmanian.py
@@ -22,7 +22,6 @@ from time import time
 
 import numpy as np
 
-from libensemble.alloc_funcs.start_only_persistent import only_persistent_gens as alloc_f
 from libensemble.gen_funcs.persistent_tasmanian import sparse_grid_batched as gen_f_batched
 
 # Import libEnsemble items for this test
@@ -74,8 +73,6 @@ if __name__ == "__main__":
         "out": [("x", float, num_dimensions)],
     }
 
-    alloc_specs = {"alloc_f": alloc_f}
-
     grid_files = []
 
     for run in range(3):
@@ -116,7 +113,7 @@ if __name__ == "__main__":
             gen_specs["user"]["sCriteria"] = "classic"
             gen_specs["user"]["iOutput"] = 0
 
-        H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, alloc_specs, libE_specs)
+        H, persis_info, flag = libE(sim_specs, gen_specs, exit_criteria, persis_info, libE_specs=libE_specs)
 
         if is_manager:
             grid_files.append(gen_specs["user"]["tasmanian_checkpoint_file"])


### PR DESCRIPTION
- [ ] Perhaps deprecate simple, non-persistent gens
- [ ] Adjust tutorials
- [ ] Adjust docs descriptions of gens
- [ ] Perhaps, for many tests that just use give_sim_work_first for sampling, refactor for persistent_sampling