### PR TITLE
initial small changes to add returns_id attribute to APOSMM class

### DIFF
--- a/libensemble/gen_classes/aposmm.py
+++ b/libensemble/gen_classes/aposmm.py
@@ -172,6 +172,8 @@ class APOSMM(PersistentGenInterfacer):
         Seed for the random number generator.
     """
 
+    returns_id = True
+
     def _validate_vocs(self, vocs: VOCS):
         if len(vocs.constraints):
             warnings.warn("APOSMM does not support constraints in VOCS. Ignoring.")

--- a/libensemble/generators.py
+++ b/libensemble/generators.py
@@ -68,7 +68,8 @@ class LibensembleGenerator(Generator):
             ):  # e.g. {"f": ["f"]} doesn't need mapping
                 self.variables_mapping["f"] = self._get_unmapped_keys(self.VOCS.objectives, "f")
         # Map sim_id to _id
-        self.variables_mapping["sim_id"] = ["_id"]
+        if self.returns_id:
+            self.variables_mapping["sim_id"] = ["_id"]
 
         if len(kwargs) > 0:  # so user can specify gen-specific parameters as kwargs to constructor
             if not self.gen_specs.get("user"):


### PR DESCRIPTION
I'm assuming that if-and-only-if generators return IDs that we'll want to map those to sim_ids. But what other conditions do we have to account for?

What behavior changes does libE still need, depending on if a gen returns IDs or not?