### PR TITLE
Add initial mypy configuration and CI integration

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -63,6 +63,12 @@ jobs:
             pip install -e .
             flake8 libensemble
 
+        - name: Install mypy
+          run: pip install mypy
+
+        - name: Run mypy (limited scope)
+          run: mypy
+
         - name: Remove various tests on newer pythons
           if: matrix.python-version == 'py311' || matrix.python-version == 'py312' || matrix.python-version == 'py313' || matrix.python-version == 'py314'
           run: |

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -83,6 +83,12 @@ jobs:
             pip install -e .
             flake8 libensemble
 
+        - name: Install mypy
+          run: pip install mypy
+
+        - name: Run mypy (limited scope)
+          run: mypy
+
         - name: Remove various tests on newer pythons
           if: matrix.python-version >= '3.11'
           run: |

--- a/libensemble/utils/misc.py
+++ b/libensemble/utils/misc.py
@@ -14,8 +14,8 @@ def extract_H_ranges(Work: dict) -> str:
     else:
         # From https://stackoverflow.com/a/30336492
         ranges = []
-        for diff, group in groupby(enumerate(work_H_rows.tolist()), lambda x: x[0] - x[1]):
-            group = list(map(itemgetter(1), group))
+        for diff, group_iter in groupby(enumerate(work_H_rows.tolist()), lambda x: x[0] - x[1]):
+            group = list(map(itemgetter(1), group_iter))
             if len(group) > 1:
                 ranges.append(str(group[0]) + "-" + str(group[-1]))
             else:

--- a/libensemble/utils/output_directory.py
+++ b/libensemble/utils/output_directory.py
@@ -110,6 +110,7 @@ class EnsembleDirectory:
 
         # If using input_dir, set of files to copy is contents of provided dir
         if input_dir:
+            assert isinstance(input_dir, Path)
             copy_files = set(copy_files + [i for i in input_dir.iterdir()])
 
         # If identical paths to copy and symlink, remove those paths from symlink_files
@@ -124,7 +125,7 @@ class EnsembleDirectory:
                 prefix = self.ensemble_dir
             else:  # Each worker does work in prefix (ensemble_dir)
                 key = self.ensemble_dir
-                dirname = self.ensemble_dir
+                dirname = str(self.ensemble_dir)
                 prefix = None
 
             locs.register_loc(

--- a/libensemble/utils/output_directory.py
+++ b/libensemble/utils/output_directory.py
@@ -110,7 +110,6 @@ class EnsembleDirectory:
 
         # If using input_dir, set of files to copy is contents of provided dir
         if input_dir:
-            assert isinstance(input_dir, Path)
             copy_files = set(copy_files + [i for i in input_dir.iterdir()])
 
         # If identical paths to copy and symlink, remove those paths from symlink_files
@@ -125,7 +124,7 @@ class EnsembleDirectory:
                 prefix = self.ensemble_dir
             else:  # Each worker does work in prefix (ensemble_dir)
                 key = self.ensemble_dir
-                dirname = str(self.ensemble_dir)
+                dirname = self.ensemble_dir
                 prefix = None
 
             locs.register_loc(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,4 +244,15 @@ inpt = "inpt"
 extend-exclude = ["*.bib", "*.xml", "docs/nitpicky"]
 
 [tool.mypy]
+# Initial, permissive mypy configuration for libensemble.
+# Allows incremental adoption. To be tightened in future releases.
+packages = ["libensemble.utils"]
+exclude = '''
+libensemble/utils/(launcher|loc_stack|runners|pydantic|output_directory)\.py
+'''
 disable_error_code = ["import-not-found", "import-untyped"]
+ignore_missing_imports = true
+follow_imports = "skip"
+check_untyped_defs = false
+disallow_untyped_defs = false
+warn_unused_ignores = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,18 @@ inpt = "inpt"
 extend-exclude = ["*.bib", "*.xml", "docs/nitpicky"]
 
 [tool.mypy]
+# Initial, permissive mypy configuration for libensemble.
+# Allows incremental adoption. To be tightened in future releases.
+packages = ["libensemble.utils"]
+exclude = '''
+libensemble/utils/(launcher|loc_stack|runners|pydantic|output_directory)\.py
+'''
 disable_error_code = ["import-not-found", "import-untyped"]
+ignore_missing_imports = true
+follow_imports = "skip"
+check_untyped_defs = false
+disallow_untyped_defs = false
+warn_unused_ignores = false
 
 [dependency-groups]
 dev = ["pyenchant", "enchant>=0.0.1,<0.0.2", "flake8-modern-annotations>=1.6.0,<2", "flake8-type-checking>=3.0.0,<4"]


### PR DESCRIPTION
# Description
This PR adds mypy type checking to libEnsemble using an intentionally permissive initial configuration.
It establishes a baseline that can be tightened incrementally without impacting CI stability.

Related issue: #1633

# Changes
- Add an initial mypy configuration to pyproject.toml
- Add mypy as a CI check
- Restrict type checking scope to libensemble/utils
- Exclude utility modules that are not yet mypy-compliant
- Refactor libensemble/utils/misc.py to satisfy mypy

# CI Impact
- mypy is executed with a restricted scope and permissive settings
- No existing CI checks are modified, relaxed, or made less strict