### PR TITLE
Updating IBCDFO handling of minq

### DIFF
--- a/install/install_ibcdfo.sh
+++ b/install/install_ibcdfo.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 
-git clone --recurse-submodules -b main https://github.com/POptUS/IBCDFO.git
-pushd IBCDFO/minq/py/minq5/
+git glone https://github.com/POptUS/MINQ
+pushd MINQ/py/minq5/
 export PYTHONPATH="$PYTHONPATH:$(pwd)"
 echo "PYTHONPATH=$PYTHONPATH" >> $GITHUB_ENV
 popd
+git clone -b main https://github.com/POptUS/IBCDFO.git
 pushd IBCDFO/ibcdfo_pypkg/
 pip install -e .
 popd

--- a/install/install_ibcdfo.sh
+++ b/install/install_ibcdfo.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-git glone https://github.com/POptUS/MINQ
+git clone https://github.com/POptUS/MINQ
 pushd MINQ/py/minq5/
 export PYTHONPATH="$PYTHONPATH:$(pwd)"
 echo "PYTHONPATH=$PYTHONPATH" >> $GITHUB_ENV


### PR DESCRIPTION
We need to update our install of IBCDFO to account for a recent IBCDFO PR that removed submodules for MINQ. https://github.com/POptUS/IBCDFO/pull/267. 

