### PR TITLE
Various fixes towards getting the pdf build working again

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -28,7 +28,7 @@ build:
     - cp -r docs/_build/html/** $READTHEDOCS_OUTPUT/html/
     - pixi run -e docs build-pdf
     - mkdir -p $READTHEDOCS_OUTPUT/pdf/
-    - cp docs/_build/latex/libensemble.pdf $READTHEDOCS_OUTPUT/pdf/
+    - cp docs/_build/latex/libEnsemble.pdf $READTHEDOCS_OUTPUT/pdf/
 
 sphinx:
     configuration: docs/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -26,6 +26,9 @@ build:
     - pixi run -e docs build-docs
     - mkdir -p $READTHEDOCS_OUTPUT/html/
     - cp -r docs/_build/html/** $READTHEDOCS_OUTPUT/html/
+    - pixi run -e docs build-pdf
+    - mkdir -p $READTHEDOCS_OUTPUT/pdf/
+    - cp docs/_build/latex/libensemble.pdf $READTHEDOCS_OUTPUT/pdf/
 
 sphinx:
     configuration: docs/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -28,7 +28,7 @@ build:
     - cp -r docs/_build/html/** $READTHEDOCS_OUTPUT/html/
     - pixi run -e docs build-pdf
     - mkdir -p $READTHEDOCS_OUTPUT/pdf/
-    - cp -r docs/_build/latex/** $READTHEDOCS_OUTPUT/pdf/
+    - cp -r docs/_build/latex/libEnsemble.pdf $READTHEDOCS_OUTPUT/pdf/
 
 sphinx:
     configuration: docs/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -28,7 +28,7 @@ build:
     - cp -r docs/_build/html/** $READTHEDOCS_OUTPUT/html/
     - pixi run -e docs build-pdf
     - mkdir -p $READTHEDOCS_OUTPUT/pdf/
-    - cp docs/_build/latex/libEnsemble.pdf $READTHEDOCS_OUTPUT/pdf/
+    - cp -r docs/_build/latex/** $READTHEDOCS_OUTPUT/pdf/
 
 sphinx:
     configuration: docs/conf.py

--- a/README.rst
+++ b/README.rst
@@ -25,8 +25,12 @@ and inference problems on the world's leading supercomputers such as Frontier, A
 **New:** libEnsemble nows supports the `gest-api`_ generator standard, and can run with
 Optimas and Xopt generators.
 
+.. before_script_creator_tag
+
 Try the |ScriptCreator| to generate customized scripts for running ensembles with your
 MPI applications.
+
+.. after_script_creator_tag
 
 Installation
 ============
@@ -109,6 +113,8 @@ and an exit condition.
         ensemble.save_output(__file__)
         print("Some output data:\n", ensemble.H[["x0", "x1", "f"]][:10])
 
+.. before_colab_tag
+
 |Inline Example|
 
 Try some other examples live in Colab.
@@ -126,6 +132,8 @@ Try some other examples live in Colab.
 +---------------------------------------------------------------+-------------------------------------+
 | Bayesian Optimization with Xopt.                              | |Bayesian Optimization with Xopt|   |
 +---------------------------------------------------------------+-------------------------------------+
+
+.. after_colab_tag
 
 There are many more examples in the `regression tests`_ and `Community Examples repository`_.
 

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ and inference problems on the world's leading supercomputers such as Frontier, A
 **New:** libEnsemble nows supports the `gest-api`_ generator standard, and can run with
 Optimas and Xopt generators.
 
-The |ScriptCreator| to generate customized scripts for running ensembles with your
+Try the |ScriptCreator| to generate customized scripts for running ensembles with your
 MPI applications.
 
 Installation
@@ -216,6 +216,6 @@ Resources
 .. |Bayesian Optimization with Xopt| image:: https://colab.research.google.com/assets/colab-badge.svg
   :target:  https://colab.research.google.com/github/Libensemble/libensemble/blob/develop/examples/tutorials/xopt_bayesian_gen/xopt_EI_example.ipynb
 
-.. |ScriptCreator| image:: https://img.shields.io/badge/Script_Creator-purple?logo=magic
+.. |ScriptCreator| image:: https://img.shields.io/badge/Script_Creator-purple
    :target: https://libensemble.github.io/script-creator/
    :alt: Script Creator

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,6 +105,10 @@ spelling_ignore_acronyms = True
 spelling_ignore_python_builtins = True
 spelling_ignore_importable_modules = True
 
+# Use ImageMagick v7's `magick` command instead of deprecated `convert`
+image_converter = "magick"
+image_converter_args = ["convert", "-background", "white"]
+
 bibtex_bibfiles = ["references.bib"]
 bibtex_default_style = "unsrt"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,7 +107,7 @@ spelling_ignore_importable_modules = True
 
 # Use ImageMagick v7's `magick` command instead of deprecated `convert`
 image_converter = "magick"
-image_converter_args = ["convert", "-background", "white"]
+# image_converter_args = ["convert", "-background", "white"]
 
 bibtex_bibfiles = ["references.bib"]
 bibtex_default_style = "unsrt"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -91,7 +91,6 @@ extensions = [
     "sphinx.ext.napoleon",
     # 'sphinx.ext.autosectionlabel',
     "sphinx.ext.intersphinx",
-    "sphinx.ext.imgconverter",
     "sphinx.ext.mathjax",
     "sphinxcontrib.autodoc_pydantic",
     "sphinx_design",
@@ -104,10 +103,6 @@ spelling_ignore_pypi_package_names = True
 spelling_ignore_acronyms = True
 spelling_ignore_python_builtins = True
 spelling_ignore_importable_modules = True
-
-# Use ImageMagick v7's `magick` command instead of deprecated `convert`
-image_converter = "magick"
-# image_converter_args = ["convert", "-background", "white"]
 
 bibtex_bibfiles = ["references.bib"]
 bibtex_default_style = "unsrt"

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -1,5 +1,13 @@
 .. include:: ../README.rst
     :start-after: after_badges_rst_tag
+    :end-before: before_script_creator_tag
+
+.. include:: ../README.rst
+    :start-after: after_script_creator_tag
+    :end-before: before_colab_tag
+
+.. include:: ../README.rst
+    :start-after: after_colab_tag
 
 See the :doc:`tutorial<tutorials/local_sine_tutorial/local_sine_tutorial>` for a step-by-step beginners guide.
 

--- a/docs/tutorials/aposmm_tutorial.rst
+++ b/docs/tutorials/aposmm_tutorial.rst
@@ -10,7 +10,9 @@ simulation :ref:`sim_f<funcguides-sim>` that defines a function with
 multiple minima, then write a libEnsemble calling script that imports APOSMM and
 parameterizes it to check for minima over a domain of outputs from our ``sim_f``.
 
-|Open in Colab|
+.. only:: html
+
+    |Open in Colab|
 
 Six-Hump Camel Simulation Function
 ----------------------------------

--- a/docs/tutorials/executor_forces_tutorial.rst
+++ b/docs/tutorials/executor_forces_tutorial.rst
@@ -6,7 +6,9 @@ This tutorial highlights libEnsemble's capability to portably execute
 and monitor external scripts or user applications within simulation or generator
 functions using the :doc:`executor<../executor/ex_index>`.
 
-|Open in Colab|
+.. only:: html
+
+    |Open in Colab|
 
 The calling script registers a compiled executable that simulates
 electrostatic forces between a collection of particles. The simulator function

--- a/docs/tutorials/gpcam_tutorial.rst
+++ b/docs/tutorials/gpcam_tutorial.rst
@@ -5,7 +5,9 @@ This example uses gpCAM_ to construct a global surrogate of ``f`` values using a
 
 In each iteration, a batch of points is produced for concurrent evaluation, maximizing uncertainty reduction.
 
-|Open in Colab|
+.. only:: html
+
+    |Open in Colab|
 
 Ensure that libEnsemble, and gpCAM are installed via: ``pip install libensemble gpcam``
 

--- a/docs/tutorials/local_sine_tutorial/local_sine_tutorial.rst
+++ b/docs/tutorials/local_sine_tutorial/local_sine_tutorial.rst
@@ -9,7 +9,10 @@ calculations in parallel using :doc:`libEnsemble<../../introduction>`.
 
 We recommend reading this brief :doc:`Overview<../../overview_usecases>`.
 
-|Open in Colab|
+.. only:: html
+
+    |Open in Colab|
+
 
 For this tutorial, our generator will produce uniform randomly sampled
 values, and our simulator will calculate the sine of each. By default we don't

--- a/docs/tutorials/xopt_bayesian_gen.rst
+++ b/docs/tutorials/xopt_bayesian_gen.rst
@@ -10,7 +10,9 @@ We'll show two approaches:
 1. Using an xopt-style simulator (callable function)
 2. Using a libEnsemble-style simulator function
 
-|Open in Colab|
+.. only:: html
+
+    |Open in Colab|
 
 Imports
 -------

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6641e7777cbbe69a6e3634cf4fb2dca7beb8414c6953694c7412e7019942043e
-size 1058196
+oid sha256:2ea06a21d57979529f90b4dff9ed39cd1279667235598e91edccce65f6435fbd
+size 1085121

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c7f473ad72a7c038dee9ec8d3dbe035f6e96e3cfe2f95e2c0522e0e937912da5
-size 1056784
+oid sha256:6641e7777cbbe69a6e3634cf4fb2dca7beb8414c6953694c7412e7019942043e
+size 1058196

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2ea06a21d57979529f90b4dff9ed39cd1279667235598e91edccce65f6435fbd
-size 1085121
+oid sha256:335e6482eef4f3abbd2de4caa77ad98d7472ba7b6546af89dfbde94ac192db12
+size 1058911

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:335e6482eef4f3abbd2de4caa77ad98d7472ba7b6546af89dfbde94ac192db12
-size 1058911
+oid sha256:95763b1326e2a21dd0aabb08e20c13f004f5fa6aef87a33614101e024318c05e
+size 1085121

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,7 @@ types-pyyaml = ">=6.0.12.20250915,<7"
 furo = ">=2025.12.19,<2026"
 latexcodec = ">=2.0.1,<3"
 latexmk = ">=4.88,<5"
-imagemagick = ">=7.1.2_16,<8"
+fonts-conda-forge = ">=1,<2"
 
 [tool.pixi.tasks.build-docs]
 cmd = "cd docs && make html"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,7 @@ types-pyyaml = ">=6.0.12.20250915,<7"
 furo = ">=2025.12.19,<2026"
 latexcodec = ">=2.0.1,<3"
 latexmk = ">=4.88,<5"
+imagemagick = ">=7.1.2_16,<8"
 
 [tool.pixi.tasks.build-docs]
 cmd = "cd docs && make html"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,9 +138,14 @@ mypy = ">=1.19.1,<2"
 types-psutil = ">=6.1.0.20241221,<7"
 types-pyyaml = ">=6.0.12.20250915,<7"
 furo = ">=2025.12.19,<2026"
+latexcodec = ">=2.0.1,<3"
+latexmk = ">=4.88,<5"
 
 [tool.pixi.tasks.build-docs]
 cmd = "cd docs && make html"
+
+[tool.pixi.tasks.build-pdf]
+cmd = "cd docs && make latexpdf"
 
 # Linux dependencies, only for extra tests
 [tool.pixi.feature.extra.target.linux-64.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,7 @@ furo = ">=2025.12.19,<2026"
 latexcodec = ">=2.0.1,<3"
 latexmk = ">=4.88,<5"
 fonts-conda-forge = ">=1,<2"
+imagemagick = ">=7.1.2_16,<8"
 
 [tool.pixi.tasks.build-docs]
 cmd = "cd docs && make html"


### PR DESCRIPTION
- `?logo=magic` somehow produces an explicitly un-convertable image for imagemagick.

The link to download the pdf 404s, but due to the URL's structure it *may* work if these changes aren't on a PR.