### PR TITLE
Fix/autolink fixes

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -24,7 +24,7 @@ Issues can be raised at
 Issues may include reporting bugs or suggested features. Administrators
 will add issues, as appropriate, to the project board at
 
-    https://github.com/Libensemble/libensemble/projects
+    https://github.com/orgs/Libensemble/projects
 
 By convention, user branch names should have a <type>/<name> format, where
 example types are feature, bugfix, testing, docs, and experimental.

--- a/README.rst
+++ b/README.rst
@@ -179,8 +179,8 @@ Resources
    :target: https://packages.spack.io/package.html?name=py-libensemble
 .. |Tests| image:: https://github.com/Libensemble/libensemble/actions/workflows/extra.yml/badge.svg?branch=main
    :target: https://github.com/Libensemble/libensemble/actions
-.. |Coverage| image:: https://codecov.io/github/Libensemble/libensemble/graph/badge.svg
-   :target: https://codecov.io/github/Libensemble/libensemble
+.. |Coverage| image:: https://app.codecov.io/github/Libensemble/libensemble/graph/badge.svg
+   :target: https://app.codecov.io/github/Libensemble/libensemble
 .. |Docs| image:: https://readthedocs.org/projects/libensemble/badge/?maxAge=2592000
    :target: https://libensemble.readthedocs.org/en/latest/
    :alt: Documentation Status
@@ -195,7 +195,7 @@ Resources
 .. _conda-forge: https://conda-forge.org/
 .. _Contributions: https://github.com/Libensemble/libensemble/blob/main/CONTRIBUTING.rst
 .. _docs: https://libensemble.readthedocs.io/en/main/advanced_installation.html
-.. _gest-api: https://gest-api.readthedocs.io
+.. _gest-api: https://gest-api.readthedocs.io/en/latest/
 .. _GitHub: https://github.com/Libensemble/libensemble
 .. _libEnsemble mailing list: https://lists.mcs.anl.gov/mailman/listinfo/libensemble
 .. _libEnsemble Slack page: https://libensemble.slack.com
@@ -203,20 +203,20 @@ Resources
 .. _mpmath: http://mpmath.org/
 .. _PyPI: https://pypi.org
 .. _Quickstart: https://libensemble.readthedocs.io/en/main/introduction.html
-.. _ReadtheDocs: http://libensemble.readthedocs.org/
+.. _ReadtheDocs: https://libensemble.readthedocs.io/en/latest/
 .. _regression tests: https://github.com/Libensemble/libensemble/tree/main/libensemble/tests/regression_tests
 
 .. |Inline Example| image:: https://colab.research.google.com/assets/colab-badge.svg
-  :target:  http://colab.research.google.com/github/Libensemble/libensemble/blob/develop/examples/readme_notebook.ipynb
+  :target:  https://colab.research.google.com/github/Libensemble/libensemble/blob/develop/examples/readme_notebook.ipynb
 
 .. |Simple Ensemble| image:: https://colab.research.google.com/assets/colab-badge.svg
-  :target:  http://colab.research.google.com/github/Libensemble/libensemble/blob/develop/examples/tutorials/simple_sine/sine_tutorial_notebook.ipynb
+  :target:  https://colab.research.google.com/github/Libensemble/libensemble/blob/develop/examples/tutorials/simple_sine/sine_tutorial_notebook.ipynb
 
 .. |Ensemble with an MPI application| image:: https://colab.research.google.com/assets/colab-badge.svg
-  :target:  http://colab.research.google.com/github/Libensemble/libensemble/blob/develop/examples/tutorials/forces_with_executor/forces_tutorial_notebook.ipynb
+  :target:  https://colab.research.google.com/github/Libensemble/libensemble/blob/develop/examples/tutorials/forces_with_executor/forces_tutorial_notebook.ipynb
 
 .. |Optimization example| image:: https://colab.research.google.com/assets/colab-badge.svg
-  :target:  http://colab.research.google.com/github/Libensemble/libensemble/blob/develop/examples/tutorials/aposmm/aposmm_tutorial_notebook.ipynb
+  :target:  https://colab.research.google.com/github/Libensemble/libensemble/blob/develop/examples/tutorials/aposmm/aposmm_tutorial_notebook.ipynb
 
 .. |Surrogate Modeling| image:: https://colab.research.google.com/assets/colab-badge.svg
   :target:  https://colab.research.google.com/github/Libensemble/libensemble/blob/develop/examples/tutorials/gpcam_surrogate_model/gpcam.ipynb

--- a/docs/FAQ.rst
+++ b/docs/FAQ.rst
@@ -298,7 +298,7 @@ macOS and Windows Errors
   on our executables, then confirming the next alerts for the executable
   and ``mpiexec.hydra``.
 
-.. _Installing PETSc On Microsoft Windows: https://petsc.org/release/install/windows/#recommended-installation-methods
+.. _Installing PETSc On Microsoft Windows: https://petsc.org/release/install/windows/#installing-petsc-on-microsoft-windows
 .. _option to srun: https://docs.nersc.gov/systems/perlmutter/running-jobs/#single-gpu-tasks-in-parallel
 .. _Perlmutter: https://docs.nersc.gov/systems/perlmutter/architecture/
 .. _Python multiprocessing docs: https://docs.python.org/3/library/multiprocessing.html

--- a/docs/advanced_installation/advanced_installation.rst
+++ b/docs/advanced_installation/advanced_installation.rst
@@ -34,8 +34,8 @@ Globus Compute
 `Globus Compute`_ may be installed optionally to submit simulation function instances to remote Globus Compute endpoints.
 
 .. _Globus Compute: https://www.globus.org/compute
-.. _Python: http://www.python.org
-.. _NumPy: http://www.numpy.org
+.. _Python: https://www.python.org/
+.. _NumPy: https://numpy.org/
 .. _psutil: https://pypi.org/project/psutil/
-.. _pydantic: https://docs.pydantic.dev/1.10/
+.. _pydantic: https://pydantic.dev/docs/validation/latest/get-started/
 .. _gest-api: https://github.com/campa-consortium/gest-api

--- a/docs/dev_guide/release_management/release_platforms/rel_github.rst
+++ b/docs/dev_guide/release_management/release_platforms/rel_github.rst
@@ -5,7 +5,7 @@ GitHub release
 
 The administrator should follow the GitHub instructions to draft a new release.
 These can currently be found at
-https://help.github.com/en/articles/creating-releases.
+https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository.
 
 Both the version and title will be of the form vX.Y.Z, for example, v0.5.0.
 

--- a/docs/dev_guide/release_management/release_platforms/rel_spack.rst
+++ b/docs/dev_guide/release_management/release_platforms/rel_spack.rst
@@ -8,7 +8,7 @@ This assumes you have already:
  - made a PyPI package for the new libEnsemble version and
  - made a GitHub fork of Spack and cloned it to your local system.
 
-Details on how to create forks can be found at https://help.github.com/articles/fork-a-repo.
+Details on how to create forks can be found at https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo.
 
 You now have a configuration like that shown at https://stackoverflow.com/a/6286877/6346040.
 
@@ -130,5 +130,5 @@ Quick summary for bringing the develop branch on a forked repo up to speed with 
 
 Reference: <https://stackoverflow.com/questions/9646167/clean-up-a-fork-and-restart-it-from-the-upstream/39628366>
 
-.. _packaging: https://spack.readthedocs.io/en/latest/packaging_guide.html
+.. _packaging: https://spack.readthedocs.io/en/latest/packaging_guide_creation.html
 .. _contribution: https://spack.readthedocs.io/en/latest/contribution_guide.html

--- a/docs/dev_guide/release_management/release_process.rst
+++ b/docs/dev_guide/release_management/release_process.rst
@@ -91,4 +91,4 @@ After release
   on the kanban project board (inc. the release checklist). Those that were
   already in *Done* should be archived.
 
-.. _libE-Templater: https://github.com/Libensemble/libE-templater
+.. _libE-Templater: https://github.com/Libensemble/libE-HPC-Templater

--- a/docs/examples/aposmm.rst
+++ b/docs/examples/aposmm.rst
@@ -65,5 +65,5 @@ LocalOptInterfacer
 .. _nlopt: https://nlopt.readthedocs.io/en/latest/
 .. _petsc4py: https://bitbucket.org/petsc/petsc4py
 .. _SciPy: https://pypi.org/project/scipy
-.. _PETSc/TAO: http://www.mcs.anl.gov/petsc
+.. _PETSc/TAO: https://www.mcs.anl.gov/petsc/
 .. _scipy.optimize: https://docs.scipy.org/doc/scipy/reference/optimize.html

--- a/docs/examples/gen_funcs.rst
+++ b/docs/examples/gen_funcs.rst
@@ -118,6 +118,6 @@ Modeling and Approximation
 .. _Surmise: https://surmise.readthedocs.io/en/latest/index.html
 .. _Tasmanian: https://github.com/ORNL/Tasmanian
 .. _user guide: https://libensemble.readthedocs.io/en/latest/programming_libE.html
-.. _VTMOP: https://github.com/Libensemble/libe-community-examples#vtmop
+.. _VTMOP: https://libensemble.readthedocs.io/projects/libe-community-examples/en/latest/generators.html#vtmop-link
 .. _WarpX: https://warpx.readthedocs.io/en/latest/
 .. _ytopt: https://github.com/ytopt-team/ytopt

--- a/docs/executor/ex_overview.rst
+++ b/docs/executor/ex_overview.rst
@@ -156,4 +156,4 @@ which partitions resources among workers, ensuring that runs utilize different
 resources (e.g., nodes). Furthermore, the ``MPIExecutor`` offers resilience via the
 feature of re-launching tasks that fail to start because of system factors.
 
-.. _concurrent futures: https://docs.python.org/library/concurrent.futures.html
+.. _concurrent futures: https://docs.python.org/3/library/concurrent.futures.html

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -55,10 +55,10 @@ See the `user guide`_ for more information.
 .. _IPAC manuscript: https://doi.org/10.18429/JACoW-ICAP2018-SAPAF03
 .. _NLopt: https://nlopt.readthedocs.io/en/latest/
 .. _OPAL: http://amas.web.psi.ch/docs/opal/opal_user_guide-1.6.0.pdf
-.. _PETSc/TAO: http://www.mcs.anl.gov/petsc
+.. _PETSc/TAO: https://www.mcs.anl.gov/petsc/
 .. _scipy.optimize: https://docs.scipy.org/doc/scipy/reference/optimize.html
 .. _Surmise: https://surmise.readthedocs.io/en/latest/index.html
 .. _Tasmanian: https://github.com/ORNL/Tasmanian
 .. _user guide: https://libensemble.readthedocs.io/en/latest/programming_libE.html
-.. _VTMOP: https://github.com/Libensemble/libe-community-examples#vtmop
+.. _VTMOP: https://libensemble.readthedocs.io/projects/libe-community-examples/en/latest/generators.html#vtmop-link
 .. _WarpX: https://warpx.readthedocs.io/en/latest/

--- a/docs/introduction_latex.rst
+++ b/docs/introduction_latex.rst
@@ -20,7 +20,7 @@
 .. _libE_specs: https://libensemble.readthedocs.io/en/main/data_structures/libE_specs.html
 .. _manuscript: https://arxiv.org/abs/2104.08322
 .. _mock: https://pypi.org/project/mock
-.. _mpi4py: https://bitbucket.org/mpi4py/mpi4py
+.. _mpi4py: https://mpi4py.readthedocs.io/en/stable/
 .. _MPICH: http://www.mpich.org/
 .. _mpmath: http://mpmath.org/
 .. _NLopt documentation: https://nlopt.readthedocs.io/en/latest/NLopt_Installation/

--- a/docs/introduction_latex.rst
+++ b/docs/introduction_latex.rst
@@ -25,22 +25,22 @@
 .. _mpmath: http://mpmath.org/
 .. _NLopt documentation: https://nlopt.readthedocs.io/en/latest/NLopt_Installation/
 .. _nlopt: https://nlopt.readthedocs.io/en/latest/
-.. _NumPy: http://www.numpy.org
+.. _NumPy: https://numpy.org/
 .. _OPAL: http://amas.web.psi.ch/docs/opal/opal_user_guide-1.6.0.pdf
 .. _petsc4py: https://bitbucket.org/petsc/petsc4py
-.. _PETSc/TAO: http://www.mcs.anl.gov/petsc
+.. _PETSc/TAO: https://www.mcs.anl.gov/petsc/
 .. _poster: https://figshare.com/articles/libEnsemble_A_Python_Library_for_Dynamic_Ensemble-Based_Computations/12559520
 .. _PSI/J: https://exaworks.org/psij
 .. _psi-j-python: https://github.com/ExaWorks/psi-j-python
 .. _psutil: https://pypi.org/project/psutil/
-.. _pydantic: https://pydantic-docs.helpmanual.io/
+.. _pydantic: https://pydantic.dev/docs/validation/latest/get-started/
 .. _PyPI: https://pypi.org
 .. _pytest-cov: https://pypi.org/project/pytest-cov/
 .. _pytest-timeout: https://pypi.org/project/pytest-timeout/
 .. _pytest: https://pypi.org/project/pytest/
-.. _Python: http://www.python.org
+.. _Python: https://www.python.org/
 .. _Quickstart: https://libensemble.readthedocs.io/en/main/introduction.html
-.. _ReadtheDocs: http://libensemble.readthedocs.org/
+.. _ReadtheDocs: https://libensemble.readthedocs.io/en/latest/
 .. _SciPy: http://www.scipy.org
 .. _scipy.optimize: https://docs.scipy.org/doc/scipy/reference/optimize.html
 .. _setuptools: https://setuptools.pypa.io/en/latest/
@@ -52,6 +52,6 @@
 .. _Tasmanian: https://github.com/ORNL/Tasmanian
 .. _tqdm: https://tqdm.github.io/
 .. _user guide: https://libensemble.readthedocs.io/en/latest/programming_libE.html
-.. _VTMOP: https://github.com/Libensemble/libe-community-examples#vtmop
+.. _VTMOP: https://libensemble.readthedocs.io/projects/libe-community-examples/en/latest/generators.html#vtmop-link
 .. _WarpX: https://warpx.readthedocs.io/en/latest/
 .. _xsdk: https://xsdk.info

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -28,4 +28,4 @@ may occur when using libEnsemble.
 * We currently recommended running in Central mode on Bridges as distributed
   runs are experiencing hangs.
 
-.. _pickle error: https://docs.nersc.gov/development/languages/python/using-python-perlmutter/#missing-support-for-matched-proberecv
+.. _pickle error: https://docs.nersc.gov/development/languages/python/using-python-perlmutter/#known-issues

--- a/docs/platforms/aurora.rst
+++ b/docs/platforms/aurora.rst
@@ -135,5 +135,5 @@ exception of different compiler options and numbers of workers (because the
 numbers of GPUs on a node differs).
 
 .. _ALCF: https://www.alcf.anl.gov/
-.. _Aurora: https://www.alcf.anl.gov/support-center/aurorasunspot/getting-started-aurora
-.. _demonstration: https://youtu.be/H2fmbZ6DnVc
+.. _Aurora: https://docs.alcf.anl.gov/aurora/getting-started-on-aurora/
+.. _demonstration: https://www.youtube.com/watch?v=H2fmbZ6DnVc&feature=youtu.be

--- a/docs/platforms/bebop.rst
+++ b/docs/platforms/bebop.rst
@@ -94,6 +94,6 @@ See the LCRC Bebop docs here_ for more information about Bebop.
 
 .. _Anaconda: https://www.anaconda.com/
 .. _Bebop: https://www.lcrc.anl.gov/systems/bebop
-.. _conda: https://conda.io/en/latest/
+.. _conda: https://docs.conda.io/en/latest/
 .. _here: https://docs.lcrc.anl.gov/bebop/running-jobs-bebop/
 .. _mpi4py: https://mpi4py.readthedocs.io/en/stable/

--- a/docs/platforms/frontier.rst
+++ b/docs/platforms/frontier.rst
@@ -75,4 +75,4 @@ To see GPU usage, ssh into the node you are on in another window and run::
 
 .. _Frontier: https://docs.olcf.ornl.gov/systems/frontier_user_guide.html
 .. _python_on_frontier: https://www.olcf.ornl.gov/wp-content/uploads/2-16-23_python_on_frontier.pdf
-.. _demonstration: https://youtu.be/H2fmbZ6DnVc
+.. _demonstration: https://www.youtube.com/watch?v=H2fmbZ6DnVc&feature=youtu.be

--- a/docs/platforms/perlmutter.rst
+++ b/docs/platforms/perlmutter.rst
@@ -188,7 +188,7 @@ Additional Information
 
 See the NERSC Perlmutter_ docs for more information about Perlmutter.
 
-.. _conda: https://conda.io/en/latest/
+.. _conda: https://docs.conda.io/en/latest/
 .. _mpi4py: https://mpi4py.readthedocs.io/en/stable/
 .. _NERSC: https://www.nersc.gov/
 .. _option to srun: https://docs.nersc.gov/systems/perlmutter/running-jobs/#single-gpu-tasks-in-parallel

--- a/docs/platforms/platforms_index.rst
+++ b/docs/platforms/platforms_index.rst
@@ -234,6 +234,6 @@ libEnsemble on specific HPC systems.
     example_scripts
 
 .. _Globus Compute: https://www.globus.org/compute
-.. _Globus Compute endpoints: https://globus-compute.readthedocs.io/en/latest/endpoints.html
+.. _Globus Compute endpoints: https://globus-compute.readthedocs.io/en/latest/endpoints/endpoint_examples.html
 .. _Globus: https://www.globus.org/
 .. _handful of task-rate and data limits: https://globus-compute.readthedocs.io/en/latest/limits.html

--- a/docs/platforms/polaris.rst
+++ b/docs/platforms/polaris.rst
@@ -85,8 +85,8 @@ GPU), see the :doc:`forces_gpu<../tutorials/forces_gpu_tutorial>` tutorial. A vi
 of this example is also available.
 
 .. _ALCF: https://www.alcf.anl.gov/
-.. _conda: https://conda.io/en/latest/
-.. _demonstration: https://youtu.be/Ff0dYYLQzoU
+.. _conda: https://docs.conda.io/en/latest/
+.. _demonstration: https://www.youtube.com/watch?v=Ff0dYYLQzoU&feature=youtu.be
 .. _mpi4py: https://mpi4py.readthedocs.io/en/stable/
 .. _Polaris: https://www.alcf.anl.gov/polaris
-.. _Python for Polaris: https://docs.alcf.anl.gov/polaris/data-science-workflows/python/
+.. _Python for Polaris: https://docs.alcf.anl.gov/polaris/

--- a/docs/tutorials/aposmm_tutorial.rst
+++ b/docs/tutorials/aposmm_tutorial.rst
@@ -209,4 +209,4 @@ can be found in libEnsemble's `WarpX Scaling Test`_.
 .. _Six-Hump Camel function: https://www.sfu.ca/~ssurjano/camel6.html
 .. _WarpX Scaling Test: https://github.com/Libensemble/libe-community-examples/tree/main/warpx
 .. |Open in Colab| image:: https://colab.research.google.com/assets/colab-badge.svg
-  :target:  http://colab.research.google.com/github/Libensemble/libensemble/blob/develop/examples/tutorials/aposmm/aposmm_tutorial_notebook.ipynb
+  :target:  https://colab.research.google.com/github/Libensemble/libensemble/blob/develop/examples/tutorials/aposmm/aposmm_tutorial_notebook.ipynb

--- a/docs/tutorials/executor_forces_tutorial.rst
+++ b/docs/tutorials/executor_forces_tutorial.rst
@@ -467,4 +467,4 @@ to generator and simulator functions.
 .. _forces_simple_with_input_file: https://github.com/Libensemble/libensemble/tree/main/libensemble/tests/scaling_tests/forces/forces_simple_with_input_file
 .. _GitHub: https://github.com/Libensemble/libensemble/issues
 .. |Open in Colab| image:: https://colab.research.google.com/assets/colab-badge.svg
-  :target:  http://colab.research.google.com/github/Libensemble/libensemble/blob/develop/examples/tutorials/forces_with_executor/forces_tutorial_notebook.ipynb
+  :target:  https://colab.research.google.com/github/Libensemble/libensemble/blob/develop/examples/tutorials/forces_with_executor/forces_tutorial_notebook.ipynb

--- a/docs/tutorials/forces_gpu_tutorial.rst
+++ b/docs/tutorials/forces_gpu_tutorial.rst
@@ -308,6 +308,6 @@ where ``SLURM_EXACT`` is set to help prevent resource conflicts on each node.
 .. _forces_gpu: https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/scaling_tests/forces/forces_gpu
 .. _forces_gpu_var_resources: https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/scaling_tests/forces/forces_gpu_var_resources/run_libe_forces.py
 .. _forces_multi_app: https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/scaling_tests/forces/forces_multi_app/run_libe_forces.py
-.. _Frontier: https://youtu.be/H2fmbZ6DnVc
+.. _Frontier: https://www.youtube.com/watch?v=H2fmbZ6DnVc&feature=youtu.be
 .. _Perlmutter: https://www.youtube.com/watch?v=Av8ctYph7-Y
-.. _Polaris: https://youtu.be/Ff0dYYLQzoU
+.. _Polaris: https://www.youtube.com/watch?v=Ff0dYYLQzoU&feature=youtu.be

--- a/docs/tutorials/gpcam_tutorial.rst
+++ b/docs/tutorials/gpcam_tutorial.rst
@@ -348,4 +348,4 @@ The plot should look similar to the following.
 
 .. _gpCAM: https://github.com/lbl-camera/gpCAM
 .. |Open in Colab| image:: https://colab.research.google.com/assets/colab-badge.svg
-  :target:  http://colab.research.google.com/github/Libensemble/libensemble/blob/develop/examples/tutorials/gpcam_surrogate_model/gpcam.ipynb
+  :target:  https://colab.research.google.com/github/Libensemble/libensemble/blob/develop/examples/tutorials/gpcam_surrogate_model/gpcam.ipynb

--- a/docs/tutorials/local_sine_tutorial/local_sine_tutorial.rst
+++ b/docs/tutorials/local_sine_tutorial/local_sine_tutorial.rst
@@ -28,4 +28,4 @@ need to write a new allocation function.
     local_sine_tutorial_5
 
 .. |Open in Colab| image:: https://colab.research.google.com/assets/colab-badge.svg
-  :target:  http://colab.research.google.com/github/Libensemble/libensemble/blob/develop/examples/tutorials/simple_sine/sine_tutorial_notebook.ipynb
+  :target:  https://colab.research.google.com/github/Libensemble/libensemble/blob/develop/examples/tutorials/simple_sine/sine_tutorial_notebook.ipynb

--- a/docs/tutorials/local_sine_tutorial/local_sine_tutorial_1.rst
+++ b/docs/tutorials/local_sine_tutorial/local_sine_tutorial_1.rst
@@ -25,4 +25,4 @@ If your system doesn't allow you to perform these installations, try adding
 ``--user`` to the end of each command.
 
 .. _Matplotlib: https://matplotlib.org/
-.. _NumPy: https://www.numpy.org/
+.. _NumPy: https://numpy.org/

--- a/docs/welcome.rst
+++ b/docs/welcome.rst
@@ -17,8 +17,8 @@
   .. image:: https://github.com/Libensemble/libensemble/actions/workflows/extra.yml/badge.svg?branch=main
     :target: https://github.com/Libensemble/libensemble/actions
 
-  .. image:: https://codecov.io/github/Libensemble/libensemble/graph/badge.svg
-    :target: https://codecov.io/github/Libensemble/libensemble
+  .. image:: https://app.codecov.io/github/Libensemble/libensemble/graph/badge.svg
+    :target: https://app.codecov.io/github/Libensemble/libensemble
 
   .. image:: https://readthedocs.org/projects/libensemble/badge/?maxAge=2592000
     :target: https://libensemble.readthedocs.org/en/latest/

--- a/libensemble/ensemble.py
+++ b/libensemble/ensemble.py
@@ -142,7 +142,7 @@ class Ensemble:
 
         libEnsemble Executor instance for use within simulator functions or generators.
 
-    H0: `NumPy structured array <https://docs.scipy.org/doc/numpy/user/basics.rec.html>`_, Optional
+    H0: `NumPy structured array <https://numpy.org/doc/stable/user/basics.rec.html>`_, Optional
 
         A libEnsemble history to be prepended to this run's history
         :ref:`(example)<funcguides-history>`.

--- a/libensemble/gen_funcs/persistent_aposmm.py
+++ b/libensemble/gen_funcs/persistent_aposmm.py
@@ -113,7 +113,7 @@ def aposmm(H, persis_info, gen_specs, libE_info):
 
     .. seealso::
 
-        `test_persistent_aposmm_scipy <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_persistent_aposmm_scipy.py>`_
+        `test_persistent_aposmm_scipy <https://github.com/Libensemble/libensemble/blob/develop/libensemble/tests/regression_tests/test_aposmm_scipy.py>`_
         for basic APOSMM usage.
 
     .. seealso::

--- a/libensemble/libE.py
+++ b/libensemble/libE.py
@@ -191,7 +191,7 @@ def libE(
         Specifications for libEnsemble
         :doc:`(example)<data_structures/libE_specs/libE_specs>`
 
-    H0: `NumPy structured array <https://docs.scipy.org/doc/numpy/user/basics.rec.html>`_, Optional
+    H0: `NumPy structured array <https://numpy.org/doc/stable/user/basics.rec.html>`_, Optional
 
         A libEnsemble history to be prepended to this run's history
         :ref:`(example)<funcguides-history>`
@@ -199,7 +199,7 @@ def libE(
     Returns
     -------
 
-    H: `NumPy structured array <https://docs.scipy.org/doc/numpy/user/basics.rec.html>`_
+    H: `NumPy structured array <https://numpy.org/doc/stable/user/basics.rec.html>`_
 
         History array storing rows for each point.
         :ref:`(example)<funcguides-history>`

--- a/libensemble/tools/tools.py
+++ b/libensemble/tools/tools.py
@@ -95,7 +95,7 @@ def save_libE_output(
     Parameters
     ----------
 
-    H: `NumPy structured array <https://docs.scipy.org/doc/numpy/user/basics.rec.html>`_
+    H: `NumPy structured array <https://numpy.org/doc/stable/user/basics.rec.html>`_
 
         History array storing rows for each point.
         :ref:`(example)<funcguides-history>`


### PR DESCRIPTION
```bash
pixi run -e docs sphinx-build -b html docs docs/_build/html -W --keep-going
pixi run -e docs sphinx-build -b linkcheck docs docs/_build/linkcheck
```

Then have a smaller LLM fix issues sensibly. 403s were ignored since they seem to resolve in my browser.

#1022 is somewhat addressed after three years